### PR TITLE
MAGECLOUD-1182: Setting unsecure URL to Secure URL if one is not provided

### DIFF
--- a/src/Test/Unit/Util/UrlManagerTest.php
+++ b/src/Test/Unit/Util/UrlManagerTest.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Util;
+
+use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Util\UrlManager;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @inheritdoc
+ */
+class UrlManagerTest extends TestCase
+{
+    /**
+     * @var UrlManager
+     */
+    private $manager;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $loggerMock;
+
+    /**
+     * @var Environment
+     */
+    private $environmentMock;
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->getMockForAbstractClass();
+        $this->environmentMock = $this->createMock(Environment::class);
+
+        $this->manager = new UrlManager(
+            $this->environmentMock,
+            $this->loggerMock
+        );
+    }
+
+    /**
+     * @param array $routes
+     * @dataProvider secureRouteDataProvider
+     */
+    public function testParseRoutesSecure(array $routes)
+    {
+        $this->environmentMock->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($routes);
+
+        $urls = $this->manager->parseRoutes($this->environmentMock->getRoutes());
+
+        $this->assertArrayHasKey('secure', $urls);
+    }
+
+    /**
+     * @param array $routes
+     * @dataProvider secureRouteDataProvider
+     */
+    public function testParseRoutesUnsecure(array $routes)
+    {
+        $this->environmentMock->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($routes);
+
+        $urls = $this->manager->parseRoutes($this->environmentMock->getRoutes());
+
+        $this->assertArrayHasKey('unsecure', $urls);
+    }
+
+    /**
+     * @param array $secureRoute
+     * @param string $expectedUrl
+     * @dataProvider secureRouteDataProvider
+     */
+    public function testGetSecureUrl(array $secureRoute, string $expectedUrl)
+    {
+        $this->environmentMock->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($secureRoute);
+
+        $urls = $this->manager->getUrls();
+
+        $this->assertEquals($urls['unsecure'], $urls['secure']);
+    }
+
+    /**
+     * @param array $secureRoute
+     * @param string $expectedUrl
+     * @dataProvider secureRouteDataProvider
+     */
+    public function testGetSecureUrlMethod(array $secureRoute, string $expectedUrl)
+    {
+        $this->environmentMock->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($secureRoute);
+
+        $urls = $this->manager->getSecureUrls();
+
+        $this->assertArrayHasKey($expectedUrl, $urls);
+    }
+
+    /**
+     * @param array $unsecureRoute
+     * @param string $expectedUrl
+     * @dataProvider unsecureRouteDataProvider
+     */
+    public function testGetunsecureUrlMethod(array $unsecureRoute, string $expectedUrl)
+    {
+        $this->environmentMock->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($unsecureRoute);
+
+        $urls = $this->manager->getunsecureUrls();
+
+        $this->assertArrayHasKey($expectedUrl, $urls);
+    }
+
+
+    /**
+     * @param array $secureRoute
+     * @param $expectedUrl
+     * @dataProvider unsecureRouteDataProvider
+     */
+    public function testNoSecure(array $unsecureRoute, string $expectedUrl)
+    {
+        // Will be invalidated quickly
+        $this->environmentMock->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($unsecureRoute);
+
+        $urls = $this->manager->getUrls();
+
+        $this->assertEquals($urls['secure'], $urls['unsecure']);
+    }
+
+    public function testGetUrlsException()
+    {
+        // No Mock so we get an exception indicating no URLS present.
+        $this->expectException(\RuntimeException::class);
+        $urls = $this->manager->getUrls();
+    }
+
+
+    public function allRoutesDataProvider()
+    {
+        return [
+            [
+                'https://example.com/' => [
+                    'original_url' => 'https://example.com/',
+                    'type' => 'upstream',
+                    'ssi' => [
+                        'enabled' => false
+                    ],
+                    'upstream' => 'mymagento',
+                    'cache' => [
+                        'cookies' => ['*'],
+                        'default_ttl' => 0,
+                        'enabled' => true,
+                        'headers' => [
+                            'Accept',
+                            'Accept-Language'
+                        ]
+                    ]
+                ],
+
+                'http://example.com/' => [
+                    'original_url' => 'https://example.com/',
+                    'type' => 'upstream',
+                    'ssi' => [
+                        'enabled' => false
+                    ],
+                    'upstream' => 'mymagento',
+                    'cache' => [
+                        'cookies' => ['*'],
+                        'default_ttl' => 0,
+                        'enabled' => true,
+                        'headers' => [
+                            'Accept',
+                            'Accept-Language'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    public function secureRouteDataProvider()
+    {
+        $route = [
+            'https://example.com/' => [
+                'original_url' => 'https://example.com/',
+                'type' => 'upstream',
+                'ssi' => [
+                    'enabled' => false
+                ],
+                'upstream' => 'mymagento',
+                'cache' => [
+                    'cookies' => ['*'],
+                    'default_ttl' => 0,
+                    'enabled' => true,
+                    'headers' => [
+                        'Accept',
+                        'Accept-Language'
+                    ]
+                ]
+            ]
+        ];
+        return [
+            [
+                $route,
+                'example.com'
+            ]
+        ];
+    }
+
+    public function unsecureRouteDataProvider()
+    {
+        $route = [
+            'http://example.com/' => [
+                'original_url' => 'http://example.com/',
+                'type' => 'upstream',
+                'ssi' => [
+                    'enabled' => false
+                ],
+                'upstream' => 'mymagento',
+                'cache' => [
+                    'cookies' => ['*'],
+                    'default_ttl' => 0,
+                    'enabled' => true,
+                    'headers' => [
+                        'Accept',
+                        'Accept-Language'
+                    ]
+                ]
+            ]
+        ];
+        return [
+            [
+                $route,
+                'example.com'
+            ]
+        ];
+    }
+}

--- a/src/Test/Unit/Util/UrlManagerTest.php
+++ b/src/Test/Unit/Util/UrlManagerTest.php
@@ -79,6 +79,7 @@ class UrlManagerTest extends TestCase
      * @param array $secureRoute
      * @param string $expectedUrl
      * @dataProvider secureRouteDataProvider
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function testGetSecureUrl(array $secureRoute, string $expectedUrl)
     {
@@ -128,6 +129,7 @@ class UrlManagerTest extends TestCase
      * @param array $secureRoute
      * @param $expectedUrl
      * @dataProvider unsecureRouteDataProvider
+      @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function testNoSecure(array $unsecureRoute, string $expectedUrl)
     {
@@ -145,7 +147,7 @@ class UrlManagerTest extends TestCase
     {
         // No Mock so we get an exception indicating no URLS present.
         $this->expectException(\RuntimeException::class);
-        $urls = $this->manager->getUrls();
+        $this->manager->getUrls();
     }
 
 

--- a/src/Test/Unit/Util/UrlManagerTest.php
+++ b/src/Test/Unit/Util/UrlManagerTest.php
@@ -55,7 +55,7 @@ class UrlManagerTest extends TestCase
             ->willReturn($routes);
 
 
-        $this->assertArrayHasKey('secure', $this->manager->parseRoutes($this->environmentMock->getRoutes()));
+        $this->assertArrayHasKey('secure', $this->manager->getUrls());
     }
 
     /**
@@ -68,9 +68,7 @@ class UrlManagerTest extends TestCase
             ->method('getRoutes')
             ->willReturn($routes);
 
-        $urls = $this->manager->parseRoutes($this->environmentMock->getRoutes());
-
-        $this->assertArrayHasKey('unsecure', $urls);
+        $this->assertArrayHasKey('unsecure', $this->manager->getUrls());
     }
 
     /**
@@ -109,18 +107,17 @@ class UrlManagerTest extends TestCase
     /**
      * @param array $secureRoute
      * @param $expectedUrl
-     * @dataProvider unsecureRouteUrlDataProvider
+     * @dataProvider nosecureRouteUrlDataProvider
      */
-    public function testNoSecure(array $unsecureRoute)
+    public function testNoSecure(array $unsecureRoute, array $expectedUrl)
     {
-        // Will be invalidated quickly
         $this->environmentMock->expects($this->once())
             ->method('getRoutes')
             ->willReturn($unsecureRoute);
 
         $urls = $this->manager->getUrls();
 
-        $this->assertEquals($urls['secure'], $urls['unsecure']);
+        $this->assertEquals($urls['secure'], $expectedUrl);
     }
 
     /**
@@ -187,6 +184,38 @@ class UrlManagerTest extends TestCase
                         ]
                     ]
                 ]
+            ]
+        ];
+    }
+
+    public function noSecureRouteUrlDataProvider()
+    {
+        $route = [
+            'http://example.com/' => [
+                'original_url' => 'http://example.com/',
+                'type' => 'upstream',
+                'ssi' => [
+                    'enabled' => false
+                ],
+                'upstream' => 'mymagento',
+                'cache' => [
+                    'cookies' => ['*'],
+                    'default_ttl' => 0,
+                    'enabled' => true,
+                    'headers' => [
+                        'Accept',
+                        'Accept-Language'
+                    ]
+                ]
+            ]
+        ];
+        $expectedRoute = [
+            'example.com' => 'https://example.com/'
+        ];
+        return [
+            [
+                $route,
+                $expectedRoute
             ]
         ];
     }
@@ -301,7 +330,7 @@ class UrlManagerTest extends TestCase
                         ]
                     ]
                 ]
-                ]
+            ]
         ];
     }
 }

--- a/src/Test/Unit/Util/UrlManagerTest.php
+++ b/src/Test/Unit/Util/UrlManagerTest.php
@@ -21,12 +21,12 @@ class UrlManagerTest extends TestCase
     private $manager;
 
     /**
-     * @var LoggerInterface
+     * @var LoggerInterface |\PHPUnit_Framework_MockObject_MockObject
      */
     private $loggerMock;
 
     /**
-     * @var Environment
+     * @var Environment |\PHPUnit_Framework_MockObject_MockObject
      */
     private $environmentMock;
 

--- a/src/Test/Unit/Util/UrlManagerTest.php
+++ b/src/Test/Unit/Util/UrlManagerTest.php
@@ -7,7 +7,6 @@ namespace Magento\MagentoCloud\Test\Unit\Util;
 
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Util\UrlManager;
-use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -30,6 +29,7 @@ class UrlManagerTest extends TestCase
      * @var Environment
      */
     private $environmentMock;
+
     /**
      * @inheritdoc
      */
@@ -101,9 +101,8 @@ class UrlManagerTest extends TestCase
         $this->assertArrayHasKey($expectedUrl, $urls);
     }
 
-
     /**
-     * @param array $secureRoute
+     * @param array $unsecureRoute
      * @param $expectedUrl
      * @dataProvider noSecureRouteUrlDataProvider
      */
@@ -118,7 +117,6 @@ class UrlManagerTest extends TestCase
 
     /**
      * @param array $secureRoute
-     * @param string $expectedUrl
      * @dataProvider secureRouteUrlDataProvider
      */
     public function testGetSecureUrl(array $secureRoute)
@@ -130,6 +128,7 @@ class UrlManagerTest extends TestCase
 
         $this->assertEquals($urls['unsecure'], $urls['secure']);
     }
+
     /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Expected at least one valid unsecure or secure route. None found.
@@ -140,74 +139,72 @@ class UrlManagerTest extends TestCase
         $this->manager->getUrls();
     }
 
-    /**************** DATA PROVIDERS ***********/
-    public function allRoutesDataProvider() : array
+    public function allRoutesDataProvider(): array
     {
         return [
             [
                 $this->secureUrlExample(),
                 $this->unsecureUrlExample(),
-            ]
+            ],
         ];
     }
 
-    public function noSecureRouteUrlDataProvider() : array
+    public function noSecureRouteUrlDataProvider(): array
     {
         return [
             [
                 $this->unsecureUrlExample(),
                 [
-                    'example.com' => 'https://example.com/'
-                ]
-            ]
+                    'example.com' => 'https://example.com/',
+                ],
+            ],
         ];
     }
 
-    public function secureRouteDataProvider() : array
+    public function secureRouteDataProvider(): array
     {
         return [
             [
                 $this->secureUrlExample(),
-                'example.com'
-            ]
+                'example.com',
+            ],
         ];
     }
 
-    public function unsecureRouteDataProvider() : array
+    public function unsecureRouteDataProvider(): array
     {
         return [
             [
                 $this->unsecureUrlExample(),
-                'example.com'
-            ]
+                'example.com',
+            ],
         ];
     }
 
-
-    public function secureRouteUrlDataProvider() : array
+    public function secureRouteUrlDataProvider(): array
     {
         return [
             [
-                $this->secureUrlExample()
-            ]
+                $this->secureUrlExample(),
+            ],
         ];
     }
 
-    public function unsecureRouteUrlDataProvider() : array
+    public function unsecureRouteUrlDataProvider(): array
     {
         return [
-            $this->secureUrlExample()
+            $this->secureUrlExample(),
         ];
     }
 
-    private function secureUrlExample() : array
+    private function secureUrlExample(): array
     {
         return [
             'https://example.com/' => [
                 'original_url' => 'https://example.com/',
                 'type' => 'upstream',
                 'ssi' => [
-                    'enabled' => false
+                    'enabled' => false,
                 ],
                 'upstream' => 'mymagento',
                 'cache' => [
@@ -216,21 +213,21 @@ class UrlManagerTest extends TestCase
                     'enabled' => true,
                     'headers' => [
                         'Accept',
-                        'Accept-Language'
-                    ]
-                ]
-            ]
+                        'Accept-Language',
+                    ],
+                ],
+            ],
         ];
     }
 
-    private function unsecureUrlExample() : array
+    private function unsecureUrlExample(): array
     {
         return [
             'http://example.com/' => [
                 'original_url' => 'https://example.com/',
                 'type' => 'upstream',
                 'ssi' => [
-                    'enabled' => false
+                    'enabled' => false,
                 ],
                 'upstream' => 'mymagento',
                 'cache' => [
@@ -239,10 +236,10 @@ class UrlManagerTest extends TestCase
                     'enabled' => true,
                     'headers' => [
                         'Accept',
-                        'Accept-Language'
-                    ]
-                ]
-            ]
+                        'Accept-Language',
+                    ],
+                ],
+            ],
         ];
     }
 }

--- a/src/Test/Unit/Util/UrlManagerTest.php
+++ b/src/Test/Unit/Util/UrlManagerTest.php
@@ -60,7 +60,7 @@ class UrlManagerTest extends TestCase
 
     /**
      * @param array $routes
-     * @dataProvider secureRouteDataProvider
+     * @dataProvider unsecureRouteDataProvider
      */
     public function testParseRoutesUnsecure(array $routes)
     {
@@ -82,9 +82,7 @@ class UrlManagerTest extends TestCase
             ->method('getRoutes')
             ->willReturn($secureRoute);
 
-        $urls = $this->manager->getSecureUrls();
-
-        $this->assertArrayHasKey($expectedUrl, $urls);
+        $this->assertArrayHasKey($expectedUrl, $this->manager->getSecureUrls());
     }
 
     /**
@@ -107,7 +105,7 @@ class UrlManagerTest extends TestCase
     /**
      * @param array $secureRoute
      * @param $expectedUrl
-     * @dataProvider nosecureRouteUrlDataProvider
+     * @dataProvider noSecureRouteUrlDataProvider
      */
     public function testNoSecure(array $unsecureRoute, array $expectedUrl)
     {
@@ -115,9 +113,7 @@ class UrlManagerTest extends TestCase
             ->method('getRoutes')
             ->willReturn($unsecureRoute);
 
-        $urls = $this->manager->getUrls();
-
-        $this->assertEquals($urls['secure'], $expectedUrl);
+        $this->assertEquals($this->manager->getUrls()['secure'], $expectedUrl);
     }
 
     /**
@@ -144,85 +140,69 @@ class UrlManagerTest extends TestCase
         $this->manager->getUrls();
     }
 
-
-    public function allRoutesDataProvider()
+    /**************** DATA PROVIDERS ***********/
+    public function allRoutesDataProvider() : array
     {
         return [
             [
-                'https://example.com/' => [
-                    'original_url' => 'https://example.com/',
-                    'type' => 'upstream',
-                    'ssi' => [
-                        'enabled' => false
-                    ],
-                    'upstream' => 'mymagento',
-                    'cache' => [
-                        'cookies' => ['*'],
-                        'default_ttl' => 0,
-                        'enabled' => true,
-                        'headers' => [
-                            'Accept',
-                            'Accept-Language'
-                        ]
-                    ]
-                ],
+                $this->secureUrlExample(),
+                $this->unsecureUrlExample(),
+            ]
+        ];
+    }
 
-                'http://example.com/' => [
-                    'original_url' => 'https://example.com/',
-                    'type' => 'upstream',
-                    'ssi' => [
-                        'enabled' => false
-                    ],
-                    'upstream' => 'mymagento',
-                    'cache' => [
-                        'cookies' => ['*'],
-                        'default_ttl' => 0,
-                        'enabled' => true,
-                        'headers' => [
-                            'Accept',
-                            'Accept-Language'
-                        ]
-                    ]
+    public function noSecureRouteUrlDataProvider() : array
+    {
+        return [
+            [
+                $this->unsecureUrlExample(),
+                [
+                    'example.com' => 'https://example.com/'
                 ]
             ]
         ];
     }
 
-    public function noSecureRouteUrlDataProvider()
+    public function secureRouteDataProvider() : array
     {
-        $route = [
-            'http://example.com/' => [
-                'original_url' => 'http://example.com/',
-                'type' => 'upstream',
-                'ssi' => [
-                    'enabled' => false
-                ],
-                'upstream' => 'mymagento',
-                'cache' => [
-                    'cookies' => ['*'],
-                    'default_ttl' => 0,
-                    'enabled' => true,
-                    'headers' => [
-                        'Accept',
-                        'Accept-Language'
-                    ]
-                ]
-            ]
-        ];
-        $expectedRoute = [
-            'example.com' => 'https://example.com/'
-        ];
         return [
             [
-                $route,
-                $expectedRoute
+                $this->secureUrlExample(),
+                'example.com'
             ]
         ];
     }
 
-    public function secureRouteDataProvider()
+    public function unsecureRouteDataProvider() : array
     {
-        $route = [
+        return [
+            [
+                $this->unsecureUrlExample(),
+                'example.com'
+            ]
+        ];
+    }
+
+
+    public function secureRouteUrlDataProvider() : array
+    {
+        return [
+            [
+                $this->secureUrlExample()
+            ]
+        ];
+    }
+
+    public function unsecureRouteUrlDataProvider() : array
+    {
+        return [
+            $this->secureUrlExample()
+        ];
+    }
+
+    private function secureUrlExample() : array
+    {
+        return [
             'https://example.com/' => [
                 'original_url' => 'https://example.com/',
                 'type' => 'upstream',
@@ -241,19 +221,13 @@ class UrlManagerTest extends TestCase
                 ]
             ]
         ];
-        return [
-            [
-                $route,
-                'example.com'
-            ]
-        ];
     }
 
-    public function unsecureRouteDataProvider()
+    private function unsecureUrlExample() : array
     {
-        $route = [
+        return [
             'http://example.com/' => [
-                'original_url' => 'http://example.com/',
+                'original_url' => 'https://example.com/',
                 'type' => 'upstream',
                 'ssi' => [
                     'enabled' => false
@@ -266,68 +240,6 @@ class UrlManagerTest extends TestCase
                     'headers' => [
                         'Accept',
                         'Accept-Language'
-                    ]
-                ]
-            ]
-        ];
-        return [
-            [
-                $route,
-                'example.com'
-            ]
-        ];
-    }
-
-
-    public function secureRouteUrlDataProvider()
-    {
-        return [
-            [
-                [
-                    'https://example.com/' => [
-                        'original_url' => 'https://example.com/',
-                        'type' => 'upstream',
-                        'ssi' => [
-                            'enabled' => false
-                        ],
-                        'upstream' => 'mymagento',
-                        'cache' => [
-                            'cookies' => ['*'],
-                            'default_ttl' => 0,
-                            'enabled' => true,
-                            'headers' => [
-                                'Accept',
-                                'Accept-Language'
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ];
-    }
-
-    public function unsecureRouteUrlDataProvider()
-    {
-
-        return [
-            [
-                [
-                    'http://example.com/' => [
-                        'original_url' => 'http://example.com/',
-                        'type' => 'upstream',
-                        'ssi' => [
-                            'enabled' => false
-                        ],
-                        'upstream' => 'mymagento',
-                        'cache' => [
-                            'cookies' => ['*'],
-                            'default_ttl' => 0,
-                            'enabled' => true,
-                            'headers' => [
-                                'Accept',
-                                'Accept-Language'
-                            ]
-                        ]
                     ]
                 ]
             ]

--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -44,13 +44,14 @@ class UrlManager
 
     /**
      * Reads JSON array of routes and parses them into an array
+     *
      * @param array $routes from environment variable MAGENTO_CLOUD_ROUTES
      * @return array
      */
-    private function parseRoutes(array $routes) : array
+    private function parseRoutes(array $routes): array
     {
-
         $urls = ['secure' => [], 'unsecure' => []];
+
         foreach ($routes as $key => $val) {
             if ($val['type'] !== 'upstream') {
                 continue;
@@ -69,15 +70,16 @@ class UrlManager
                 continue;
             }
         }
+
         return $urls;
     }
 
-
     /**
      * Parse MagentoCloud routes to more readable format.
+     *
      * @throws \RuntimeException if no valid secure or unsecure route found
      */
-    public function getUrls()
+    public function getUrls(): array
     {
         if ($this->urls !== null) {
             return $this->urls;

--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -97,7 +97,7 @@ class UrlManager
         }
 
         if (0 == count($urls['secure'])) {
-            $urls['secure'] = str_replace(self::PREFIX_UNSECURE, self::PREFIX_SECURE, $urls['unsecure']);
+            $urls['secure'] = substr_replace($urls['unsecure'], self::PREFIX_SECURE, 0, strlen(self::PREFIX_UNSECURE));
         }
 
         $this->logger->info(sprintf('Routes: %s', var_export($urls, true)));

--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -47,7 +47,7 @@ class UrlManager
      * @param array $routes from environment variable MAGENTO_CLOUD_ROUTES
      * @return array
      */
-    public function parseRoutes(array $routes) : array
+    private function parseRoutes(array $routes) : array
     {
 
         $urls = ['secure' => [], 'unsecure' => []];
@@ -95,7 +95,7 @@ class UrlManager
         }
 
         if (!count($urls['secure'])) {
-            $urls['secure'] = $urls['unsecure'];
+            $urls['secure'] = str_replace(self::PREFIX_UNSECURE, self::PREFIX_SECURE, $urls['unsecure']);
         }
 
         $this->logger->info(sprintf('Routes: %s', var_export($urls, true)));

--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -87,14 +87,14 @@ class UrlManager
 
         $urls = $this->parseRoutes($this->environment->getRoutes());
 
-        if (!count($urls['unsecure']) && !count($urls['secure'])) {
+        if (0 == count($urls['unsecure']) && 0 == count($urls['secure'])) {
             throw new \RuntimeException('Expected at least one valid unsecure or secure route. None found.');
         }
-        if (!count($urls['unsecure'])) {
+        if (0 == count($urls['unsecure'])) {
             $urls['unsecure'] = $urls['secure'];
         }
 
-        if (!count($urls['secure'])) {
+        if (0 == count($urls['secure'])) {
             $urls['secure'] = str_replace(self::PREFIX_UNSECURE, self::PREFIX_SECURE, $urls['unsecure']);
         }
 

--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -25,7 +25,7 @@ class UrlManager
      */
     private $urls;
 
-    /**1
+    /**
      * @var LoggerInterface
      */
     private $logger;
@@ -85,22 +85,22 @@ class UrlManager
 
         $this->logger->info('Initializing routes.');
 
-        $this->urls = $this->parseRoutes($this->environment->getRoutes());
+        $urls = $this->parseRoutes($this->environment->getRoutes());
 
-        if (!count($this->urls['unsecure']) && !count($this->urls['secure'])) {
-            throw new \RuntimeException("Expected at least one valid unsecure or secure route. None found.");
+        if (!count($urls['unsecure']) && !count($urls['secure'])) {
+            throw new \RuntimeException('Expected at least one valid unsecure or secure route. None found.');
         }
-        if (!count($this->urls['unsecure'])) {
-            $this->urls['unsecure'] = $this->urls['secure'];
-        }
-
-        if (!count($this->urls['secure'])) {
-            $this->urls['secure'] = str_replace(self::PREFIX_UNSECURE, self::PREFIX_SECURE, $this->urls['unsecure']);
+        if (!count($urls['unsecure'])) {
+            $urls['unsecure'] = $urls['secure'];
         }
 
-        $this->logger->info(sprintf('Routes: %s', var_export($this->urls, true)));
+        if (!count($urls['secure'])) {
+            $urls['secure'] = $urls['unsecure'];
+        }
 
-        return $this->urls;
+        $this->logger->info(sprintf('Routes: %s', var_export($urls, true)));
+
+        return $this->urls = $urls;
     }
 
     public function getSecureUrls()


### PR DESCRIPTION
Setting unsecure URL to secure URL should one not be provided

### Description
1. Added in logic to set the unsecure URL if only Secure URL is provided
2. Refactor of getURLs method to reduce complexity
3. Added unit test coverage for URLManager

### Fixed Issues (if relevant)
1. https://magento2.atlassian.net/browse/MAGECLOUD-1182

### Zephyr Tests
1. https://jira.corp.magento.com/browse/MAGETWO-83086

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
