### PR TITLE
MAGECLOUD-996: Do not remove env.php redis settings. Only overwrite t…

### DIFF
--- a/src/Magento/MagentoCloud/Command/Deploy.php
+++ b/src/Magento/MagentoCloud/Command/Deploy.php
@@ -503,15 +503,15 @@ class Deploy extends Command
 
         if ($this->redisHost !== null && $this->redisPort !== null) {
             $this->env->log("Updating env.php Redis cache configuration.");
-            $config['cache'] = $this->getRedisCacheConfiguration();
-            $config['session'] = [
-                'save' => 'redis',
-                'redis' => [
-                    'host' => $this->redisHost,
-                    'port' => $this->redisPort,
-                    'database' => $this->redisSessionDb
-                ]
-            ];
+            if (empty($config['cache'])) {
+                $config['cache'] = $this->getRedisCacheConfiguration();
+            } else {
+                $config['cache'] = array_replace_recursive($config['cache'], $this->getRedisCacheConfiguration());
+            }
+            $config['session']['save'] = "redis";
+            $config['session']['redis']['host'] = $this->redisHost;
+            $config['session']['redis']['port'] = $this->redisPort;
+            $config['session']['redis']['database'] = $this->redisSessionDb;
         } else {
             $config = $this->removeRedisConfiguration($config);
         }


### PR DESCRIPTION
### Description

Do not remove env.php redis settings. Only overwrite the ones that we are changing.

### Fixed Issues (if relevant)
1. Deploy.php was removing customers redis settings in env.php such as minLifeTime

### Manual testing scenarios
1. After setting up environment, modify env.php on the server to add some redis keys.
2. Then redeploy.
3. Before this PR, your changes will get removed, after this PR, your changes will stay.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
