### PR TITLE
Set secure url to unsecure if not provided

### DIFF
--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -44,6 +44,7 @@ class UrlManager
 
     /**
      * Parse MagentoCloud routes to more readable format.
+     * @throws \RuntimeException if no valid secure or unsecure route found
      */
     public function getUrls()
     {
@@ -76,8 +77,16 @@ class UrlManager
             }
         }
 
+        if (!count($this->urls['unsecure']) && !count($this->urls['secure'])) {
+            throw new \RuntimeException("Expected at least one valid unsecure or secure route. None found.");
+        }
+
+        if (!count($this->urls['unsecure'])) {
+            $this->urls['unsecure'] = $this->urls['secure'];
+        }
+
         if (!count($this->urls['secure'])) {
-            $this->urls['secure'] = $this->urls['unsecure'];
+            $this->urls['secure'] = str_replace(self::PREFIX_UNSECURE, self::PREFIX_SECURE, $this->urls['unsecure']);
         }
 
         $this->logger->info(sprintf('Routes: %s', var_export($this->urls, true)));


### PR DESCRIPTION
Also check that at lease one (secure or unsecure) is provided

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
.magento/routes.yaml does not require an unsecure url. A secure url by itself is valid. However, magento setup:install does require a "--base-url" which may be a secure (https://) url.
m2-ece-deploy should accept only the secure url if it is all that is provided, and set the unsecure url to the secure url value to provide the --base-url option in magento setup:install.

### Fixed Issues (if relevant)
1. Do not force user to provide an unsecure url (platform.sh does not)
2. Check for at least one valid secure or unsecure url
3. Also includes #65 change

### Manual testing scenarios
1. in .magento/routes.yaml provide only the secure url. This will be accepted by platform.sh but ultimately cause an error in magento setup:install (despite --base-url=https:// being valid).

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
