### PR TITLE
MAGECLOUD-1159: Replace all hardcoded config filenames and directories

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -36,12 +36,13 @@ class Container extends \Illuminate\Container\Container implements ContainerInte
         $this->singleton(\Magento\MagentoCloud\Filesystem\DirectoryList::class, function () use ($root, $config) {
             return new \Magento\MagentoCloud\Filesystem\DirectoryList($root, $config);
         });
+        $this->singleton(\Magento\MagentoCloud\Filesystem\FileList::class);
         $this->singleton(\Composer\Composer::class, function () {
-            $directoryList = $this->get(\Magento\MagentoCloud\Filesystem\DirectoryList::class);
+            $fileList = $this->get(\Magento\MagentoCloud\Filesystem\FileList::class);
 
             return \Composer\Factory::create(
                 new \Composer\IO\BufferIO(),
-                $directoryList->getMagentoRoot() . '/composer.json'
+                $fileList->getComposer()
             );
         });
         /**

--- a/src/Config/Build/Reader.php
+++ b/src/Config/Build/Reader.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\MagentoCloud\Config\Build;
 
-use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Filesystem\Reader\ReaderInterface;
 
@@ -20,18 +20,18 @@ class Reader implements ReaderInterface
     private $file;
 
     /**
-     * @var DirectoryList
+     * @var FileList
      */
-    private $directoryList;
+    private $fileList;
 
     /**
      * @param File $file
-     * @param DirectoryList $directoryList
+     * @param FileList $fileList
      */
-    public function __construct(File $file, DirectoryList $directoryList)
+    public function __construct(File $file, FileList $fileList)
     {
         $this->file = $file;
-        $this->directoryList = $directoryList;
+        $this->fileList = $fileList;
     }
 
     /**
@@ -39,16 +39,8 @@ class Reader implements ReaderInterface
      */
     public function read(): array
     {
-        $fileName = $this->getPath();
+        $fileName = $this->fileList->getBuildConfig();
 
         return $this->file->isExists($fileName) ? $this->file->parseIni($fileName) : [];
-    }
-
-    /**
-     * @return string
-     */
-    public function getPath(): string
-    {
-        return $this->directoryList->getMagentoRoot() . '/build_options.ini';
     }
 }

--- a/src/Config/Deploy/Reader.php
+++ b/src/Config/Deploy/Reader.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\MagentoCloud\Config\Deploy;
 
-use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Filesystem\Reader\ReaderInterface;
 
@@ -20,18 +20,18 @@ class Reader implements ReaderInterface
     private $file;
 
     /**
-     * @var DirectoryList
+     * @var FileList
      */
-    private $directoryList;
+    private $fileList;
 
     /**
      * @param File $file
-     * @param DirectoryList $directoryList
+     * @param FileList $fileList
      */
-    public function __construct(File $file, DirectoryList $directoryList)
+    public function __construct(File $file, FileList $fileList)
     {
         $this->file = $file;
-        $this->directoryList = $directoryList;
+        $this->fileList = $fileList;
     }
 
     /**
@@ -39,19 +39,11 @@ class Reader implements ReaderInterface
      */
     public function read(): array
     {
-        $configPath = $this->getPath();
+        $configPath = $this->fileList->getEnv();
         if (!$this->file->isExists($configPath)) {
             return [];
         }
 
-        return include $configPath;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPath(): string
-    {
-        return $this->directoryList->getMagentoRoot() . '/app/etc/env.php';
+        return require $configPath;
     }
 }

--- a/src/Config/Deploy/Writer.php
+++ b/src/Config/Deploy/Writer.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\MagentoCloud\Config\Deploy;
 
-use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 
 class Writer
@@ -16,9 +16,9 @@ class Writer
     private $reader;
 
     /**
-     * @var DirectoryList
+     * @var FileList
      */
-    private $directoryList;
+    private $fileList;
 
     /**
      * @var File
@@ -28,16 +28,16 @@ class Writer
     /**
      * @param Reader $reader
      * @param File $file
-     * @param DirectoryList $directoryList
+     * @param FileList $fileList
      */
     public function __construct(
         Reader $reader,
         File $file,
-        DirectoryList $directoryList
+        FileList $fileList
     ) {
         $this->reader = $reader;
         $this->file = $file;
-        $this->directoryList = $directoryList;
+        $this->fileList = $fileList;
     }
 
     /**
@@ -49,7 +49,7 @@ class Writer
     {
         $updatedConfig = '<?php' . PHP_EOL . 'return ' . var_export($config, true) . ';';
 
-        $this->file->filePutContents($this->reader->getPath(), $updatedConfig);
+        $this->file->filePutContents($this->fileList->getEnv(), $updatedConfig);
     }
 
     /**

--- a/src/Config/Shared/Reader.php
+++ b/src/Config/Shared/Reader.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\MagentoCloud\Config\Shared;
 
-use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\Reader\ReaderInterface;
 
 /**
@@ -20,18 +20,18 @@ class Reader implements ReaderInterface
     private $file;
 
     /**
-     * @var DirectoryList
+     * @var FileList
      */
-    private $directoryList;
+    private $fileList;
 
     /**
      * @param File $file
-     * @param DirectoryList $directoryList
+     * @param FileList $fileList
      */
-    public function __construct(File $file, DirectoryList $directoryList)
+    public function __construct(File $file, FileList $fileList)
     {
         $this->file = $file;
-        $this->directoryList = $directoryList;
+        $this->fileList = $fileList;
     }
 
     /**
@@ -39,19 +39,11 @@ class Reader implements ReaderInterface
      */
     public function read(): array
     {
-        $configPath = $this->getPath();
+        $configPath = $this->fileList->getConfig();
         if (!$this->file->isExists($configPath)) {
             return [];
         }
 
         return require $configPath;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPath(): string
-    {
-        return $this->directoryList->getMagentoRoot() . '/app/etc/config.php';
     }
 }

--- a/src/Filesystem/DirectoryList.php
+++ b/src/Filesystem/DirectoryList.php
@@ -64,7 +64,7 @@ class DirectoryList
         }
 
         $path = $directories[$code][self::PATH];
-        $normalizedPath = $root . ($root && $path ? DIRECTORY_SEPARATOR : '') . $path;
+        $normalizedPath = $root . ($root && $path ? '/' : '') . $path;
 
         return $normalizedPath;
     }

--- a/src/Filesystem/DirectoryList.php
+++ b/src/Filesystem/DirectoryList.php
@@ -112,7 +112,7 @@ class DirectoryList
              * Magento application's vendor folder.
              */
             static::MAGENTO_ROOT => [static::PATH => '../../..'],
-            static::INIT => [static::PATH => 'init'],
+            static::INIT => [static::PATH => '../../../init'],
         ];
     }
 }

--- a/src/Filesystem/DirectoryList.php
+++ b/src/Filesystem/DirectoryList.php
@@ -20,6 +20,7 @@ class DirectoryList
      */
     const ROOT = 'root';
     const MAGENTO_ROOT = 'magento_root';
+    const INIT = 'init';
 
     /**
      * @var string
@@ -93,6 +94,14 @@ class DirectoryList
     }
 
     /**
+     * @return string
+     */
+    public function getInit(): string
+    {
+        return $this->getPath(static::INIT);
+    }
+
+    /**
      * @return array
      */
     public static function getDefaultConfig(): array
@@ -103,6 +112,7 @@ class DirectoryList
              * Magento application's vendor folder.
              */
             static::MAGENTO_ROOT => [static::PATH => '../../..'],
+            static::INIT => [static::PATH => 'init'],
         ];
     }
 }

--- a/src/Filesystem/FileList.php
+++ b/src/Filesystem/FileList.php
@@ -38,4 +38,12 @@ class FileList
     {
         return $this->directoryList->getMagentoRoot() . '/app/etc/env.php';
     }
+
+    /**
+     * @return string
+     */
+    public function getBuildConfig()
+    {
+        return $this->directoryList->getMagentoRoot() . '/build_options.ini';
+    }
 }

--- a/src/Filesystem/FileList.php
+++ b/src/Filesystem/FileList.php
@@ -42,8 +42,16 @@ class FileList
     /**
      * @return string
      */
-    public function getBuildConfig()
+    public function getBuildConfig(): string
     {
         return $this->directoryList->getMagentoRoot() . '/build_options.ini';
+    }
+
+    /**
+     * @return string
+     */
+    public function getComposer(): string
+    {
+        return $this->directoryList->getMagentoRoot() . '/composer.json';
     }
 }

--- a/src/Filesystem/Reader/ReaderInterface.php
+++ b/src/Filesystem/Reader/ReaderInterface.php
@@ -14,9 +14,4 @@ interface ReaderInterface
      * @return array
      */
     public function read(): array;
-
-    /**
-     * @return string
-     */
-    public function getPath(): string;
 }

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -63,8 +63,8 @@ class BackupData implements ProcessInterface
      */
     public function execute()
     {
-        $magentoRoot = $this->directoryList->getMagentoRoot() . DIRECTORY_SEPARATOR;
-        $rootInitDir = $this->directoryList->getInit() . DIRECTORY_SEPARATOR;
+        $magentoRoot = $this->directoryList->getMagentoRoot() . '/';
+        $rootInitDir = $this->directoryList->getInit() . '/';
 
         if ($this->file->isExists($magentoRoot . Environment::REGENERATE_FLAG)) {
             $this->logger->info('Removing .regenerate flag');

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -63,7 +63,8 @@ class BackupData implements ProcessInterface
      */
     public function execute()
     {
-        $magentoRoot = $this->directoryList->getMagentoRoot() . '/';
+        $magentoRoot = $this->directoryList->getMagentoRoot() . DIRECTORY_SEPARATOR;
+        $rootInitDir = $this->directoryList->getInit() . DIRECTORY_SEPARATOR;
 
         if ($this->file->isExists($magentoRoot . Environment::REGENERATE_FLAG)) {
             $this->logger->info('Removing .regenerate flag');
@@ -71,7 +72,7 @@ class BackupData implements ProcessInterface
         }
 
         if ($this->environment->isStaticDeployInBuild()) {
-            $initPub = $magentoRoot . 'init/pub/';
+            $initPub = $rootInitDir . 'pub/';
             $initPubStatic = $initPub . 'static/';
             $originalPubStatic = $magentoRoot . 'pub/static/';
 
@@ -87,7 +88,7 @@ class BackupData implements ProcessInterface
             $this->file->copyDirectory($originalPubStatic, $initPubStatic);
             $this->file->copy(
                 $magentoRoot . Environment::STATIC_CONTENT_DEPLOY_FLAG,
-                $magentoRoot . 'init/' . Environment::STATIC_CONTENT_DEPLOY_FLAG
+                $rootInitDir . Environment::STATIC_CONTENT_DEPLOY_FLAG
             );
         } else {
             $this->logger->info('No file ' . Environment::STATIC_CONTENT_DEPLOY_FLAG);
@@ -97,7 +98,7 @@ class BackupData implements ProcessInterface
 
         foreach ($this->environment->getWritableDirectories() as $dir) {
             $originalDir = $magentoRoot . $dir;
-            $initDir = $magentoRoot . 'init/' . $dir;
+            $initDir = $rootInitDir . $dir;
 
             $this->file->createDirectory($initDir);
             $this->file->createDirectory($originalDir);

--- a/src/Process/Build/ClearInitDirectory.php
+++ b/src/Process/Build/ClearInitDirectory.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\MagentoCloud\Process\Build;
 
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
@@ -31,17 +32,25 @@ class ClearInitDirectory implements ProcessInterface
     private $logger;
 
     /**
+     * @var FileList
+     */
+    private $fileList;
+
+    /**
      * @param File $file
      * @param DirectoryList $directoryList
+     * @param FileList $fileList
      * @param LoggerInterface $logger
      */
     public function __construct(
         File $file,
         DirectoryList $directoryList,
+        FileList $fileList,
         LoggerInterface $logger
     ) {
         $this->file = $file;
         $this->directoryList = $directoryList;
+        $this->fileList = $fileList;
         $this->logger = $logger;
     }
 
@@ -50,9 +59,8 @@ class ClearInitDirectory implements ProcessInterface
      */
     public function execute()
     {
-        $magentoRoot = $this->directoryList->getMagentoRoot();
-        $envPhpPath = $magentoRoot . '/app/etc/env.php';
-        $initPath = $magentoRoot . '/init/';
+        $envPhpPath = $this->fileList->getEnv();
+        $initPath = $this->directoryList->getInit();
         $this->logger->info('Clearing temporary directory.');
 
         if ($this->file->isExists($initPath)) {

--- a/src/Process/Build/DeployStaticContent.php
+++ b/src/Process/Build/DeployStaticContent.php
@@ -6,7 +6,7 @@
 namespace Magento\MagentoCloud\Process\Build;
 
 use Magento\MagentoCloud\Config\Environment;
-use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Magento\MagentoCloud\Config\Build as BuildConfig;
@@ -39,9 +39,9 @@ class DeployStaticContent implements ProcessInterface
     private $environment;
 
     /**
-     * @var DirectoryList
+     * @var FileList
      */
-    private $directoryList;
+    private $fileList;
 
     /**
      * @var ArrayManager
@@ -58,7 +58,7 @@ class DeployStaticContent implements ProcessInterface
      * @param BuildConfig $buildConfig
      * @param File $file
      * @param Environment $environment
-     * @param DirectoryList $directoryList
+     * @param FileList $fileList
      * @param ArrayManager $arrayManager
      * @param ProcessInterface $process
      */
@@ -67,7 +67,7 @@ class DeployStaticContent implements ProcessInterface
         BuildConfig $buildConfig,
         File $file,
         Environment $environment,
-        DirectoryList $directoryList,
+        FileList $fileList,
         ArrayManager $arrayManager,
         ProcessInterface $process
     ) {
@@ -75,7 +75,7 @@ class DeployStaticContent implements ProcessInterface
         $this->file = $file;
         $this->buildConfig = $buildConfig;
         $this->environment = $environment;
-        $this->directoryList = $directoryList;
+        $this->fileList = $fileList;
         $this->arrayManager = $arrayManager;
         $this->process = $process;
     }
@@ -85,7 +85,7 @@ class DeployStaticContent implements ProcessInterface
      */
     public function execute()
     {
-        $configFile = $this->directoryList->getMagentoRoot() . '/app/etc/config.php';
+        $configFile = $this->fileList->getConfig();
 
         if (!$this->file->isExists($configFile) || $this->buildConfig->get(BuildConfig::OPT_SKIP_SCD)) {
             $this->logger->notice('Skipping static content deploy');

--- a/src/StaticContent/Build/Option.php
+++ b/src/StaticContent/Build/Option.php
@@ -6,7 +6,7 @@
 namespace Magento\MagentoCloud\StaticContent\Build;
 
 use Magento\MagentoCloud\Config\Environment;
-use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\StaticContent\OptionInterface;
 use Magento\MagentoCloud\Util\ArrayManager;
@@ -33,9 +33,9 @@ class Option implements OptionInterface
     private $arrayManager;
 
     /**
-     * @var DirectoryList
+     * @var FileList
      */
-    private $directoryList;
+    private $fileList;
 
     /**
      * @var BuildConfig
@@ -46,20 +46,20 @@ class Option implements OptionInterface
      * @param Environment $environment
      * @param ArrayManager $arrayManager
      * @param MagentoVersion $magentoVersion
-     * @param DirectoryList $directoryList
+     * @param FileList $fileList
      * @param BuildConfig $buildConfig
      */
     public function __construct(
         Environment $environment,
         ArrayManager $arrayManager,
         MagentoVersion $magentoVersion,
-        DirectoryList $directoryList,
+        FileList $fileList,
         BuildConfig $buildConfig
     ) {
         $this->environment = $environment;
         $this->magentoVersion = $magentoVersion;
         $this->arrayManager = $arrayManager;
-        $this->directoryList = $directoryList;
+        $this->fileList = $fileList;
         $this->buildConfig = $buildConfig;
     }
 
@@ -102,8 +102,9 @@ class Option implements OptionInterface
      */
     public function getLocales(): array
     {
-        $configPath = require $this->directoryList->getMagentoRoot() . '/app/etc/config.php';
-        $flattenedConfig = $this->arrayManager->flatten($configPath);
+        $configPath = $this->fileList->getConfig();
+        $configuration = require $configPath;
+        $flattenedConfig = $this->arrayManager->flatten($configuration);
 
         $locales = [$this->environment->getAdminLocale()];
         $locales = array_merge($locales, $this->arrayManager->filter($flattenedConfig, 'general/locale/code'));

--- a/src/Test/Integration/Bootstrap.php
+++ b/src/Test/Integration/Bootstrap.php
@@ -137,6 +137,9 @@ class Bootstrap
             DirectoryList::MAGENTO_ROOT => [
                 DirectoryList::PATH => '',
             ],
+            DirectoryList::INIT => [
+                DirectoryList::PATH => 'init',
+            ],
         ];
 
         return \Magento\MagentoCloud\App\Bootstrap::create($this->getSandboxDir(), $server)

--- a/src/Test/Unit/Config/Build/ReaderTest.php
+++ b/src/Test/Unit/Config/Build/ReaderTest.php
@@ -6,7 +6,7 @@
 namespace Magento\MagentoCloud\Test\Unit\Config\Build;
 
 use Magento\MagentoCloud\Config\Build\Reader;
-use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use PHPUnit\Framework\TestCase;
 
@@ -26,9 +26,9 @@ class ReaderTest extends TestCase
     private $fileMock;
 
     /**
-     * @var DirectoryList|\PHPUnit_Framework_MockObject_MockObject
+     * @var FileList|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $directoryListMock;
+    private $fileListMock;
 
     /**
      * @inheritdoc
@@ -36,18 +36,19 @@ class ReaderTest extends TestCase
     protected function setUp()
     {
         $this->fileMock = $this->createMock(File::class);
-        $this->directoryListMock = $this->createMock(DirectoryList::class);
+        $this->fileListMock = $this->createMock(FileList::class);
 
         $this->reader = new Reader(
             $this->fileMock,
-            $this->directoryListMock
+            $this->fileListMock
         );
     }
 
     public function testRead()
     {
-        $this->directoryListMock->method('getMagentoRoot')
-            ->willReturn('magento_root');
+        $this->fileListMock->expects($this->once())
+            ->method('getBuildConfig')
+            ->willReturn('magento_root/build_options.ini');
         $this->fileMock->method('isExists')
             ->with('magento_root/build_options.ini')
             ->willReturn(true);
@@ -60,8 +61,9 @@ class ReaderTest extends TestCase
 
     public function testReadNoFile()
     {
-        $this->directoryListMock->method('getMagentoRoot')
-            ->willReturn('magento_root');
+        $this->fileListMock->expects($this->once())
+            ->method('getBuildConfig')
+            ->willReturn('magento_root/build_options.ini');
         $this->fileMock->method('isExists')
             ->with('magento_root/build_options.ini')
             ->willReturn(false);
@@ -69,16 +71,5 @@ class ReaderTest extends TestCase
             ->method('parseIni');
 
         $this->assertSame([], $this->reader->read());
-    }
-
-    public function testGetPath()
-    {
-        $this->directoryListMock->method('getMagentoRoot')
-            ->willReturn('magento_root');
-
-        $this->assertSame(
-            'magento_root/build_options.ini',
-            $this->reader->getPath()
-        );
     }
 }

--- a/src/Test/Unit/Config/Deploy/ReaderTest.php
+++ b/src/Test/Unit/Config/Deploy/ReaderTest.php
@@ -6,7 +6,7 @@
 namespace Magento\MagentoCloud\Test\Unit\Config\Deploy;
 
 use Magento\MagentoCloud\Config\Deploy\Reader;
-use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
@@ -19,9 +19,9 @@ class ReaderTest extends TestCase
     private $fileMock;
 
     /**
-     * @var DirectoryList|Mock
+     * @var FileList|Mock
      */
-    private $directoryListMock;
+    private $fileListMock;
 
     /**
      * @var Reader
@@ -31,19 +31,19 @@ class ReaderTest extends TestCase
     protected function setUp()
     {
         $this->fileMock = $this->createMock(File::class);
-        $this->directoryListMock = $this->createMock(DirectoryList::class);
+        $this->fileListMock = $this->createMock(FileList::class);
 
         $this->reader = new Reader(
             $this->fileMock,
-            $this->directoryListMock
+            $this->fileListMock
         );
     }
 
     public function testRead()
     {
-        $this->directoryListMock->expects($this->once())
-            ->method('getMagentoRoot')
-            ->willReturn(__DIR__ . '/../_file/Deploy');
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
+            ->willReturn(__DIR__ . '/../_file/Deploy/app/etc/env.php');
         $this->fileMock->expects($this->once())
             ->method('isExists')
             ->with(__DIR__ . '/../_file/Deploy/app/etc/env.php')
@@ -61,9 +61,9 @@ class ReaderTest extends TestCase
 
     public function testReadFileNotExists()
     {
-        $this->directoryListMock->expects($this->once())
-            ->method('getMagentoRoot')
-            ->willReturn(__DIR__ . '/../_file/Deploy');
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
+            ->willReturn(__DIR__ . '/../_file/Deploy/app/etc/env.php');
         $this->fileMock->expects($this->once())
             ->method('isExists')
             ->with(__DIR__ . '/../_file/Deploy/app/etc/env.php')
@@ -72,19 +72,6 @@ class ReaderTest extends TestCase
         $this->assertEquals(
             [],
             $this->reader->read()
-        );
-    }
-
-
-    public function testGetPath()
-    {
-        $this->directoryListMock->expects($this->once())
-            ->method('getMagentoRoot')
-            ->willReturn('/path');
-
-        $this->assertEquals(
-            '/path/app/etc/env.php',
-            $this->reader->getPath()
         );
     }
 }

--- a/src/Test/Unit/Config/Deploy/WriterTest.php
+++ b/src/Test/Unit/Config/Deploy/WriterTest.php
@@ -95,8 +95,8 @@ class WriterTest extends TestCase
     public function testUpdate(array $config, array $currentConfig, $updatedConfig)
     {
         $filePath = '/path/to/file';
-        $this->readerMock->expects($this->once())
-            ->method('getPath')
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
             ->willReturn($filePath);
         $this->readerMock->expects($this->once())
             ->method('read')

--- a/src/Test/Unit/Config/Deploy/WriterTest.php
+++ b/src/Test/Unit/Config/Deploy/WriterTest.php
@@ -7,7 +7,7 @@ namespace Magento\MagentoCloud\Test\Unit\Config\Deploy;
 
 use Magento\MagentoCloud\Config\Deploy\Reader;
 use Magento\MagentoCloud\Config\Deploy\Writer;
-use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
@@ -20,9 +20,9 @@ class WriterTest extends TestCase
     private $fileMock;
 
     /**
-     * @var DirectoryList|Mock
+     * @var FileList|Mock
      */
-    private $directoryListMock;
+    private $fileListMock;
 
     /**
      * @var Reader|Mock
@@ -38,12 +38,12 @@ class WriterTest extends TestCase
     {
         $this->fileMock = $this->createMock(File::class);
         $this->readerMock = $this->createMock(Reader::class);
-        $this->directoryListMock = $this->createMock(DirectoryList::class);
+        $this->fileListMock = $this->createMock(FileList::class);
 
         $this->writer = new Writer(
             $this->readerMock,
             $this->fileMock,
-            $this->directoryListMock
+            $this->fileListMock
         );
     }
 
@@ -55,8 +55,8 @@ class WriterTest extends TestCase
     public function testWrite(array $config, $updatedConfig)
     {
         $filePath = '/path/to/file';
-        $this->readerMock->expects($this->once())
-            ->method('getPath')
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
             ->willReturn($filePath);
         $this->fileMock->expects($this->once())
             ->method('filePutContents')

--- a/src/Test/Unit/Config/Shared/ReaderTest.php
+++ b/src/Test/Unit/Config/Shared/ReaderTest.php
@@ -6,8 +6,8 @@
 namespace Magento\MagentoCloud\Test\Unit\Config\Shared;
 
 use Magento\MagentoCloud\Config\Shared\Reader;
-use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Filesystem\FileList;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
 
@@ -19,9 +19,9 @@ class ReaderTest extends TestCase
     private $fileMock;
 
     /**
-     * @var DirectoryList|Mock
+     * @var FileList|Mock
      */
-    private $directoryListMock;
+    private $fileListMock;
 
     /**
      * @var Reader
@@ -31,19 +31,19 @@ class ReaderTest extends TestCase
     protected function setUp()
     {
         $this->fileMock = $this->createMock(File::class);
-        $this->directoryListMock = $this->createMock(DirectoryList::class);
+        $this->fileListMock = $this->createMock(FileList::class);
 
         $this->reader = new Reader(
             $this->fileMock,
-            $this->directoryListMock
+            $this->fileListMock
         );
     }
 
     public function testRead()
     {
-        $this->directoryListMock->expects($this->once())
-            ->method('getMagentoRoot')
-            ->willReturn(__DIR__ . '/_file');
+        $this->fileListMock->expects($this->once())
+            ->method('getConfig')
+            ->willReturn(__DIR__ . '/_file/app/etc/config.php');
         $this->fileMock->expects($this->once())
             ->method('isExists')
             ->with(__DIR__ . '/_file/app/etc/config.php')
@@ -62,30 +62,17 @@ class ReaderTest extends TestCase
 
     public function testReadFileNotExists()
     {
-        $this->directoryListMock->expects($this->once())
-            ->method('getMagentoRoot')
-            ->willReturn(__DIR__ . '/_file');
+        $this->fileListMock->expects($this->once())
+            ->method('getConfig')
+            ->willReturn('/path/to/file');
         $this->fileMock->expects($this->once())
             ->method('isExists')
-            ->with(__DIR__ . '/_file/app/etc/config.php')
+            ->with('/path/to/file')
             ->willReturn(false);
 
         $this->assertEquals(
             [],
             $this->reader->read()
-        );
-    }
-
-
-    public function testGetPath()
-    {
-        $this->directoryListMock->expects($this->once())
-            ->method('getMagentoRoot')
-            ->willReturn('/path');
-
-        $this->assertEquals(
-            '/path/app/etc/config.php',
-            $this->reader->getPath()
         );
     }
 }

--- a/src/Test/Unit/Filesystem/DirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/DirectoryListTest.php
@@ -93,4 +93,12 @@ class DirectoryListTest extends TestCase
             $this->directoryList->getMagentoRoot()
         );
     }
+
+    public function testGetInit()
+    {
+        $this->assertSame(
+            __DIR__ . DIRECTORY_SEPARATOR . '../../../init',
+            $this->directoryList->getInit()
+        );
+    }
 }

--- a/src/Test/Unit/Filesystem/DirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/DirectoryListTest.php
@@ -51,11 +51,11 @@ class DirectoryListTest extends TestCase
             'root' => [DirectoryList::ROOT, __DIR__],
             'magento root' => [
                 DirectoryList::MAGENTO_ROOT,
-                __DIR__ . DIRECTORY_SEPARATOR . '../../..',
+                __DIR__ . '/../../..',
             ],
             'test var' => [
                 'test_var',
-                __DIR__ . DIRECTORY_SEPARATOR . '_files/test/var',
+                __DIR__ . '/_files/test/var',
             ],
         ];
     }
@@ -89,7 +89,7 @@ class DirectoryListTest extends TestCase
     public function testGetMagentoRoot()
     {
         $this->assertSame(
-            __DIR__ . DIRECTORY_SEPARATOR . '../../..',
+            __DIR__ . '/../../..',
             $this->directoryList->getMagentoRoot()
         );
     }
@@ -97,7 +97,7 @@ class DirectoryListTest extends TestCase
     public function testGetInit()
     {
         $this->assertSame(
-            __DIR__ . DIRECTORY_SEPARATOR . '../../../init',
+            __DIR__ . '/../../../init',
             $this->directoryList->getInit()
         );
     }

--- a/src/Test/Unit/Filesystem/FileListTest.php
+++ b/src/Test/Unit/Filesystem/FileListTest.php
@@ -30,6 +30,9 @@ class FileListTest extends TestCase
     protected function setUp()
     {
         $this->directoryListMock = $this->createMock(DirectoryList::class);
+        $this->directoryListMock->expects($this->once())
+            ->method('getMagentoRoot')
+            ->willReturn('magento_root');
 
         $this->fileList = new FileList(
             $this->directoryListMock
@@ -38,19 +41,21 @@ class FileListTest extends TestCase
 
     public function testGetConfig()
     {
-        $this->directoryListMock->expects($this->once())
-            ->method('getMagentoRoot')
-            ->willReturn('magento_root');
-
         $this->assertSame('magento_root/app/etc/config.php', $this->fileList->getConfig());
     }
 
     public function testGetEnv()
     {
-        $this->directoryListMock->expects($this->once())
-            ->method('getMagentoRoot')
-            ->willReturn('magento_root');
-
         $this->assertSame('magento_root/app/etc/env.php', $this->fileList->getEnv());
+    }
+
+    public function testGetBuildConfig()
+    {
+        $this->assertSame('magento_root/build_options.ini', $this->fileList->getBuildConfig());
+    }
+
+    public function testGetComposer()
+    {
+        $this->assertSame('magento_root/composer.json', $this->fileList->getComposer());
     }
 }

--- a/src/Test/Unit/Process/Build/BackupDataTest.php
+++ b/src/Test/Unit/Process/Build/BackupDataTest.php
@@ -62,6 +62,9 @@ class BackupDataTest extends TestCase
         $this->directoryListMock->expects($this->once())
             ->method('getMagentoRoot')
             ->willReturn('magento_root');
+        $this->directoryListMock->expects($this->once())
+            ->method('getInit')
+            ->willReturn('magento_root/init');
 
         $this->process = new BackupData(
             $this->fileMock,

--- a/src/Test/Unit/Process/Build/ClearInitDirectoryTest.php
+++ b/src/Test/Unit/Process/Build/ClearInitDirectoryTest.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\MagentoCloud\Test\Unit\Process\Build;
 
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Process\Build\ClearInitDirectory;
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
@@ -32,6 +33,11 @@ class ClearInitDirectoryTest extends TestCase
     private $directoryListMock;
 
     /**
+     * @var FileList|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $fileListMock;
+
+    /**
      * @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $loggerMock;
@@ -43,12 +49,14 @@ class ClearInitDirectoryTest extends TestCase
     {
         $this->fileMock = $this->createMock(File::class);
         $this->directoryListMock = $this->createMock(DirectoryList::class);
+        $this->fileListMock = $this->createMock(FileList::class);
         $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
             ->getMockForAbstractClass();
 
         $this->process = new ClearInitDirectory(
             $this->fileMock,
             $this->directoryListMock,
+            $this->fileListMock,
             $this->loggerMock
         );
     }
@@ -65,17 +73,20 @@ class ClearInitDirectoryTest extends TestCase
             ->method('info')
             ->with('Clearing temporary directory.');
         $this->directoryListMock->expects($this->once())
-            ->method('getMagentoRoot')
-            ->willReturn('magento_root');
+            ->method('getInit')
+            ->willReturn('magento_root/init');
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
+            ->willReturn('magento_root/app/etc/env.php');
         $this->fileMock->expects($this->exactly(2))
             ->method('isExists')
             ->willReturnMap([
-                ['magento_root/init/', $isExists],
+                ['magento_root/init', $isExists],
                 ['magento_root/app/etc/env.php', $isExists]
             ]);
         $this->fileMock->expects($this->exactly($clearDirectory))
             ->method('clearDirectory')
-            ->with('magento_root/init/')
+            ->with('magento_root/init')
             ->willReturn(true);
         $this->fileMock->expects($this->exactly($deleteFile))
             ->method('deleteFile')

--- a/src/Test/Unit/Process/Build/DeployStaticContentTest.php
+++ b/src/Test/Unit/Process/Build/DeployStaticContentTest.php
@@ -7,7 +7,7 @@ namespace Magento\MagentoCloud\Test\Unit\Process\Build;
 
 use Magento\MagentoCloud\Config\Build;
 use Magento\MagentoCloud\Config\Environment;
-use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Process\Build\DeployStaticContent;
 use Magento\MagentoCloud\Process\ProcessInterface;
@@ -46,9 +46,9 @@ class DeployStaticContentTest extends TestCase
     private $environmentMock;
 
     /**
-     * @var DirectoryList|\PHPUnit_Framework_MockObject_MockObject
+     * @var FileList|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $directoryListMock;
+    private $fileListMock;
 
     /**
      * @var ArrayManager|\PHPUnit_Framework_MockObject_MockObject
@@ -76,7 +76,7 @@ class DeployStaticContentTest extends TestCase
         $this->environmentMock = $this->getMockBuilder(Environment::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->directoryListMock = $this->getMockBuilder(DirectoryList::class)
+        $this->fileListMock = $this->getMockBuilder(FileList::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->arrayManagerMock = $this->getMockBuilder(ArrayManager::class)
@@ -84,20 +84,19 @@ class DeployStaticContentTest extends TestCase
             ->getMock();
         $this->processMock = $this->getMockForAbstractClass(ProcessInterface::class);
 
-        $this->directoryListMock->method('getMagentoRoot')
-            ->willReturn(__DIR__ . '/_files');
+        $this->fileListMock->method('getConfig')
+            ->willReturn(__DIR__ . '/_files/app/etc/config.php');
 
         $this->process = new DeployStaticContent(
             $this->loggerMock,
             $this->buildConfigMock,
             $this->fileMock,
             $this->environmentMock,
-            $this->directoryListMock,
+            $this->fileListMock,
             $this->arrayManagerMock,
             $this->processMock
         );
     }
-
 
     public function testExecute()
     {

--- a/src/Test/Unit/StaticContent/Build/OptionTest.php
+++ b/src/Test/Unit/StaticContent/Build/OptionTest.php
@@ -7,7 +7,7 @@ namespace Magento\MagentoCloud\Test\Unit\StaticContent\Build;
 
 use Magento\MagentoCloud\Config\Build as BuildConfig;
 use Magento\MagentoCloud\Config\Environment;
-use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\StaticContent\Build\Option;
 use Magento\MagentoCloud\Util\ArrayManager;
@@ -42,14 +42,14 @@ class OptionTest extends TestCase
     private $buildConfigMock;
 
     /**
-     * @var DirectoryList|Mock
+     * @var FileList|Mock
      */
-    private $directoryListMock;
+    private $fileListMock;
 
     protected function setUp()
     {
         $this->magentoVersionMock = $this->createMock(MagentoVersion::class);
-        $this->directoryListMock = $this->createMock(DirectoryList::class);
+        $this->fileListMock = $this->createMock(FileList::class);
         $this->buildConfigMock = $this->createMock(BuildConfig::class);
         $this->environmentMock = $this->createMock(Environment::class);
         $this->arrayManagerMock = $this->createMock(ArrayManager::class);
@@ -58,7 +58,7 @@ class OptionTest extends TestCase
             $this->environmentMock,
             $this->arrayManagerMock,
             $this->magentoVersionMock,
-            $this->directoryListMock,
+            $this->fileListMock,
             $this->buildConfigMock
         );
     }
@@ -131,9 +131,9 @@ class OptionTest extends TestCase
 
     public function testGetLocales()
     {
-        $this->directoryListMock->expects($this->once())
-            ->method('getMagentoRoot')
-            ->willReturn(__DIR__ . '/_files/');
+        $this->fileListMock->expects($this->once())
+            ->method('getConfig')
+            ->willReturn(__DIR__ . '/_files/app/etc/config.php');
         $flattenConfig = [
             'scopes' => [
                 'websites' => [],

--- a/src/Test/Unit/Util/BuildDirCopierTest.php
+++ b/src/Test/Unit/Util/BuildDirCopierTest.php
@@ -51,9 +51,9 @@ class BuildDirCopierTest extends TestCase
     public function testCopy()
     {
         $rootDir = '/path/to/root';
-        $initDir = $rootDir . DIRECTORY_SEPARATOR . 'init';
+        $initDir = $rootDir . '/init';
         $dir = 'dir';
-        $rootInitDir = $initDir . DIRECTORY_SEPARATOR . $dir;
+        $rootInitDir = $initDir . '/' . $dir;
 
         $this->directoryListMock->expects($this->once())
             ->method('getMagentoRoot')
@@ -65,14 +65,14 @@ class BuildDirCopierTest extends TestCase
             ->method('isExists')
             ->withConsecutive(
                 [$rootInitDir],
-                [$rootDir . DIRECTORY_SEPARATOR . $dir]
+                [$rootDir . '/' . $dir]
             )
             ->willReturnOnConsecutiveCalls(true, true);
         $this->fileMock->expects($this->never())
             ->method('createDirectory');
         $this->fileMock->expects($this->once())
             ->method('copyDirectory')
-            ->with($rootInitDir, $rootDir . DIRECTORY_SEPARATOR .$dir)
+            ->with($rootInitDir, $rootDir . '/' .$dir)
             ->willReturn(true);
         $this->loggerMock->expects($this->once())
             ->method('info')
@@ -86,9 +86,9 @@ class BuildDirCopierTest extends TestCase
     public function testCopyDirectoryNotExist()
     {
         $rootDir = '/path/to/root';
-        $initDir = $rootDir . DIRECTORY_SEPARATOR . 'init';
+        $initDir = $rootDir . '/init';
         $dir = 'not-exist-dir';
-        $rootInitDir = $initDir . DIRECTORY_SEPARATOR . $dir;
+        $rootInitDir = $initDir . '/' . $dir;
 
         $this->directoryListMock->expects($this->once())
             ->method('getMagentoRoot')
@@ -100,15 +100,15 @@ class BuildDirCopierTest extends TestCase
             ->method('isExists')
             ->withConsecutive(
                 [$rootInitDir],
-                [$rootDir . DIRECTORY_SEPARATOR . $dir]
+                [$rootDir . '/' . $dir]
             )
             ->willReturnOnConsecutiveCalls(true, false);
         $this->fileMock->expects($this->once())
             ->method('createDirectory')
-            ->with($rootDir . DIRECTORY_SEPARATOR . $dir);
+            ->with($rootDir . '/' . $dir);
         $this->fileMock->expects($this->once())
             ->method('copyDirectory')
-            ->with($rootInitDir, $rootDir . DIRECTORY_SEPARATOR .$dir)
+            ->with($rootInitDir, $rootDir . '/' .$dir)
             ->willReturn(true);
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
@@ -125,9 +125,9 @@ class BuildDirCopierTest extends TestCase
     public function testCopyInitDirectoryNotExists()
     {
         $rootDir = '/path/to/root';
-        $initDir = $rootDir . DIRECTORY_SEPARATOR . 'init';
+        $initDir = $rootDir . '/init';
         $dir = 'not-exist-dir';
-        $rootInitDir = $initDir . DIRECTORY_SEPARATOR . $dir;
+        $rootInitDir = $initDir . '/' . $dir;
 
         $this->directoryListMock->expects($this->once())
             ->method('getMagentoRoot')

--- a/src/Test/Unit/Util/BuildDirCopierTest.php
+++ b/src/Test/Unit/Util/BuildDirCopierTest.php
@@ -51,24 +51,28 @@ class BuildDirCopierTest extends TestCase
     public function testCopy()
     {
         $rootDir = '/path/to/root';
+        $initDir = $rootDir . DIRECTORY_SEPARATOR . 'init';
         $dir = 'dir';
-        $rootInitDir = $rootDir . '/init/'. $dir;
+        $rootInitDir = $initDir . DIRECTORY_SEPARATOR . $dir;
 
         $this->directoryListMock->expects($this->once())
             ->method('getMagentoRoot')
             ->willReturn($rootDir);
+        $this->directoryListMock->expects($this->once())
+            ->method('getInit')
+            ->willReturn($initDir);
         $this->fileMock->expects($this->exactly(2))
             ->method('isExists')
             ->withConsecutive(
                 [$rootInitDir],
-                [$rootDir . '/' . $dir]
+                [$rootDir . DIRECTORY_SEPARATOR . $dir]
             )
             ->willReturnOnConsecutiveCalls(true, true);
         $this->fileMock->expects($this->never())
             ->method('createDirectory');
         $this->fileMock->expects($this->once())
             ->method('copyDirectory')
-            ->with($rootInitDir, $rootDir . '/' .$dir)
+            ->with($rootInitDir, $rootDir . DIRECTORY_SEPARATOR .$dir)
             ->willReturn(true);
         $this->loggerMock->expects($this->once())
             ->method('info')
@@ -82,25 +86,29 @@ class BuildDirCopierTest extends TestCase
     public function testCopyDirectoryNotExist()
     {
         $rootDir = '/path/to/root';
+        $initDir = $rootDir . DIRECTORY_SEPARATOR . 'init';
         $dir = 'not-exist-dir';
-        $rootInitDir = $rootDir . '/init/'. $dir;
+        $rootInitDir = $initDir . DIRECTORY_SEPARATOR . $dir;
 
         $this->directoryListMock->expects($this->once())
             ->method('getMagentoRoot')
             ->willReturn($rootDir);
+        $this->directoryListMock->expects($this->once())
+            ->method('getInit')
+            ->willReturn($initDir);
         $this->fileMock->expects($this->exactly(2))
             ->method('isExists')
             ->withConsecutive(
                 [$rootInitDir],
-                [$rootDir . '/' . $dir]
+                [$rootDir . DIRECTORY_SEPARATOR . $dir]
             )
             ->willReturnOnConsecutiveCalls(true, false);
         $this->fileMock->expects($this->once())
             ->method('createDirectory')
-            ->with($rootDir . '/' . $dir);
+            ->with($rootDir . DIRECTORY_SEPARATOR . $dir);
         $this->fileMock->expects($this->once())
             ->method('copyDirectory')
-            ->with($rootDir . '/init/' .$dir, $rootDir . '/' .$dir)
+            ->with($rootInitDir, $rootDir . DIRECTORY_SEPARATOR .$dir)
             ->willReturn(true);
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
@@ -117,12 +125,16 @@ class BuildDirCopierTest extends TestCase
     public function testCopyInitDirectoryNotExists()
     {
         $rootDir = '/path/to/root';
+        $initDir = $rootDir . DIRECTORY_SEPARATOR . 'init';
         $dir = 'not-exist-dir';
-        $rootInitDir = $rootDir . '/init/'. $dir;
+        $rootInitDir = $initDir . DIRECTORY_SEPARATOR . $dir;
 
         $this->directoryListMock->expects($this->once())
             ->method('getMagentoRoot')
             ->willReturn($rootDir);
+        $this->directoryListMock->expects($this->once())
+            ->method('getInit')
+            ->willReturn($initDir);
         $this->fileMock->expects($this->once())
             ->method('isExists')
             ->with($rootInitDir)

--- a/src/Util/BuildDirCopier.php
+++ b/src/Util/BuildDirCopier.php
@@ -48,8 +48,8 @@ class BuildDirCopier
     public function copy($dir)
     {
         $magentoRoot = $this->directoryList->getMagentoRoot();
-        $originalDir = $magentoRoot . DIRECTORY_SEPARATOR . $dir;
-        $initDir = $this->directoryList->getInit() . DIRECTORY_SEPARATOR . $dir;
+        $originalDir = $magentoRoot . '/' . $dir;
+        $initDir = $this->directoryList->getInit() . '/' . $dir;
 
         if (!$this->file->isExists($initDir)) {
             $this->logger->notice(sprintf('Can\'t copy directory %s. Directory does not exist.', $magentoRoot));

--- a/src/Util/BuildDirCopier.php
+++ b/src/Util/BuildDirCopier.php
@@ -48,8 +48,8 @@ class BuildDirCopier
     public function copy($dir)
     {
         $magentoRoot = $this->directoryList->getMagentoRoot();
-        $originalDir = $magentoRoot . '/' . $dir;
-        $initDir = $magentoRoot . '/init/' . $dir;
+        $originalDir = $magentoRoot . DIRECTORY_SEPARATOR . $dir;
+        $initDir = $this->directoryList->getInit() . DIRECTORY_SEPARATOR . $dir;
 
         if (!$this->file->isExists($initDir)) {
             $this->logger->notice(sprintf('Can\'t copy directory %s. Directory does not exist.', $magentoRoot));


### PR DESCRIPTION
### Description

We have many places where hardcoded path to env.php and config.php need to replace them with methods of class Magento\MagentoCloud\Filesystem\FileList.


### Fixed Issues (if relevant)

https://magento2.atlassian.net/browse/MAGECLOUD-1159

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
No

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
