### PR TITLE
MAGECLOUD-1349: Add possibility to disable static content compression

### DIFF
--- a/src/Config/Build.php
+++ b/src/Config/Build.php
@@ -17,6 +17,7 @@ class Build
     const OPT_SKIP_SCD = 'skip_scd';
     const OPT_SCD_STRATEGY = 'SCD_STRATEGY';
     const OPT_VERBOSE_COMMANDS = 'VERBOSE_COMMANDS';
+    const OPT_SCD_COMPRESSION_LEVEL = 'SCD_COMPRESSION_LEVEL';
 
     /**
      * @var ReaderInterface

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -32,11 +32,12 @@ class Environment
     const DEFAULT_ADMIN_FIRSTNAME = 'Admin';
     const DEFAULT_ADMIN_LASTNAME = 'Username';
 
-    const VAR_REDIS_SESSION_DISABLE_LOCKING = 'REDIS_SESSION_DISABLE_LOCKING';
     /**
-     * Let's keep variable names same for both phases.
+     * Variables.
      */
+    const VAR_REDIS_SESSION_DISABLE_LOCKING = 'REDIS_SESSION_DISABLE_LOCKING';
     const VAR_SCD_STRATEGY = Build::OPT_SCD_STRATEGY;
+    const VAR_SCD_COMPRESSION_LEVEL = Build::OPT_SCD_COMPRESSION_LEVEL;
 
     /**
      * @var LoggerInterface

--- a/src/Filesystem/FileList.php
+++ b/src/Filesystem/FileList.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\MagentoCloud\Filesystem;
 
+use Magento\MagentoCloud\Filesystem\Driver\File;
+
 /**
  * Resolver of file configurations.
  */
@@ -16,11 +18,18 @@ class FileList
     private $directoryList;
 
     /**
-     * @param DirectoryList $directoryList
+     * @var File
      */
-    public function __construct(DirectoryList $directoryList)
+    private $file;
+
+    /**
+     * @param DirectoryList $directoryList
+     * @param File $file
+     */
+    public function __construct(DirectoryList $directoryList, File $file)
     {
         $this->directoryList = $directoryList;
+        $this->file = $file;
     }
 
     /**
@@ -49,10 +58,20 @@ class FileList
 
     /**
      * @return string
+     * @throws FileSystemException
      */
     public function getComposer(): string
     {
-        return $this->directoryList->getMagentoRoot() . '/composer.json';
+        $magentoComposer = $this->directoryList->getMagentoRoot() . '/composer.json';
+
+        if ($this->file->isExists($magentoComposer)) {
+            return $magentoComposer;
+        }
+
+        /**
+         * Workaround for local development.
+         */
+        return $this->directoryList->getRoot() . '/composer.json';
     }
 
     /**

--- a/src/Process/Build/CompressStaticContent.php
+++ b/src/Process/Build/CompressStaticContent.php
@@ -74,7 +74,7 @@ class CompressStaticContent implements ProcessInterface
     {
         if ($this->environment->isStaticDeployInBuild()) {
             $this->staticContentCompressor->process(
-                static::COMPRESSION_LEVEL,
+                $this->buildConfig->get(BuildConfig::OPT_SCD_COMPRESSION_LEVEL, static::COMPRESSION_LEVEL),
                 $this->buildConfig->getVerbosityLevel()
             );
         } else {

--- a/src/Process/Deploy/CompressStaticContent.php
+++ b/src/Process/Deploy/CompressStaticContent.php
@@ -41,8 +41,8 @@ class CompressStaticContent implements ProcessInterface
     private $staticContentCompressor;
 
     /**
-     * @param LoggerInterface         $logger
-     * @param Environment             $environment
+     * @param LoggerInterface $logger
+     * @param Environment $environment
      * @param StaticContentCompressor $staticContentCompressor
      */
     public function __construct(
@@ -64,7 +64,10 @@ class CompressStaticContent implements ProcessInterface
     {
         if ($this->environment->isDeployStaticContent()) {
             $this->staticContentCompressor->process(
-                static::COMPRESSION_LEVEL,
+                $this->environment->getVariable(
+                    Environment::VAR_SCD_COMPRESSION_LEVEL,
+                    static::COMPRESSION_LEVEL
+                ),
                 $this->environment->getVerbosityLevel()
             );
         } else {

--- a/src/Test/Unit/Process/Build/CompressStaticContentTest.php
+++ b/src/Test/Unit/Process/Build/CompressStaticContentTest.php
@@ -73,6 +73,10 @@ class CompressStaticContentTest extends TestCase
      */
     public function testExecute()
     {
+        $this->buildConfigMock->expects($this->once())
+            ->method('get')
+            ->with(BuildConfig::OPT_SCD_COMPRESSION_LEVEL, CompressStaticContent::COMPRESSION_LEVEL)
+            ->willReturn(6);
         $this->environmentMock
             ->expects($this->once())
             ->method('isStaticDeployInBuild')
@@ -80,7 +84,7 @@ class CompressStaticContentTest extends TestCase
         $this->compressorMock
             ->expects($this->once())
             ->method('process')
-            ->with('6');
+            ->with(6);
 
         $this->process->execute();
     }

--- a/src/Test/Unit/Process/Deploy/CompressStaticContentTest.php
+++ b/src/Test/Unit/Process/Deploy/CompressStaticContentTest.php
@@ -63,6 +63,10 @@ class CompressStaticContentTest extends TestCase
      */
     public function testExecute()
     {
+        $this->environmentMock->expects($this->once())
+            ->method('getVariable')
+            ->with(Environment::VAR_SCD_COMPRESSION_LEVEL, CompressStaticContent::COMPRESSION_LEVEL)
+            ->willReturn(4);
         $this->environmentMock
             ->expects($this->once())
             ->method('isDeployStaticContent')
@@ -70,7 +74,7 @@ class CompressStaticContentTest extends TestCase
         $this->compressorMock
             ->expects($this->once())
             ->method('process')
-            ->with('4');
+            ->with(4);
 
         $this->process->execute();
     }

--- a/src/Test/Unit/Util/StaticContentCompressorTest.php
+++ b/src/Test/Unit/Util/StaticContentCompressorTest.php
@@ -65,7 +65,7 @@ class StaticContentCompressorTest extends TestCase
                         $this->stringContains('xargs'),
                         $this->stringContains($this->staticContentCompressor::TARGET_DIR),
                         $this->stringContains("-$i")
-                    )
+                    ),
                 ];
             }
 
@@ -80,5 +80,14 @@ class StaticContentCompressorTest extends TestCase
         for ($i = $minLevel; $i <= $maxLevel; $i++) {
             $this->staticContentCompressor->process($i);
         }
+    }
+
+    public function testCompressionDisabled()
+    {
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Static content compression was disabled.');
+
+        $this->staticContentCompressor->process(0);
     }
 }

--- a/src/Util/StaticContentCompressor.php
+++ b/src/Util/StaticContentCompressor.php
@@ -47,7 +47,7 @@ class StaticContentCompressor
 
     /**
      * @param LoggerInterface $logger
-     * @param ShellInterface  $shell
+     * @param ShellInterface $shell
      */
     public function __construct(
         LoggerInterface $logger,
@@ -61,11 +61,17 @@ class StaticContentCompressor
      * Compress select files in the static content directory.
      *
      * @param int $compressionLevel
-     *
-     * @return bool
+     * @param string $verbose
+     * @return void
      */
-    public function process(int $compressionLevel = self::DEFAULT_COMPRESSION_LEVEL, string $verbose = ''): bool
+    public function process(int $compressionLevel = self::DEFAULT_COMPRESSION_LEVEL, string $verbose = '')
     {
+        if ($compressionLevel === 0) {
+            $this->logger->info('Static content compression was disabled.');
+
+            return;
+        }
+
         $compressionCommand = $this->getCompressionCommand($compressionLevel);
 
         $startTime = microtime(true);
@@ -77,12 +83,10 @@ class StaticContentCompressor
             $this->logger->info(
                 "Static content compression took $duration seconds.",
                 [
-                    'commandRun' => $compressionCommand
+                    'commandRun' => $compressionCommand,
                 ]
             );
         }
-
-        return true;
     }
 
     /**
@@ -101,9 +105,7 @@ class StaticContentCompressor
     /**
      * Get the string containing the full shell command for compression.
      *
-     * @param int  $compressionLevel
-     * @param bool $verbose
-     *
+     * @param int $compressionLevel
      * @return string
      */
     private function getCompressionCommand(


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
https://magento2.atlassian.net/browse/MAGECLOUD-1349

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Adds possibility to disable static content depression via build or environment variable respectively.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
1. https://magento2.atlassian.net/browse/MAGECLOUD-1349

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. https://jira.corp.magento.com/browse/MAGETWO-82442
2. https://jira.corp.magento.com/browse/MAGETWO-82443

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
