### PR TITLE
MAGECLOUD-1322: ECE-Tools does not provide definition for BP

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -20,8 +20,10 @@ if (!file_exists($magentoRoot . '/app/etc/NonComposerComponentRegistration.php')
     );
 }
 
-foreach ([__DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php'] as $file) {
+foreach ([__DIR__ . '/../../../app/autoload.php', __DIR__ . '/vendor/autoload.php'] as $file) {
     if (file_exists($file)) {
         return require $file;
     }
 }
+
+throw new \RuntimeException('Required file \'autoload.php\' was not found.');


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Fixes issue when `BP` constant was not defined by Magento

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
1. https://magento2.atlassian.net/browse/MAGECLOUD-1322

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. https://jira.corp.magento.com/browse/MAGETWO-84362

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
