### PR TITLE
MAGECLOUD-1121: [develop] In the file "app/etc/ env.php" settings "system" =>"default" =>"catalog"=>"search" does not exist after activation of ElasticSearch service

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -108,6 +108,7 @@ class Container extends \Illuminate\Container\Container implements ContainerInte
                         $this->make(DeployProcess\InstallUpdate\Install\Setup::class),
                         $this->make(DeployProcess\InstallUpdate\Install\SecureAdmin::class),
                         $this->make(DeployProcess\InstallUpdate\ConfigUpdate::class),
+                        $this->make(DeployProcess\InstallUpdate\Install\ConfigImport::class),
                         $this->make(DeployProcess\InstallUpdate\Install\ResetPassword::class),
                     ],
                 ]);

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
@@ -62,8 +62,8 @@ class SearchEngine implements ProcessInterface
         }
 
         $this->logger->info('Set search engine to: ' . $searchConfig['engine']);
-
-        $this->writer->update($searchConfig);
+        $config['system']['default']['catalog']['search'] = $searchConfig;
+        $this->writer->update($config);
     }
 
     /**

--- a/src/Process/Deploy/InstallUpdate/Install/ConfigImport.php
+++ b/src/Process/Deploy/InstallUpdate/Install/ConfigImport.php
@@ -44,6 +44,6 @@ class ConfigImport implements ProcessInterface
     public function execute()
     {
         $this->logger->info('Run app:config:import command');
-        $this->shell->execute('php ./bin/magento app:config:import');
+        $this->shell->execute('php ./bin/magento app:config:import -n');
     }
 }

--- a/src/Process/Deploy/InstallUpdate/Install/ConfigImport.php
+++ b/src/Process/Deploy/InstallUpdate/Install/ConfigImport.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\Install;
+
+use Magento\MagentoCloud\Process\ProcessInterface;
+use Magento\MagentoCloud\Shell\ShellInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Imports configurations after changes env.php
+ *
+ * {@inheritdoc}
+ */
+class ConfigImport implements ProcessInterface
+{
+    /**
+     * @var ShellInterface
+     */
+    private $shell;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ShellInterface $shell
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ShellInterface $shell,
+        LoggerInterface $logger
+    ) {
+        $this->shell = $shell;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        $this->logger->info('Run app:config:import command');
+        $this->shell->execute('php ./bin/magento app:config:import');
+    }
+}

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngineTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngineTest.php
@@ -49,12 +49,13 @@ class SearchEngineTest extends TestCase
 
     public function testExecute()
     {
+        $config['system']['default']['catalog']['search'] = ['engine' => 'mysql'];
         $this->environmentMock->expects($this->once())
             ->method('getRelationships')
             ->willReturn([]);
         $this->writerMock->expects($this->once())
             ->method('update')
-            ->with(['engine' => 'mysql']);
+            ->with($config);
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
             ->withConsecutive(
@@ -67,6 +68,12 @@ class SearchEngineTest extends TestCase
 
     public function testExecuteWithElasticSearch()
     {
+        $config['system']['default']['catalog']['search'] = [
+            'engine' => 'elasticsearch',
+            'elasticsearch_server_hostname' => 'localhost',
+            'elasticsearch_server_port' => 1234
+        ];
+
         $this->environmentMock->expects($this->once())
             ->method('getRelationships')
             ->willReturn(
@@ -81,11 +88,7 @@ class SearchEngineTest extends TestCase
             );
         $this->writerMock->expects($this->once())
             ->method('update')
-            ->with([
-                'engine' => 'elasticsearch',
-                'elasticsearch_server_hostname' => 'localhost',
-                'elasticsearch_server_port' => 1234
-            ]);
+            ->with($config);
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
             ->withConsecutive(
@@ -98,6 +101,13 @@ class SearchEngineTest extends TestCase
 
     public function testExecuteWithElasticSolr()
     {
+        $config['system']['default']['catalog']['search'] = [
+            'engine' => 'solr',
+            'solr_server_hostname' => 'localhost',
+            'solr_server_port' => 1234,
+            'solr_server_username' => 'scheme',
+            'solr_server_path' => 'path'
+        ];
         $this->environmentMock->expects($this->once())
             ->method('getRelationships')
             ->willReturn(
@@ -114,13 +124,7 @@ class SearchEngineTest extends TestCase
             );
         $this->writerMock->expects($this->once())
             ->method('update')
-            ->with([
-                'engine' => 'solr',
-                'solr_server_hostname' => 'localhost',
-                'solr_server_port' => 1234,
-                'solr_server_username' => 'scheme',
-                'solr_server_path' => 'path'
-            ]);
+            ->with($config);
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
             ->withConsecutive(

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Install/ConfigImportTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Install/ConfigImportTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Process\Deploy\InstallUpdate\Install;
+
+use Magento\MagentoCloud\Process\Deploy\InstallUpdate\Install\ConfigImport;
+use PHPUnit\Framework\TestCase;
+use Magento\MagentoCloud\Shell\ShellInterface;
+use Psr\Log\LoggerInterface;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+class ConfigImportTest extends TestCase
+{
+    /**
+     * @var ShellInterface|Mock
+     */
+    private $shellMock;
+
+    /**
+     * @var LoggerInterface|Mock
+     */
+    private $loggerMock;
+
+    /**
+     * @var ConfigImport
+     */
+    private $configImport;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->shellMock = $this->getMockBuilder(ShellInterface::class)
+            ->getMockForAbstractClass();
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->configImport = new ConfigImport($this->shellMock, $this->loggerMock);
+    }
+
+    /**
+     * return void
+     */
+    public function testExecute()
+    {
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Run app:config:import command');
+        $this->shellMock->expects($this->once())
+            ->method('execute')
+            ->with('php ./bin/magento app:config:import');
+
+        $this->configImport->execute();
+    }
+}

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Install/ConfigImportTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Install/ConfigImportTest.php
@@ -51,7 +51,7 @@ class ConfigImportTest extends TestCase
             ->with('Run app:config:import command');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('php ./bin/magento app:config:import');
+            ->with('php ./bin/magento app:config:import -n');
 
         $this->configImport->execute();
     }


### PR DESCRIPTION
### Description
There was incorrect fix port to develop branch.
Search engine configuration was stored at the wrong level of array env.php

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
https://magento2.atlassian.net/browse/MAGECLOUD-1121

### Manual testing scenarios
https://jira.corp.magento.com/browse/MAGETWO-72585

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
