### PR TITLE
[2002.0] MAGECLOUD-1186: No exception on patching error

### DIFF
--- a/src/Test/Unit/Process/Build/ApplyPatchesTest.php
+++ b/src/Test/Unit/Process/Build/ApplyPatchesTest.php
@@ -5,7 +5,8 @@
  */
 namespace Magento\MagentoCloud\Test\Unit\Process\Build;
 
-use Magento\MagentoCloud\Package\MagentoVersion;
+use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Process\Build\ApplyPatches;
 use Magento\MagentoCloud\Shell\ShellInterface;
 use PHPUnit\Framework\TestCase;
@@ -33,9 +34,14 @@ class ApplyPatchesTest extends TestCase
     private $shellMock;
 
     /**
-     * @var MagentoVersion|Mock
+     * @var File|Mock
      */
-    private $magentoVersionMock;
+    private $fileMock;
+
+    /**
+     * @var DirectoryList|Mock
+     */
+    private $directoryListMock;
 
     /**
      * @inheritdoc
@@ -46,14 +52,16 @@ class ApplyPatchesTest extends TestCase
             ->getMockForAbstractClass();
         $this->shellMock = $this->getMockBuilder(ShellInterface::class)
             ->getMockForAbstractClass();
-        $this->magentoVersionMock = $this->getMockBuilder(MagentoVersion::class)
+        $this->fileMock = $this->getMockBuilder(File::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->directoryListMock = $this->createMock(DirectoryList::class);
 
         $this->process = new ApplyPatches(
             $this->shellMock,
             $this->loggerMock,
-            $this->magentoVersionMock
+            $this->fileMock,
+            $this->directoryListMock
         );
 
         parent::setUp();
@@ -61,14 +69,16 @@ class ApplyPatchesTest extends TestCase
 
     public function testExecute()
     {
+        $this->directoryListMock->method('getMagentoRoot')
+            ->willReturn('magento_root');
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Applying patches.');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('php vendor/bin/m2-apply-patches');
-        $this->magentoVersionMock->method('isGreaterOrEqual')
-            ->with('2.2')
+            ->with('php magento_root/vendor/bin/m2-apply-patches');
+        $this->fileMock->method('isExists')
+            ->with('magento_root/vendor/bin/m2-apply-patches')
             ->willReturn(true);
 
         $this->process->execute();
@@ -76,18 +86,19 @@ class ApplyPatchesTest extends TestCase
 
     public function testExecuteWithoutPatches()
     {
+        $this->directoryListMock->method('getMagentoRoot')
+            ->willReturn('magento_root');
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Applying patches.');
-        $this->magentoVersionMock->method('isGreaterOrEqual')
-            ->with('2.2')
-            ->willReturn(true);
+        $this->fileMock->method('isExists')
+            ->with('magento_root/vendor/bin/m2-apply-patches')
+            ->willReturn(false);
         $this->loggerMock->expects($this->once())
             ->method('warning')
-            ->with('Patching was failed. Skipping.');
-        $this->shellMock->expects($this->once())
-            ->method('execute')
-            ->willThrowException(new \Exception('Patching failed.'));
+            ->with('Package with patches was not found.');
+        $this->shellMock->expects($this->never())
+            ->method('execute');
 
         $this->process->execute();
     }


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-1186
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
ECE-Tools should stop any execution and throw exception, if no patches can not be applied.
In case of warning, application may be hang in unexpected state.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
1. https://magento2.atlassian.net/browse/MAGECLOUD-1186

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. https://jira.corp.magento.com/browse/MAGETWO-70994

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
