### PR TITLE
provide the user a way to see the install progress

### DIFF
--- a/src/Process/Deploy/InstallUpdate/Install/Setup.php
+++ b/src/Process/Deploy/InstallUpdate/Install/Setup.php
@@ -101,6 +101,6 @@ class Setup implements ProcessInterface
 
         $command .= $this->environment->getVerbosityLevel();
 
-        $this->shell->execute(escapeshellcmd($command));
+        $this->shell->execute('/bin/bash -c "set -o pipefail; '.escapeshellcmd($command).' | tee -a /tmp/install.log"');
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
`magento setup:install` can be a very long running process, which is exactly why [Progress: ..] lines are written. However, by using exec as written, there is no progress until after the command succeeds or fail. This is very frustrating and can hide potential problems (e.g. steps that are taking longer than expected, output that would cause you to abort the install, etc.).


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
1. Write progress to a file that a user can `tail -f`
There may be other solutions, but this is the one that I came up with. Using  the bash shell and `set -o pipefail` allows the proper exit status to return to the exec command, and so the remaining deploy code can handle it properly.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
