### PR TITLE
MAGECLOUD-1246: Cover different RabbitMQ relationship names

### DIFF
--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Amqp.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Amqp.php
@@ -73,7 +73,7 @@ class Amqp implements ProcessInterface
             $config['queue']['amqp']['port'] = $amqpConfig['port'];
             $config['queue']['amqp']['user'] = $amqpConfig['username'];
             $config['queue']['amqp']['password'] = $amqpConfig['password'];
-            $config['queue']['amqp']['virtualhost'] = '/';
+            $config['queue']['amqp']['virtualhost'] = isset($amqpConfig['vhost']) ? $amqpConfig['vhost'] : '/';
             $config['queue']['amqp']['ssl'] = '';
         } else {
             $config = $this->removeAmqpConfig($config);

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Amqp.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Amqp.php
@@ -34,6 +34,13 @@ class Amqp implements ProcessInterface
     private $configReader;
 
     /**
+     * Possible names for amqp relationship
+     *
+     * @var array
+     */
+    private $possibleRelationshipNames = ['rabbitmq', 'mq', 'amqp'];
+
+    /**
      * @param Environment $environment
      * @param ConfigReader $configReader
      * @param ConfigWriter $configWriter
@@ -56,7 +63,7 @@ class Amqp implements ProcessInterface
      */
     public function execute()
     {
-        $mqConfig = $this->environment->getRelationship('mq');
+        $mqConfig = $this->getAmqpConfig();
         $config = $this->configReader->read();
 
         if (count($mqConfig)) {
@@ -94,5 +101,23 @@ class Amqp implements ProcessInterface
         }
 
         return $config;
+    }
+
+    /**
+     * Finds if configuration exists for one of possible amqp relationship names and return first match,
+     * amqp relationship can have different name on different environment.
+     *
+     * @return array
+     */
+    private function getAmqpConfig(): array
+    {
+        foreach ($this->possibleRelationshipNames as $relationshipName) {
+            $mqConfig = $this->environment->getRelationship($relationshipName);
+            if (!empty($mqConfig)) {
+                return $mqConfig;
+            }
+        }
+
+        return [];
     }
 }

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/AmqpTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/AmqpTest.php
@@ -88,28 +88,8 @@ class AmqpTest extends TestCase
      * @return void
      * @dataProvider executeAddUpdateDataProvider
      */
-    public function testExecuteAddUpdate(array $config)
+    public function testExecuteAddUpdate(array $config, array $amqpConfig, array $resultConfig)
     {
-        $amqpConfig = [[
-            'host' => 'localhost',
-            'port' => '777',
-            'username' => 'login',
-            'password' => 'pswd'
-        ]];
-        $resultConfig = [
-            'some config',
-            'queue' => [
-                'amqp' => [
-                    'host' => 'localhost',
-                    'port' => '777',
-                    'user' => 'login',
-                    'password' => 'pswd',
-                    'virtualhost' => '/',
-                    'ssl' => '',
-                ]
-            ],
-        ];
-
         $this->environmentMock->expects($this->exactly(2))
             ->method('getRelationship')
             ->withConsecutive(
@@ -139,20 +119,86 @@ class AmqpTest extends TestCase
     public function executeAddUpdateDataProvider(): array
     {
         return [
-            [['some config']],
-            [[
-                'some config',
-                'queue' => [
-                    'amqp' => [
-                        'host' => 'some-host',
-                        'port' => '888',
-                        'user' => 'mylogin',
-                        'password' => 'mysqwwd',
-                        'virtualhost' => 'virtualhost',
-                        'ssl' => '1',
-                    ]
+            [
+                ['some config'],
+                [[
+                    'host' => 'localhost',
+                    'port' => '777',
+                    'username' => 'login',
+                    'password' => 'pswd',
+                    'vhost' => 'virtualhost'
+                ]],
+                [
+                    'some config',
+                    'queue' => [
+                        'amqp' => [
+                            'host' => 'localhost',
+                            'port' => '777',
+                            'user' => 'login',
+                            'password' => 'pswd',
+                            'virtualhost' => 'virtualhost',
+                            'ssl' => '',
+                        ]
+                    ],
+                ]
+            ],
+            [
+                ['some config'],
+                [[
+                    'host' => 'localhost',
+                    'port' => '777',
+                    'username' => 'login',
+                    'password' => 'pswd',
+                ]],
+                [
+                    'some config',
+                    'queue' => [
+                        'amqp' => [
+                            'host' => 'localhost',
+                            'port' => '777',
+                            'user' => 'login',
+                            'password' => 'pswd',
+                            'virtualhost' => '/',
+                            'ssl' => '',
+                        ]
+                    ],
+                ]
+            ],
+            [
+                [
+                    'some config',
+                    'queue' => [
+                        'amqp' => [
+                            'host' => 'some-host',
+                            'port' => '888',
+                            'user' => 'mylogin',
+                            'password' => 'mysqwwd',
+                            'virtualhost' => 'virtualhost',
+                            'ssl' => '1',
+                        ]
+                    ],
                 ],
-            ]]
+                [[
+                    'host' => 'localhost',
+                    'port' => '777',
+                    'username' => 'login',
+                    'password' => 'pswd',
+                    'vhost' => 'virtualhost'
+                ]],
+                [
+                    'some config',
+                    'queue' => [
+                        'amqp' => [
+                            'host' => 'localhost',
+                            'port' => '777',
+                            'user' => 'login',
+                            'password' => 'pswd',
+                            'virtualhost' => 'virtualhost',
+                            'ssl' => '',
+                        ]
+                    ],
+                ]
+            ]
         ];
     }
 

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/AmqpTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/AmqpTest.php
@@ -67,9 +67,9 @@ class AmqpTest extends TestCase
     public function testExecuteWithoutAmqp()
     {
         $config = ['some config'];
-        $this->environmentMock->expects($this->once())
+        $this->environmentMock->expects($this->any())
             ->method('getRelationship')
-            ->with('mq')
+            ->with($this->anything())
             ->willReturn([]);
         $this->configReaderMock->expects($this->once())
             ->method('read')
@@ -110,10 +110,16 @@ class AmqpTest extends TestCase
             ],
         ];
 
-        $this->environmentMock->expects($this->once())
+        $this->environmentMock->expects($this->exactly(2))
             ->method('getRelationship')
-            ->with('mq')
-            ->willReturn($amqpConfig);
+            ->withConsecutive(
+                ['rabbitmq'],
+                ['mq']
+            )
+            ->willReturnOnConsecutiveCalls(
+                [],
+                $amqpConfig
+            );
         $this->configReaderMock->expects($this->once())
             ->method('read')
             ->willReturn($config);
@@ -158,9 +164,9 @@ class AmqpTest extends TestCase
      */
     public function testExecuteRemoveAmqp(array $config, array $expectedConfig)
     {
-        $this->environmentMock->expects($this->once())
+        $this->environmentMock->expects($this->any())
             ->method('getRelationship')
-            ->with('mq')
+            ->with($this->anything())
             ->willReturn([]);
         $this->configReaderMock->expects($this->once())
             ->method('read')


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
We need to change mq to some RegEx covering mq / rabbitmq / amqp

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1246

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
https://jira.corp.magento.com/browse/MAGETWO-71187

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
