### PR TITLE
MAGECLOUD-1343: Drop Stuck Crons During Deployment Process

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -96,6 +96,7 @@ class Container extends \Illuminate\Container\Container implements ContainerInte
                         $this->make(DeployProcess\InstallUpdate::class),
                         $this->make(DeployProcess\DeployStaticContent::class),
                         $this->make(DeployProcess\DisableGoogleAnalytics::class),
+                        $this->make(DeployProcess\UnlockCronJobs::class)
                     ],
                 ]);
             });

--- a/src/Process/Deploy/UnlockCronJobs.php
+++ b/src/Process/Deploy/UnlockCronJobs.php
@@ -59,7 +59,7 @@ class UnlockCronJobs implements ProcessInterface
         if ($updatedJobsCount) {
             $this->logger->info(
                 sprintf(
-                    '%d cron jobs were updated from status %s to status %s',
+                    '%d cron jobs were updated from status "%s" to status "%s"',
                     $updatedJobsCount,
                     self::STATUS_RUNNING,
                     self::STATUS_MISSED

--- a/src/Process/Deploy/UnlockCronJobs.php
+++ b/src/Process/Deploy/UnlockCronJobs.php
@@ -11,6 +11,10 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Updates running cron jobs.
+ *
+ * In magento version 2.2 was implemented locking functionality for cron jobs, new cron jobs can't be started
+ * if exist job in status 'running' with same 'job_code'.
+ * This process are used for unlocking cron jobs that stuck in 'running' status.
  */
 class UnlockCronJobs implements ProcessInterface
 {

--- a/src/Process/Deploy/UnlockCronJobs.php
+++ b/src/Process/Deploy/UnlockCronJobs.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Process\Deploy;
+
+use Magento\MagentoCloud\DB\ConnectionInterface;
+use Magento\MagentoCloud\Process\ProcessInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Updates running cron jobs.
+ */
+class UnlockCronJobs implements ProcessInterface
+{
+    const STATUS_RUNNING = 'running';
+
+    const STATUS_MISSED = 'missed';
+
+    /**
+     * @var ConnectionInterface
+     */
+    private $connection;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ConnectionInterface $connection
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ConnectionInterface $connection,
+        LoggerInterface $logger
+    ) {
+        $this->connection = $connection;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Updates running cron jobs to status 'missed'.
+     *
+     * {@inheritdoc}
+     */
+    public function execute()
+    {
+        $updateCronStatusQuery = 'UPDATE cron_schedule SET status = :to_status WHERE status = :from_status';
+
+        $updatedJobsCount = $this->connection->affectingQuery(
+            $updateCronStatusQuery,
+            [
+                ':to_status' => self::STATUS_MISSED,
+                ':from_status' => self::STATUS_RUNNING
+            ]
+        );
+
+        if ($updatedJobsCount) {
+            $this->logger->info(
+                sprintf(
+                    '%d cron jobs was updated from status %s to status %s',
+                    $updatedJobsCount,
+                    self::STATUS_RUNNING,
+                    self::STATUS_MISSED
+                )
+            );
+        }
+    }
+}

--- a/src/Process/Deploy/UnlockCronJobs.php
+++ b/src/Process/Deploy/UnlockCronJobs.php
@@ -15,7 +15,6 @@ use Psr\Log\LoggerInterface;
 class UnlockCronJobs implements ProcessInterface
 {
     const STATUS_RUNNING = 'running';
-
     const STATUS_MISSED = 'missed';
 
     /**
@@ -47,7 +46,7 @@ class UnlockCronJobs implements ProcessInterface
      */
     public function execute()
     {
-        $updateCronStatusQuery = 'UPDATE cron_schedule SET status = :to_status WHERE status = :from_status';
+        $updateCronStatusQuery = 'UPDATE `cron_schedule` SET `status` = :to_status WHERE `status` = :from_status';
 
         $updatedJobsCount = $this->connection->affectingQuery(
             $updateCronStatusQuery,
@@ -60,7 +59,7 @@ class UnlockCronJobs implements ProcessInterface
         if ($updatedJobsCount) {
             $this->logger->info(
                 sprintf(
-                    '%d cron jobs was updated from status %s to status %s',
+                    '%d cron jobs were updated from status %s to status %s',
                     $updatedJobsCount,
                     self::STATUS_RUNNING,
                     self::STATUS_MISSED

--- a/src/Test/Unit/Process/Deploy/UnlockCronJobsTest.php
+++ b/src/Test/Unit/Process/Deploy/UnlockCronJobsTest.php
@@ -44,7 +44,7 @@ class UnlockCronJobsTest extends TestCase
         $this->updateCronJobs(5);
         $this->loggerMock->expects($this->once())
             ->method('info')
-            ->with('5 cron jobs was updated from status running to status missed');
+            ->with('5 cron jobs were updated from status "running" to status "missed"');
 
         $this->process->execute();
     }

--- a/src/Test/Unit/Process/Deploy/UnlockCronJobsTest.php
+++ b/src/Test/Unit/Process/Deploy/UnlockCronJobsTest.php
@@ -66,7 +66,7 @@ class UnlockCronJobsTest extends TestCase
         $this->connectionMock->expects($this->once())
             ->method('affectingQuery')
             ->with(
-                'UPDATE cron_schedule SET status = :to_status WHERE status = :from_status',
+                'UPDATE `cron_schedule` SET `status` = :to_status WHERE `status` = :from_status',
                 [
                     ':to_status' => UnlockCronJobs::STATUS_MISSED,
                     ':from_status' => UnlockCronJobs::STATUS_RUNNING

--- a/src/Test/Unit/Process/Deploy/UnlockCronJobsTest.php
+++ b/src/Test/Unit/Process/Deploy/UnlockCronJobsTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Process\Deploy;
+
+use Magento\MagentoCloud\Process\Deploy\UnlockCronJobs;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+use Psr\Log\LoggerInterface;
+use Magento\MagentoCloud\DB\ConnectionInterface;
+
+class UnlockCronJobsTest extends TestCase
+{
+    /**
+     * @var LoggerInterface|Mock
+     */
+    private $loggerMock;
+
+    /**
+     * @var ConnectionInterface|Mock
+     */
+    private $connectionMock;
+
+    /**
+     * @var UnlockCronJobs
+     */
+    private $process;
+
+    protected function setUp()
+    {
+        $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
+        $this->connectionMock = $this->getMockForAbstractClass(ConnectionInterface::class);
+
+        $this->process = new UnlockCronJobs(
+            $this->connectionMock,
+            $this->loggerMock
+        );
+    }
+
+    public function testExecute()
+    {
+        $this->updateCronJobs(5);
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('5 cron jobs was updated from status running to status missed');
+
+        $this->process->execute();
+    }
+
+    public function testExecuteNoJobsUpdated()
+    {
+        $this->updateCronJobs(0);
+        $this->loggerMock->expects($this->never())
+            ->method('info');
+
+        $this->process->execute();
+    }
+
+    /**
+     * @param int $updatedRowsCount
+     */
+    private function updateCronJobs(int $updatedRowsCount)
+    {
+        $this->connectionMock->expects($this->once())
+            ->method('affectingQuery')
+            ->with(
+                'UPDATE cron_schedule SET status = :to_status WHERE status = :from_status',
+                [
+                    ':to_status' => UnlockCronJobs::STATUS_MISSED,
+                    ':from_status' => UnlockCronJobs::STATUS_RUNNING
+                ]
+            )
+            ->willReturn($updatedRowsCount);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
crons are stuck in "Running" state. Other crons of the same type cannot be launched

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1343

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. Install magento
2. Set status Running for several cron jobs
3. Perform redeploy

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] Pull request was approved by architect
 - [x] Pull request was approved by QA member
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
