### PR TITLE
MAGECLOUD-1138: HTML minification is not working as expected

### DIFF
--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -241,7 +241,7 @@ class Environment
      */
     public function getRecoverableDirectories(): array
     {
-        return ['var/log', 'app/etc', 'pub/media'];
+        return ['var/log', 'var/view_preprocessed', 'app/etc', 'pub/media'];
     }
 
     /**

--- a/src/Process/Deploy/DeployStaticContent.php
+++ b/src/Process/Deploy/DeployStaticContent.php
@@ -76,7 +76,8 @@ class DeployStaticContent implements ProcessInterface
 
         // Clear old static content if necessary
         if ($this->environment->doCleanStaticFiles()) {
-            $this->staticContentCleaner->clean();
+            $this->staticContentCleaner->cleanPubStatic();
+            $this->staticContentCleaner->cleanViewPreprocessed();
         }
 
         $this->logger->info('Generating fresh static content');

--- a/src/Process/Deploy/PreDeploy/ProcessStaticContent.php
+++ b/src/Process/Deploy/PreDeploy/ProcessStaticContent.php
@@ -74,7 +74,7 @@ class ProcessStaticContent implements ProcessInterface
         }
 
         $this->logger->info('Static content deployment was performed during build hook');
-        $this->staticContentCleaner->clean();
+        $this->staticContentCleaner->cleanPubStatic();
 
         if ($this->env->isStaticContentSymlinkOn()) {
             $this->logger->info('Symlinking static content from pub/static to init/pub/static');

--- a/src/Test/Unit/Config/EnvironmentTest.php
+++ b/src/Test/Unit/Config/EnvironmentTest.php
@@ -194,7 +194,7 @@ class EnvironmentTest extends TestCase
     public function testGetRecoverableDirectories()
     {
         $this->assertSame(
-            ['var/log', 'app/etc', 'pub/media'],
+            ['var/log', 'var/view_preprocessed', 'app/etc', 'pub/media'],
             $this->environment->getRecoverableDirectories()
         );
     }

--- a/src/Test/Unit/Process/Deploy/DeployStaticContentTest.php
+++ b/src/Test/Unit/Process/Deploy/DeployStaticContentTest.php
@@ -89,7 +89,9 @@ class DeployStaticContentTest extends TestCase
             ->method('doCleanStaticFiles')
             ->willReturn(true);
         $this->staticContentCleanerMock->expects($this->once())
-            ->method('clean');
+            ->method('cleanPubStatic');
+        $this->staticContentCleanerMock->expects($this->once())
+            ->method('cleanViewPreprocessed');
         $this->processMock->expects($this->once())
             ->method('execute');
 
@@ -114,7 +116,9 @@ class DeployStaticContentTest extends TestCase
             ->method('doCleanStaticFiles')
             ->willReturn(false);
         $this->staticContentCleanerMock->expects($this->never())
-            ->method('clean');
+            ->method('cleanPubStatic');
+        $this->staticContentCleanerMock->expects($this->never())
+            ->method('cleanViewPreprocessed');
         $this->processMock->expects($this->once())
             ->method('execute');
 

--- a/src/Test/Unit/Process/Deploy/PreDeploy/ProcessStaticContentTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeploy/ProcessStaticContentTest.php
@@ -73,7 +73,7 @@ class ProcessStaticContentTest extends TestCase
             ->method('isStaticContentSymlinkOn')
             ->willReturn(true);
         $this->staticContentCleanerMock->expects($this->once())
-            ->method('clean');
+            ->method('cleanPubStatic');
         $this->staticContentSymlinkMock->expects($this->once())
             ->method('create');
         $this->buildDirCopierMock->expects($this->never())
@@ -97,7 +97,7 @@ class ProcessStaticContentTest extends TestCase
             ->method('isStaticContentSymlinkOn')
             ->willReturn(false);
         $this->staticContentCleanerMock->expects($this->once())
-            ->method('clean');
+            ->method('cleanPubStatic');
         $this->buildDirCopierMock->expects($this->once())
             ->method('copy');
         $this->staticContentSymlinkMock->expects($this->never())
@@ -120,7 +120,7 @@ class ProcessStaticContentTest extends TestCase
         $this->environmentMock->expects($this->never())
             ->method('isStaticContentSymlinkOn');
         $this->staticContentCleanerMock->expects($this->never())
-            ->method('clean');
+            ->method('cleanPubStatic');
         $this->buildDirCopierMock->expects($this->never())
             ->method('copy');
         $this->staticContentSymlinkMock->expects($this->never())

--- a/src/Test/Unit/Util/StaticContentCleanerTest.php
+++ b/src/Test/Unit/Util/StaticContentCleanerTest.php
@@ -53,12 +53,8 @@ class StaticContentCleanerTest extends TestCase
             ->getMockForAbstractClass();
         $this->shellMock = $this->getMockBuilder(ShellInterface::class)
             ->getMockForAbstractClass();
-        $this->fileMock = $this->getMockBuilder(File::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->directoryListMock = $this->getMockBuilder(DirectoryList::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->fileMock = $this->createMock(File::class);
+        $this->directoryListMock = $this->createMock(DirectoryList::class);
 
         $this->staticContentCleaner = new StaticContentCleaner(
             $this->loggerMock,
@@ -71,28 +67,17 @@ class StaticContentCleanerTest extends TestCase
     /**
      * @param bool $oldStaticExists
      * @param int $createOldStaticExpects
-     * @param bool $preprocessedExists
-     * @param int $logInfoExpects
-     * @param int $backgroundExecuteExpects
-     * @param int $renameExpects
      * @dataProvider cleanDataProvider
      * @return void
      */
-    public function testClean(
+    public function testCleanPubStatic(
         $oldStaticExists,
-        $createOldStaticExpects,
-        $preprocessedExists,
-        $logInfoExpects,
-        $backgroundExecuteExpects,
-        $renameExpects
+        $createOldStaticExpects
     ) {
         $magentoRoot = '/magento/';
         $pubStatic = $magentoRoot . '/pub/static';
-        $var = $magentoRoot . '/var';
-        $varPreprocessed = $var . '/view_preprocessed';
         $time = 123456;
         $oldStaticContentLocation = $pubStatic . '/old_static_content_' . $time . '/';
-        $oldPreprocessedLocation = $varPreprocessed . '_old_' . $time;
 
         $timeMock = $this->getFunctionMock('Magento\MagentoCloud\Util', 'time');
         $timeMock->expects($this->once())
@@ -102,45 +87,37 @@ class StaticContentCleanerTest extends TestCase
             ->method('getMagentoRoot')
             ->willReturn($magentoRoot);
 
-        $this->loggerMock->expects($this->exactly($logInfoExpects))
+        $this->loggerMock->expects($this->exactly(5))
             ->method('info')
             ->withConsecutive(
                 ['Moving out old static content into ' . $oldStaticContentLocation],
                 ['Rename ' . $pubStatic . '/folder1 to ' . $oldStaticContentLocation . 'folder1'],
                 ['Rename ' . $pubStatic . '/file1.jpg to ' . $oldStaticContentLocation . 'file1.jpg'],
                 ['Rename ' . $pubStatic . '/file2.jpg to ' . $oldStaticContentLocation . 'file2.jpg'],
-                ['Removing ' . $oldStaticContentLocation . ' in the background'],
-                ['Rename ' . $varPreprocessed . ' to ' . $oldPreprocessedLocation],
-                ['Removing '.  $oldPreprocessedLocation . ' in the background']
+                ['Removing ' . $oldStaticContentLocation . ' in the background']
             );
 
-        $this->shellMock->expects($this->exactly($backgroundExecuteExpects))
+        $this->shellMock->expects($this->once())
             ->method('backgroundExecute')
             ->withConsecutive(
-                ['rm -rf ' . $oldStaticContentLocation],
-                ['rm -rf ' . $oldPreprocessedLocation]
+                ['rm -rf ' . $oldStaticContentLocation]
             );
 
-        $this->fileMock->expects($this->exactly(2))
+        $this->fileMock->expects($this->once())
             ->method('getRealPath')
-            ->willReturnMap([
-                [$pubStatic, $pubStatic],
-                [$var, $var]
-            ]);
-        $this->fileMock->expects($this->exactly($renameExpects))
+            ->with($pubStatic)
+            ->willReturn($pubStatic);
+        $this->fileMock->expects($this->exactly(3))
             ->method('rename')
             ->withConsecutive(
                 [$pubStatic . '/folder1', $oldStaticContentLocation . 'folder1'],
                 [$pubStatic . '/file1.jpg', $oldStaticContentLocation . 'file1.jpg'],
-                [$pubStatic . '/file2.jpg', $oldStaticContentLocation . 'file2.jpg'],
-                [$varPreprocessed, $oldPreprocessedLocation]
+                [$pubStatic . '/file2.jpg', $oldStaticContentLocation . 'file2.jpg']
             );
-        $this->fileMock->expects($this->exactly(2))
+        $this->fileMock->expects($this->once())
             ->method('isExists')
-            ->willReturnMap([
-                [$oldStaticContentLocation, $oldStaticExists],
-                [$varPreprocessed, $preprocessedExists],
-            ]);
+            ->with($oldStaticContentLocation)
+            ->willReturn($oldStaticExists);
         $this->fileMock->expects($this->exactly($createOldStaticExpects))
             ->method('createDirectory')
             ->with($oldStaticContentLocation);
@@ -154,7 +131,7 @@ class StaticContentCleanerTest extends TestCase
                 $pubStatic . '/file2.jpg',
             ]);
 
-        $this->staticContentCleaner->clean();
+        $this->staticContentCleaner->cleanPubStatic();
     }
 
     public function cleanDataProvider()
@@ -163,27 +140,77 @@ class StaticContentCleanerTest extends TestCase
             [
                 'oldStaticExists' => true,
                 'createOldStaticExpects' => 0,
-                'preprocessedExists' => true,
-                'logInfoExpects' => 7,
-                'backgroundExecuteExpects' => 2,
-                'renameExpects' => 4,
             ],
             [
                 'oldStaticExists' => false,
                 'createOldStaticExpects' => 1,
-                'preprocessedExists' => true,
-                'logInfoExpects' => 7,
-                'backgroundExecuteExpects' => 2,
-                'renameExpects' => 4,
-            ],
-            [
-                'oldStaticExists' => false,
-                'createOldStaticExpects' => 1,
-                'preprocessedExists' => false,
-                'logInfoExpects' => 5,
-                'backgroundExecuteExpects' => 1,
-                'renameExpects' => 3,
-            ],
+            ]
         ];
+    }
+
+    public function testCleanViewPreprocessedExists()
+    {
+        $time = 123456;
+        $magentoRootDir = '/magento';
+        $magentoVarDir = $magentoRootDir . '/var';
+        $magentoVarPreprocessedDir = $magentoVarDir . '/view_preprocessed';
+        $oldPreprocessedLocation = $magentoVarPreprocessedDir . '_old_' . $time;
+
+        $timeMock = $this->getFunctionMock('Magento\MagentoCloud\Util', 'time');
+        $timeMock->expects($this->once())
+            ->willReturn($time);
+
+        $this->directoryListMock->expects($this->once())
+            ->method('getMagentoRoot')
+            ->willReturn($magentoRootDir);
+        $this->fileMock->expects($this->once())
+            ->method('getRealPath')
+            ->with($magentoVarDir)
+            ->willReturn($magentoVarDir);
+        $this->fileMock->expects($this->once())
+            ->method('isExists')
+            ->with($magentoVarDir . '/view_preprocessed')
+            ->willReturn(true);
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('info')
+            ->withConsecutive(
+                ['Rename ' . $magentoVarPreprocessedDir . ' to ' . $oldPreprocessedLocation],
+                ['Removing '.  $oldPreprocessedLocation . ' in the background']
+            );
+        $this->fileMock->expects($this->once())
+            ->method('rename')
+            ->with($magentoVarPreprocessedDir, $oldPreprocessedLocation);
+        $this->shellMock->expects($this->once())
+            ->method('backgroundExecute')
+            ->with('rm -rf ' . $oldPreprocessedLocation);
+
+        $this->staticContentCleaner->cleanViewPreprocessed();
+    }
+
+    public function testCleanViewPreprocessedNotExists()
+    {
+        $magentoRootDir = '/magento/';
+        $magentoVarDir = $magentoRootDir . '/var';
+
+        $this->directoryListMock->expects($this->once())
+            ->method('getMagentoRoot')
+            ->willReturn($magentoRootDir);
+        $this->fileMock->expects($this->once())
+            ->method('getRealPath')
+            ->with($magentoVarDir)
+            ->willReturn($magentoVarDir);
+        $this->fileMock->expects($this->once())
+            ->method('isExists')
+            ->with($magentoVarDir . '/view_preprocessed')
+            ->willReturn(false);
+
+        $this->fileMock->expects($this->never())
+            ->method('rename');
+        $this->shellMock->expects($this->never())
+            ->method('backgroundExecute');
+        $this->loggerMock->expects($this->never())
+            ->method('info');
+
+        $this->staticContentCleaner->cleanViewPreprocessed();
     }
 }

--- a/src/Util/BuildDirCopier.php
+++ b/src/Util/BuildDirCopier.php
@@ -50,6 +50,12 @@ class BuildDirCopier
         $magentoRoot = $this->directoryList->getMagentoRoot();
         $originalDir = $magentoRoot . '/' . $dir;
         $initDir = $magentoRoot . '/init/' . $dir;
+
+        if (!$this->file->isExists($initDir)) {
+            $this->logger->notice(sprintf('Can\'t copy directory %s. Directory does not exist.', $magentoRoot));
+            return;
+        }
+
         if (!$this->file->isExists($originalDir)) {
             $this->file->createDirectory($originalDir);
             $this->logger->info(sprintf('Created directory: %s', $dir));

--- a/src/Util/StaticContentCleaner.php
+++ b/src/Util/StaticContentCleaner.php
@@ -50,7 +50,7 @@ class StaticContentCleaner
         $this->directoryList = $directoryList;
     }
 
-    public function clean()
+    public function cleanPubStatic()
     {
         $magentoRoot = $this->directoryList->getMagentoRoot();
         // atomic move within pub/static directory
@@ -74,10 +74,16 @@ class StaticContentCleaner
 
         $this->logger->info('Removing ' . $oldStaticContentLocation . ' in the background');
         $this->shell->backgroundExecute('rm -rf ' . $oldStaticContentLocation);
+    }
 
-        // Clean view_preprocessed directory
+
+    public function cleanViewPreprocessed()
+    {
+        $magentoRoot = $this->directoryList->getMagentoRoot();
         $preprocessedLocation = $this->file->getRealPath($magentoRoot . '/var') . '/view_preprocessed';
+
         if ($this->file->isExists($preprocessedLocation)) {
+            $timestamp = time();
             $oldPreprocessedLocation = $preprocessedLocation . '_old_' . $timestamp;
             $this->logger->info('Rename ' . $preprocessedLocation . ' to ' . $oldPreprocessedLocation);
             $this->file->rename($preprocessedLocation, $oldPreprocessedLocation);


### PR DESCRIPTION
### Description
Added copying of var/view_preprocessed folder if static was generated in the build phase.
Fixed redundant clean of var/view_preprocessed folder.
### Fixed issue
https://magento2.atlassian.net/browse/MAGECLOUD-1138
### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
https://jira.corp.magento.com/browse/MAGETWO-82706

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] Pull request was approved by architect
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
