### PR TITLE
MAGECLOUD-1332: Add ability to configure cron_consumers_runner via an environment variable

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -11,6 +11,10 @@ define('ECE_BP', __DIR__);
  */
 $magentoRoot = __DIR__ . '/../../../';
 
+if (!defined('BP')) {
+    define('BP', realpath($magentoRoot));
+}
+
 if (!file_exists($magentoRoot . '/app/etc/NonComposerComponentRegistration.php') &&
     file_exists($magentoRoot . '/init/app/etc/NonComposerComponentRegistration.php')
 ) {
@@ -20,7 +24,7 @@ if (!file_exists($magentoRoot . '/app/etc/NonComposerComponentRegistration.php')
     );
 }
 
-foreach ([__DIR__ . '/../../../app/autoload.php', __DIR__ . '/vendor/autoload.php'] as $file) {
+foreach ([__DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php'] as $file) {
     if (file_exists($file)) {
         return require $file;
     }

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -175,6 +175,7 @@ class Container implements ContainerInterface
             ->give(function () {
                 return $this->container->makeWith(ProcessComposite::class, [
                     'processes' => [
+                        $this->container->make(DeployProcess\InstallUpdate\ConfigUpdate\CronConsumersRunner::class),
                         $this->container->make(DeployProcess\InstallUpdate\ConfigUpdate\DbConnection::class),
                         $this->container->make(DeployProcess\InstallUpdate\ConfigUpdate\Amqp::class),
                         $this->container->make(DeployProcess\InstallUpdate\ConfigUpdate\Redis::class),

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -386,6 +386,20 @@ class Environment
     }
 
     /**
+     * @return array
+     */
+    public function getCronConsumersRunner(): array
+    {
+        $config = $this->getVariable('CRON_CONSUMERS_RUNNER', []);
+
+        if (!is_array($config)) {
+            $config = json_decode($config, true);
+        }
+
+        return $config;
+    }
+
+    /**
      * @return bool
      */
     public function isUpdateUrlsEnabled(): bool

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunner.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunner.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate;
+
+use Psr\Log\LoggerInterface;
+use Magento\MagentoCloud\Process\ProcessInterface;
+use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
+use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
+use Illuminate\Config\Repository;
+
+/**
+ * @inheritdoc
+ */
+class CronConsumersRunner implements ProcessInterface
+{
+    /**
+     * @var Environment
+     */
+    private $environment;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var ConfigReader
+     */
+    private $configReader;
+
+    /**
+     * @var ConfigWriter
+     */
+    private $configWriter;
+
+    /**
+     * @param Environment $environment
+     * @param ConfigReader $configReader
+     * @param ConfigWriter $configWriter
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        Environment $environment,
+        ConfigReader $configReader,
+        ConfigWriter $configWriter,
+        LoggerInterface $logger
+    ) {
+        $this->environment = $environment;
+        $this->configReader = $configReader;
+        $this->configWriter = $configWriter;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        $this->logger->info('Updating env.php cron consumers runner configuration.');
+        $config = $this->configReader->read();
+        $cronConsumersRunnerConfig = new Repository($this->environment->getCronConsumersRunner());
+
+        $config['cron_consumers_runner'] = [
+            'cron_run' => $cronConsumersRunnerConfig->get('cron_run') === 'true',
+            'max_messages' => $cronConsumersRunnerConfig->get('max_messages', 10000),
+            'consumers' => $cronConsumersRunnerConfig->get('consumers', []),
+        ];
+
+        $this->configWriter->write($config);
+    }
+}

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunner.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunner.php
@@ -38,6 +38,11 @@ class CronConsumersRunner implements ProcessInterface
     private $configWriter;
 
     /**
+     * Max messages that will be processed by each consumer
+     */
+    const DEFAULT_MAX_MESSAGES = 10000;
+
+    /**
      * @param Environment $environment
      * @param ConfigReader $configReader
      * @param ConfigWriter $configWriter
@@ -66,7 +71,7 @@ class CronConsumersRunner implements ProcessInterface
 
         $config['cron_consumers_runner'] = [
             'cron_run' => $cronConsumersRunnerConfig->get('cron_run') === 'true',
-            'max_messages' => $cronConsumersRunnerConfig->get('max_messages', 10000),
+            'max_messages' => $cronConsumersRunnerConfig->get('max_messages', static::DEFAULT_MAX_MESSAGES),
             'consumers' => $cronConsumersRunnerConfig->get('consumers', []),
         ];
 

--- a/src/Test/Integration/AcceptanceTest.php
+++ b/src/Test/Integration/AcceptanceTest.php
@@ -8,6 +8,7 @@ namespace Magento\MagentoCloud\Test\Integration;
 use Magento\MagentoCloud\Command\Build;
 use Magento\MagentoCloud\Command\Deploy;
 use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -47,9 +48,10 @@ class AcceptanceTest extends TestCase
 
     /**
      * @param array $environment
+     * @param array $expectedConsumersRunnerConfig
      * @dataProvider defaultDataProvider
      */
-    public function testDefault(array $environment)
+    public function testDefault(array $environment, array $expectedConsumersRunnerConfig)
     {
         $application = $this->bootstrap->createApplication($environment);
 
@@ -67,6 +69,12 @@ class AcceptanceTest extends TestCase
 
         $this->assertSame(0, $commandTester->getStatusCode());
         $this->assertContentPresence($environment);
+
+        /** @var ConfigReader $configReader */
+        $configReader = $application->getContainer()->get(ConfigReader::class);
+        $config = $configReader->read();
+
+        $this->assertArraySubset($expectedConsumersRunnerConfig, $config);
     }
 
     /**
@@ -81,6 +89,47 @@ class AcceptanceTest extends TestCase
                         'ADMIN_EMAIL' => 'admin@example.com',
                     ],
                 ],
+                'expectedConsumersRunnerConfig' => [
+                    'cron_consumers_runner' => [
+                        'cron_run' => false,
+                        'max_messages' => 10000,
+                        'consumers' => [],
+                    ]
+                ]
+            ],
+            'test cron_consumers_runner with array' => [
+                'environment' => [
+                    'variables' => [
+                        'ADMIN_EMAIL' => 'admin@example.com',
+                        'CRON_CONSUMERS_RUNNER' => [
+                            'cron_run' => "true",
+                            'max_messages' => 5000,
+                            'consumers' => ['test'],
+                        ]
+                    ],
+                ],
+                'expectedConsumersRunnerConfig' => [
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 5000,
+                        'consumers' => ['test'],
+                    ]
+                ]
+            ],
+            'test cron_consumers_runner with string' => [
+                'environment' => [
+                    'variables' => [
+                        'ADMIN_EMAIL' => 'admin@example.com',
+                        'CRON_CONSUMERS_RUNNER' => '{"cron_run":"true", "max_messages":100, "consumers":["test2"]}',
+                    ],
+                ],
+                'expectedConsumersRunnerConfig' => [
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 100,
+                        'consumers' => ['test2'],
+                    ]
+                ]
             ],
             'disabled static content symlinks 3 jobs' => [
                 'environment' => [

--- a/src/Test/Integration/AcceptanceTest.php
+++ b/src/Test/Integration/AcceptanceTest.php
@@ -139,6 +139,13 @@ class AcceptanceTest extends TestCase
                         'STATIC_CONTENT_THREADS' => 3,
                     ],
                 ],
+                'expectedConsumersRunnerConfig' => [
+                    'cron_consumers_runner' => [
+                        'cron_run' => false,
+                        'max_messages' => 10000,
+                        'consumers' => [],
+                    ]
+                ],
             ],
         ];
     }

--- a/src/Test/Unit/Config/EnvironmentTest.php
+++ b/src/Test/Unit/Config/EnvironmentTest.php
@@ -297,4 +297,49 @@ class EnvironmentTest extends TestCase
             $this->environment->getDefaultCurrency()
         );
     }
+
+    /**
+     * @param array $variables
+     * @param array $expectedResult
+     * @dataProvider getCronConsumersRunnerDataProvider
+     */
+    public function testGetCronConsumersRunner(array $variables, array $expectedResult)
+    {
+        $this->setVariables($variables);
+        $this->assertEquals($expectedResult, $this->environment->getCronConsumersRunner());
+    }
+
+    /**
+     * @return array
+     */
+    public function getCronConsumersRunnerDataProvider(): array
+    {
+        return [
+            ['variables' => [], 'expectedResult' => []],
+            [
+                'variables' => [
+                    'CRON_CONSUMERS_RUNNER' => [
+                        'cron_run' => 'false',
+                        'max_messages' => '100',
+                        'consumers' => ['test'],
+                    ],
+                ],
+                'expectedResult' => [
+                    'cron_run' => 'false',
+                    'max_messages' => '100',
+                    'consumers' => ['test'],
+                ]
+            ],
+            [
+                'variables' => [
+                    'CRON_CONSUMERS_RUNNER' => '{"cron_run":"false", "max_messages":"100", "consumers":["test"]}',
+                ],
+                'expectedResult' => [
+                    'cron_run' => 'false',
+                    'max_messages' => '100',
+                    'consumers' => ['test'],
+                ]
+            ]
+        ];
+    }
 }

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunnerTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunnerTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Process\Deploy\InstallUpdate\ConfigUpdate;
+
+use Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate\CronConsumersRunner;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
+use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+class CronConsumersRunnerTest extends TestCase
+{
+    /**
+     * @var Environment|Mock
+     */
+    private $environmentMock;
+
+    /**
+     * @var LoggerInterface|Mock
+     */
+    private $loggerMock;
+
+    /**
+     * @var ConfigReader|Mock
+     */
+    private $configReaderMock;
+
+    /**
+     * @var ConfigWriter|Mock
+     */
+    private $configWriterMock;
+
+    /**
+     * @var CronConsumersRunner
+     */
+    private $cronConsumersRunner;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->environmentMock = $this->createMock(Environment::class);
+        $this->configReaderMock = $this->createMock(ConfigReader::class);
+        $this->configWriterMock = $this->createMock(ConfigWriter::class);
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->cronConsumersRunner = new CronConsumersRunner(
+            $this->environmentMock,
+            $this->configReaderMock,
+            $this->configWriterMock,
+            $this->loggerMock
+        );
+    }
+
+    /**
+     * @param array $config
+     * @param array $configFromVariable
+     * @param array $expectedResult
+     * @dataProvider executeDataProvider
+     */
+    public function testExecute(array $config, array $configFromVariable, array $expectedResult)
+    {
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Updating env.php cron consumers runner configuration.');
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn($config);
+        $this->environmentMock->expects($this->once())
+            ->method('getCronConsumersRunner')
+            ->willReturn($configFromVariable);
+        $this->configWriterMock->expects($this->once())
+            ->method('write')
+            ->with($expectedResult);
+
+        $this->cronConsumersRunner->execute();
+    }
+
+    /**
+     * @return array
+     */
+    public function executeDataProvider(): array
+    {
+        return [
+            [
+                'config' => [],
+                'configFromVariable' => [],
+                'expectedResult' => [
+                    'cron_consumers_runner' => [
+                        'cron_run' => false,
+                        'max_messages' => 10000,
+                        'consumers' => [],
+                    ],
+                ],
+            ],
+            [
+                'config' => [
+                    'someConfig' => 'someValue',
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 6000,
+                        'consumers' => ['test'],
+                    ],
+                ],
+                'configFromVariable' => [],
+                'expectedResult' => [
+                    'someConfig' => 'someValue',
+                    'cron_consumers_runner' => [
+                        'cron_run' => false,
+                        'max_messages' => 10000,
+                        'consumers' => [],
+                    ],
+                ],
+            ],
+            [
+                'config' => [
+                    'someConfig' => 'someValue',
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 6000,
+                        'consumers' => ['test'],
+                    ],
+                ],
+                'configFromVariable' => ['cron_run' => 'false'],
+                'expectedResult' => [
+                    'someConfig' => 'someValue',
+                    'cron_consumers_runner' => [
+                        'cron_run' => false,
+                        'max_messages' => 10000,
+                        'consumers' => [],
+                    ],
+                ],
+            ],
+            [
+                'config' => [
+                    'someConfig' => 'someValue',
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 6000,
+                        'consumers' => ['test'],
+                    ],
+                ],
+                'configFromVariable' => ['cron_run' => 'true'],
+                'expectedResult' => [
+                    'someConfig' => 'someValue',
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 10000,
+                        'consumers' => [],
+                    ],
+                ],
+            ],
+            [
+                'config' => [
+                    'someConfig' => 'someValue',
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 6000,
+                        'consumers' => ['test'],
+                    ],
+                ],
+                'configFromVariable' => [
+                    'cron_run' => 'true',
+                    'max_messages' => 200,
+                    'consumers' => ['test2', 'test3']
+                ],
+                'expectedResult' => [
+                    'someConfig' => 'someValue',
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 200,
+                        'consumers' => ['test2', 'test3'],
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### Description
Magento allows to configure cron_consummers_runner via app/etc/env.php
We added opportunity to configure cron job cron_consummers_runner via an environment variable CRON_CONSUMERS_RUNNER.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1332

### Zephyr Tests
https://jira.corp.magento.com/browse/MAGETWO-84602

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
