### PR TITLE
MAGECLOUD-1171 Replacing http:// with https:// for the secure url

### DIFF
--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -77,7 +77,7 @@ class UrlManager
         }
 
         if (!count($this->urls['secure'])) {
-            $this->urls['secure'] = $this->urls['unsecure'];
+            $this->urls['secure'] = str_replace(self::PREFIX_UNSECURE, self::PREFIX_SECURE, $this->urls['unsecure']);
         }
 
         $this->logger->info(sprintf('Routes: %s', var_export($this->urls, true)));


### PR DESCRIPTION
update the secure url so it has the right prefix

### Description
1. magento setup:install won't allow 'http://' for the base secure url, but as written, the current code assigns a url with 'http:' to the secure url without modifying it (if a secure url is not specified)

### Fixed Issues (if relevant)
1. read the code - it's clear from the lines preceding the change that this is a bug and a url with http is being assigned to the secure url key
2. modify the env var MAGENTO_CLOUD_ROUTES so that it does not contain a secure url and run m2-ece-deploy

### Manual testing scenarios
https://jira.corp.magento.com/browse/MAGETWO-82864

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
