### PR TITLE
MAGECLOUD-894: fixed random password not following password requirements

### DIFF
--- a/src/Magento/MagentoCloud/Command/Deploy.php
+++ b/src/Magento/MagentoCloud/Command/Deploy.php
@@ -238,7 +238,7 @@ class Deploy extends Command
             $this->adminUsername = "admin";
         }
         if ($this->isInstalling && empty($this->adminPassword)) {
-            $this->adminPassword = Password::generateRandomString(20);
+            $this->adminPassword = Password::generateRandomPassword();
         }
         $this->adminFirstname = isset($var["ADMIN_FIRSTNAME"]) ? $var["ADMIN_FIRSTNAME"] : ($this->isInstalling ? "Changeme" : "");
         $this->adminLastname = isset($var["ADMIN_LASTNAME"]) ? $var["ADMIN_LASTNAME"] : ($this->isInstalling ? "Changeme" : "");
@@ -343,7 +343,7 @@ class Deploy extends Command
             . " " . escapeshellarg("--admin-firstname=$this->adminFirstname")
             . " " . escapeshellarg("--admin-lastname=$this->adminLastname")
             . " " . escapeshellarg("--admin-email=$this->adminEmail")
-            . " " . escapeshellarg("--admin-password=" . Password::generateRandomString(20)); // Note: This password gets changed later in this script in updateAdminCredentials
+            . " " . escapeshellarg("--admin-password=" . Password::generateRandomPassword()); // Note: This password gets changed later in this script in updateAdminCredentials
 
         if (strlen($this->dbPassword)) {
             $command .= " " . escapeshellarg("--db-password=$this->dbPassword");

--- a/src/Magento/MagentoCloud/Password.php
+++ b/src/Magento/MagentoCloud/Password.php
@@ -43,10 +43,7 @@ class Password
              /* http://docs.magento.com/m2/ee/user_guide/stores/admin-signin.html
               *	An Admin password must be seven or more characters long, and include both letters and numbers.
               */
-            if (
-                ( preg_match('/.*[A-Za-z].*/', $password) )
-                && ( preg_match('/.*[\d].*/', $password) )
-            ) {
+            if ((preg_match('/.*[A-Za-z].*/', $password)) && ( preg_match('/.*[\d].*/', $password))) {
                 return $password;
             }
         }

--- a/src/Magento/MagentoCloud/Password.php
+++ b/src/Magento/MagentoCloud/Password.php
@@ -12,7 +12,7 @@ namespace Magento\MagentoCloud;
 class Password
 {
     /**
-     * Generates admin password using default Magento settings
+     * Generates a random string at the desired length
      * @param int $length the length of the random string
      * @return string
      */
@@ -30,6 +30,28 @@ class Password
         }
         return $output;
     }
+
+    /**
+     * Generates an admin password using default Magento settings
+     * @param int $length the length of the random string
+     * @return string
+     */
+    public static function generateRandomPassword(int $length = 20) : string
+    {
+        while (true) {
+            $password = self::generateRandomString($length);
+             /* http://docs.magento.com/m2/ee/user_guide/stores/admin-signin.html
+              *	An Admin password must be seven or more characters long, and include both letters and numbers.
+              */
+            if (
+                ( preg_match('/.*[A-Za-z].*/', $password) )
+                && ( preg_match('/.*[\d].*/', $password) )
+            ) {
+                return $password;
+            }
+        }
+    }
+
 
     /**
      * Generates salt and hash for the admin password using default Magento settings


### PR DESCRIPTION
MAGECLOUD-894: fixed random password not following password requirements

### Description
Fixed bug where random password could cause this message:
"Your password must include both numeric and alphabetic characters."

### Fixed Issues (if relevant)
1. Randomly generated password now always contains at least 1 letter and 1 number, as per documented here http://docs.magento.com/m2/ee/user_guide/stores/admin-signin.html


### Manual testing scenarios
1. Create a new project with ADMIN_EMAIL variable set.
2. Use the ece-tools with MAGECLOUD-894 (such as master branch)
3. The randomly generated password could contain a random set of all letters or all numbers.  The probability of this occurring is really low, but I didn't do the math on it, so I don't know the exact number for % chance of it happening.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
