### PR TITLE
MAGECLOUD-1266: Remove composer cache from Docker volumes

### DIFF
--- a/tests/integration-docker/docker-compose.yml
+++ b/tests/integration-docker/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     build: ./7.0-cli
     links:
       - db
-    volumes:
-      - ~/.composer/cache:/root/.composer/cache
     volumes_from:
       - appdata
     env_file:


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-1266
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

Fixes issue with shared composer cache on Travis

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
1. Red Docker-integration build

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
