### PR TITLE
MAGECLOUD-708 Adding versions (ece-tools and magento2-base) to log files

### DIFF
--- a/src/Magento/MagentoCloud/Command/Build.php
+++ b/src/Magento/MagentoCloud/Command/Build.php
@@ -52,7 +52,7 @@ class Build
     public function execute()
     {
         $this->env->setStaticDeployInBuild(false);
-        $this->env->log("Start build.");
+        $this->env->log($this->env->startingMessage("build"));
         $this->applyPatches();
         $this->marshallingFiles();
         $this->composerDumpAutoload();

--- a/src/Magento/MagentoCloud/Command/Deploy.php
+++ b/src/Magento/MagentoCloud/Command/Deploy.php
@@ -76,7 +76,7 @@ class Deploy
     public function execute()
     {
         $this->preDeploy();
-        $this->env->log("Start deploy.");
+        $this->env->log("Starting deploy.");
         $this->saveEnvironmentData();
         $this->createConfigIfNotYetExist();
         $this->processMagentoMode();
@@ -659,6 +659,7 @@ class Deploy
      */
     private function preDeploy()
     {
+        $this->env->log($this->env->startingMessage("pre-deploy"));
         // Clear redis and file caches
         $relationships = $this->env->getRelationships();
         $var = $this->env->getVariables();


### PR DESCRIPTION
MAGECLOUD-708 was only requested for Deploy, but I went ahead and added it to the others as well. Also I cleaned up the verbiage so that it is consistent with the rest of the verbs. I am getting the the version from the composer.json file so that we know that it is always correct and don't have to worry about managing the version in multiple places.

https://magento2.atlassian.net/browse/MAGECLOUD-708