### PR TITLE
[2002.0] MAGECLOUD-1181: Set STATIC_CONTENT_THREADS = 1 for Separate Deployment Strategies

### DIFF
--- a/src/StaticContent/Build/Option.php
+++ b/src/StaticContent/Build/Option.php
@@ -9,6 +9,7 @@ use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\StaticContent\OptionInterface;
+use Magento\MagentoCloud\StaticContent\ThreadCountOptimizer;
 use Magento\MagentoCloud\Util\ArrayManager;
 use Magento\MagentoCloud\Config\Build as BuildConfig;
 
@@ -43,24 +44,32 @@ class Option implements OptionInterface
     private $buildConfig;
 
     /**
+     * @var ThreadCountOptimizer
+     */
+    private $threadCountOptimizer;
+
+    /**
      * @param Environment $environment
      * @param ArrayManager $arrayManager
      * @param MagentoVersion $magentoVersion
      * @param DirectoryList $directoryList
      * @param BuildConfig $buildConfig
+     * @param ThreadCountOptimizer $threadCountOptimizer
      */
     public function __construct(
         Environment $environment,
         ArrayManager $arrayManager,
         MagentoVersion $magentoVersion,
         DirectoryList $directoryList,
-        BuildConfig $buildConfig
+        BuildConfig $buildConfig,
+        ThreadCountOptimizer $threadCountOptimizer
     ) {
         $this->environment = $environment;
         $this->magentoVersion = $magentoVersion;
         $this->arrayManager = $arrayManager;
         $this->directoryList = $directoryList;
         $this->buildConfig = $buildConfig;
+        $this->threadCountOptimizer = $threadCountOptimizer;
     }
 
     /**
@@ -68,7 +77,10 @@ class Option implements OptionInterface
      */
     public function getTreadCount(): int
     {
-        return (int)$this->buildConfig->get(BuildConfig::OPT_SCD_THREADS, 1);
+        return $this->threadCountOptimizer->optimize(
+            (int)$this->buildConfig->get(BuildConfig::OPT_SCD_THREADS, 1),
+            $this->getStrategy()
+        );
     }
 
     /**

--- a/src/StaticContent/Deploy/Option.php
+++ b/src/StaticContent/Deploy/Option.php
@@ -9,6 +9,7 @@ use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\DB\ConnectionInterface;
 use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\StaticContent\OptionInterface;
+use Magento\MagentoCloud\StaticContent\ThreadCountOptimizer;
 
 /**
  * Options for static deploy command in build process
@@ -31,18 +32,26 @@ class Option implements OptionInterface
     private $magentoVersion;
 
     /**
+     * @var ThreadCountOptimizer
+     */
+    private $threadCountOptimizer;
+
+    /**
      * @param Environment $environment
      * @param ConnectionInterface $connection
      * @param MagentoVersion $magentoVersion
+     * @param ThreadCountOptimizer $threadCountOptimizer
      */
     public function __construct(
         Environment $environment,
         ConnectionInterface $connection,
-        MagentoVersion $magentoVersion
+        MagentoVersion $magentoVersion,
+        ThreadCountOptimizer $threadCountOptimizer
     ) {
         $this->environment = $environment;
         $this->connection = $connection;
         $this->magentoVersion = $magentoVersion;
+        $this->threadCountOptimizer = $threadCountOptimizer;
     }
 
     /**
@@ -50,7 +59,10 @@ class Option implements OptionInterface
      */
     public function getTreadCount(): int
     {
-        return $this->environment->getStaticDeployThreadsCount();
+        return $this->threadCountOptimizer->optimize(
+            $this->environment->getStaticDeployThreadsCount(),
+            $this->getStrategy()
+        );
     }
 
     /**

--- a/src/StaticContent/ThreadCountOptimizer.php
+++ b/src/StaticContent/ThreadCountOptimizer.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\StaticContent;
+
+class ThreadCountOptimizer
+{
+    /**
+     * @var string
+     */
+    const STRATEGY_COMPACT = 'compact';
+
+    /**
+     * Recommended tread count value for compact strategy
+     *
+     * @var int
+     */
+    const THREAD_COUNT_COMPACT_STRATEGY = 1;
+
+    /**
+     * Defines best thread count value based on deploy strategy name
+     *
+     * @param int $threads
+     * @param string $strategy
+     * @return int
+     */
+    public function optimize(int $threads, string $strategy): int
+    {
+        if ($strategy === self::STRATEGY_COMPACT) {
+            return self::THREAD_COUNT_COMPACT_STRATEGY;
+        }
+
+        return $threads;
+    }
+}

--- a/src/Test/Unit/StaticContent/Build/OptionTest.php
+++ b/src/Test/Unit/StaticContent/Build/OptionTest.php
@@ -10,6 +10,7 @@ use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\StaticContent\Build\Option;
+use Magento\MagentoCloud\StaticContent\ThreadCountOptimizer;
 use Magento\MagentoCloud\Util\ArrayManager;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
@@ -46,6 +47,11 @@ class OptionTest extends TestCase
      */
     private $directoryListMock;
 
+    /**
+     * @var ThreadCountOptimizer|Mock
+     */
+    private $threadCountOptimizerMock;
+
     protected function setUp()
     {
         $this->magentoVersionMock = $this->createMock(MagentoVersion::class);
@@ -53,21 +59,30 @@ class OptionTest extends TestCase
         $this->buildConfigMock = $this->createMock(BuildConfig::class);
         $this->environmentMock = $this->createMock(Environment::class);
         $this->arrayManagerMock = $this->createMock(ArrayManager::class);
+        $this->threadCountOptimizerMock = $this->createMock(ThreadCountOptimizer::class);
 
         $this->option = new Option(
             $this->environmentMock,
             $this->arrayManagerMock,
             $this->magentoVersionMock,
             $this->directoryListMock,
-            $this->buildConfigMock
+            $this->buildConfigMock,
+            $this->threadCountOptimizerMock
         );
     }
 
     public function testGetThreadCount()
     {
-        $this->buildConfigMock->expects($this->once())
+        $this->buildConfigMock->expects($this->exactly(2))
             ->method('get')
-            ->with(BuildConfig::OPT_SCD_THREADS)
+            ->withConsecutive(
+                [BuildConfig::OPT_SCD_THREADS],
+                [BuildConfig::OPT_SCD_STRATEGY]
+            )
+            ->willReturnOnConsecutiveCalls(3, 'strategyName');
+        $this->threadCountOptimizerMock->expects($this->once())
+            ->method('optimize')
+            ->with(3, 'strategyName')
             ->willReturn(3);
 
         $this->assertEquals(3, $this->option->getTreadCount());

--- a/src/Test/Unit/StaticContent/Deploy/OptionTest.php
+++ b/src/Test/Unit/StaticContent/Deploy/OptionTest.php
@@ -9,6 +9,7 @@ use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\DB\Connection;
 use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\StaticContent\Deploy\Option;
+use Magento\MagentoCloud\StaticContent\ThreadCountOptimizer;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
 
@@ -34,16 +35,23 @@ class OptionTest extends TestCase
      */
     private $connectionMock;
 
+    /**
+     * @var ThreadCountOptimizer|Mock
+     */
+    private $threadCountOptimizerMock;
+
     protected function setUp()
     {
         $this->magentoVersionMock = $this->createMock(MagentoVersion::class);
         $this->connectionMock = $this->createMock(Connection::class);
         $this->environmentMock = $this->createMock(Environment::class);
+        $this->threadCountOptimizerMock = $this->createMock(ThreadCountOptimizer::class);
 
         $this->option = new Option(
             $this->environmentMock,
             $this->connectionMock,
-            $this->magentoVersionMock
+            $this->magentoVersionMock,
+            $this->threadCountOptimizerMock
         );
     }
 
@@ -51,6 +59,14 @@ class OptionTest extends TestCase
     {
         $this->environmentMock->expects($this->once())
             ->method('getStaticDeployThreadsCount')
+            ->willReturn(3);
+        $this->environmentMock->expects($this->once())
+            ->method('getVariable')
+            ->with(Environment::VAR_SCD_STRATEGY)
+            ->willReturn('strategyName');
+        $this->threadCountOptimizerMock->expects($this->once())
+            ->method('optimize')
+            ->with(3, 'strategyName')
             ->willReturn(3);
 
         $this->assertEquals(3, $this->option->getTreadCount());

--- a/src/Test/Unit/StaticContent/ThreadCountOptimizerTest.php
+++ b/src/Test/Unit/StaticContent/ThreadCountOptimizerTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\StaticContent;
+
+use Magento\MagentoCloud\StaticContent\ThreadCountOptimizer;
+use PHPUnit\Framework\TestCase;
+
+class ThreadCountOptimizerTest extends TestCase
+{
+    /**
+     * @var ThreadCountOptimizer
+     */
+    private $optimizer;
+
+    protected function setUp()
+    {
+        $this->optimizer = new ThreadCountOptimizer();
+    }
+
+    /**
+     * @param int $threadCount
+     * @param string $strategy
+     * @param int $expectedThreadCount
+     * @dataProvider optimizeDataProvider
+     */
+    public function testOptimize(int $threadCount, string $strategy, int $expectedThreadCount)
+    {
+        $this->assertEquals(
+            $expectedThreadCount,
+            $this->optimizer->optimize($threadCount, $strategy)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function optimizeDataProvider(): array
+    {
+        return [
+            [
+                3,
+                ThreadCountOptimizer::STRATEGY_COMPACT,
+                1
+            ],
+        ];
+    }
+}

--- a/src/Test/Unit/StaticContent/ThreadCountOptimizerTest.php
+++ b/src/Test/Unit/StaticContent/ThreadCountOptimizerTest.php
@@ -45,6 +45,16 @@ class ThreadCountOptimizerTest extends TestCase
                 ThreadCountOptimizer::STRATEGY_COMPACT,
                 1
             ],
+            [
+                5,
+                'SomeStrategy',
+                5
+            ],
+            [
+                1,
+                'SomeStrategy',
+                1
+            ]
         ];
     }
 }


### PR DESCRIPTION
### Description
Compact and possibly Standard (need to test) deployment strategies do not work with multi-threads;
Default qty of threads is set to 3 on Production, so deployment strategies always fail by default.
This needs to go in the earliest next release of ece-tools.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
https://magento2.atlassian.net/browse/MAGECLOUD-1181

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
On Production - set SCD_STRATEGY to compact
Push code

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
