### PR TITLE
MAGECLOUD-1327: Move cache clean operation in deploy phase to the ver…

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -19,6 +19,7 @@ use Magento\MagentoCloud\Process\Deploy as DeployProcess;
 use Magento\MagentoCloud\Process\ConfigDump as ConfigDumpProcess;
 use Magento\MagentoCloud\Process\PostDeploy as PostDeployProcess;
 use Psr\Container\ContainerInterface;
+use Magento\MagentoCloud\Process as Process;
 
 /**
  * @inheritdoc
@@ -142,6 +143,7 @@ class Container implements ContainerInterface
                         $this->container->make(DeployProcess\DeployStaticContent::class),
                         $this->container->make(DeployProcess\CompressStaticContent::class),
                         $this->container->make(DeployProcess\DisableGoogleAnalytics::class),
+                        $this->container->make(Process\CleanCache::class),
                     ],
                 ]);
             });
@@ -166,7 +168,6 @@ class Container implements ContainerInterface
                         $this->container->make(DeployProcess\InstallUpdate\Update\SetAdminUrl::class),
                         $this->container->make(DeployProcess\InstallUpdate\Update\Setup::class),
                         $this->container->make(DeployProcess\InstallUpdate\Update\AdminCredentials::class),
-                        $this->container->make(DeployProcess\InstallUpdate\Update\ClearCache::class),
                     ],
                 ]);
             });

--- a/src/Process/CleanCache.php
+++ b/src/Process/CleanCache.php
@@ -3,20 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\Update;
+namespace Magento\MagentoCloud\Process;
 
 use Magento\MagentoCloud\Config\Environment;
-use Magento\MagentoCloud\Process\ProcessInterface;
 use Magento\MagentoCloud\Shell\ShellInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * Class ClearCache.
+ * Class CleanCache.
  *
  * @deprecated This functionality will be moved to post-deploy hook.
  * @see \Magento\MagentoCloud\Process\PostDeploy\CleanCache
  */
-class ClearCache implements ProcessInterface
+class CleanCache implements ProcessInterface
 {
     /**
      * @var LoggerInterface

--- a/src/Test/Unit/Process/CleanCacheTest.php
+++ b/src/Test/Unit/Process/CleanCacheTest.php
@@ -6,13 +6,13 @@
 namespace Magento\MagentoCloud\Test\Unit\Process\Deploy\InstallUpdate\Update;
 
 use Magento\MagentoCloud\Config\Environment;
-use Magento\MagentoCloud\Process\Deploy\InstallUpdate\Update\ClearCache;
+use Magento\MagentoCloud\Process\CleanCache;
 use Magento\MagentoCloud\Shell\ShellInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
 use Psr\Log\LoggerInterface;
 
-class ClearCacheTest extends TestCase
+class CleanCacheTest extends TestCase
 {
     /**
      * @var Environment|Mock
@@ -30,7 +30,7 @@ class ClearCacheTest extends TestCase
     private $shellMock;
 
     /**
-     * @var ClearCache
+     * @var CleanCache
      */
     private $process;
 
@@ -40,7 +40,7 @@ class ClearCacheTest extends TestCase
         $this->shellMock = $this->getMockForAbstractClass(ShellInterface::class);
         $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
 
-        $this->process = new ClearCache(
+        $this->process = new CleanCache(
             $this->loggerMock,
             $this->environmentMock,
             $this->shellMock


### PR DESCRIPTION
Moves the cache clear process to the end of the deploy process
### Description
[MAGECLOUD-1327: Move cache clean operation in deploy phase to the very end](https://magento2.atlassian.net/browse/MAGECLOUD-1327)
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
