### PR TITLE
MAGECLOUD-1311 Add "disable_locking" parameter

### DIFF
--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -32,6 +32,7 @@ class Environment
     const DEFAULT_ADMIN_FIRSTNAME = 'Admin';
     const DEFAULT_ADMIN_LASTNAME = 'Username';
 
+    const VAR_REDIS_SESSION_DISABLE_LOCKING = 'REDIS_SESSION_DISABLE_LOCKING';
     /**
      * Let's keep variable names same for both phases.
      */

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
@@ -84,7 +84,7 @@ class Redis implements ProcessInterface
                 'host' => $redisConfig[0]['host'],
                 'port' => $redisConfig[0]['port'],
                 'database' => 0,
-                'disable_locking' => intval($this->isLockingDisabled())
+                'disable_locking' => (int)$this->isLockingDisabled()
             ];
             $config['session'] = [
                 'save' => 'redis',
@@ -130,8 +130,8 @@ class Redis implements ProcessInterface
 
     /**
      * Checks if disable_locking options is enabled.
-     * By default this method returns true and disable_locking options will be set to = 1.
-     * For turning of this option should be added environment variable 'REDIS_SESSION_DISABLE_LOCKING' = 'disabled'
+     * By default this method returns true and disable_locking options will be set to 1.
+     * For turning this option off environment variable 'REDIS_SESSION_DISABLE_LOCKING' should have value 'disabled'.
      *
      * @return bool
      */

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
@@ -86,6 +86,7 @@ class Redis implements ProcessInterface
                     'host' => $redisConfig[0]['host'],
                     'port' => $redisConfig[0]['port'],
                     'database' => 0,
+                    'disable_locking' => intval($this->isLockingDisabled())
                 ],
             ];
         } else {
@@ -121,5 +122,19 @@ class Redis implements ProcessInterface
         }
 
         return $config;
+    }
+
+    /**
+     * Checks if disable_locking options is enabled.
+     * By default this method returns true and disable_locking options will be set to = 1.
+     * For turning of this option should be added environment variable 'REDIS_SESSION_DISABLE_LOCKING' = 'disabled'
+     *
+     * @return bool
+     */
+    private function isLockingDisabled(): bool
+    {
+        $envValue = $this->environment->getVariable(Environment::VAR_REDIS_SESSION_DISABLE_LOCKING);
+
+        return $envValue !== Environment::VAL_DISABLED;
     }
 }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
@@ -80,14 +80,18 @@ class Redis implements ProcessInterface
                 ? $cacheConfig
                 : array_replace_recursive($config['cache'], $cacheConfig);
 
+            $redisSessionConfig = [
+                'host' => $redisConfig[0]['host'],
+                'port' => $redisConfig[0]['port'],
+                'database' => 0,
+                'disable_locking' => intval($this->isLockingDisabled())
+            ];
             $config['session'] = [
                 'save' => 'redis',
-                'redis' => [
-                    'host' => $redisConfig[0]['host'],
-                    'port' => $redisConfig[0]['port'],
-                    'database' => 0,
-                    'disable_locking' => intval($this->isLockingDisabled())
-                ],
+                'redis' => array_replace_recursive(
+                    $config['session']['redis'] ?? [],
+                    $redisSessionConfig
+                )
             ];
         } else {
             $config = $this->removeRedisConfiguration($config);

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/RedisTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/RedisTest.php
@@ -209,4 +209,83 @@ class RedisTest extends TestCase
 
         $this->process->execute();
     }
+
+
+    public function testExecuteWithDifferentRedisOptions()
+    {
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Updating env.php Redis cache configuration.');
+        $this->environmentMock->expects($this->any())
+            ->method('getRelationships')
+            ->willReturn([
+                'redis' => [
+                    0 => [
+                        'host' => '127.0.0.1',
+                        'port' => '6379'
+                    ]
+                ],
+            ]);
+        $this->environmentMock->expects($this->any())
+            ->method('getAdminUrl')
+            ->willReturn('admin');
+        $this->environmentMock->expects($this->once())
+            ->method('getVariable')
+            ->with(Environment::VAR_REDIS_SESSION_DISABLE_LOCKING)
+            ->willReturn('');
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn([
+                'session' => [
+                    'redis' => [
+                        'max_concurrency' => 10,
+                        'bot_first_lifetime' => 100,
+                        'bot_lifetime' => 10000,
+                        'min_lifetime' => 100,
+                        'max_lifetime' => 10000
+                    ]
+                ]
+            ]);
+
+        $this->configWriterMock->expects($this->once())
+            ->method('write')
+            ->with([
+                'cache' => [
+                    'frontend' => [
+                        'default' => [
+                            'backend' => 'Cm_Cache_Backend_Redis',
+                            'backend_options' => [
+                                'server' => '127.0.0.1',
+                                'port' => '6379',
+                                'database' => 1,
+                            ],
+                        ],
+                        'page_cache' => [
+                            'backend' => 'Cm_Cache_Backend_Redis',
+                            'backend_options' => [
+                                'server' => '127.0.0.1',
+                                'port' => '6379',
+                                'database' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+                'session' => [
+                    'save' => 'redis',
+                    'redis' => [
+                        'host' => '127.0.0.1',
+                        'port' => '6379',
+                        'database' => 0,
+                        'disable_locking' => 1,
+                        'max_concurrency' => 10,
+                        'bot_first_lifetime' => 100,
+                        'bot_lifetime' => 10000,
+                        'min_lifetime' => 100,
+                        'max_lifetime' => 10000
+                    ],
+                ],
+            ]);
+
+        $this->process->execute();
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Added `disable_locking` paramater to redis session configuration.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1311

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
https://jira.corp.magento.com/browse/MAGETWO-84292
https://jira.corp.magento.com/browse/MAGETWO-84294

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
