### PR TITLE
MAGECLOUD-1253: [GitHub][PR] Provide the user a way to see the install progress #74

### DIFF
--- a/src/Filesystem/FileList.php
+++ b/src/Filesystem/FileList.php
@@ -78,4 +78,12 @@ class FileList
     {
         return $this->directoryList->getInit() . '/var/log/cloud.log';
     }
+
+    /**
+     * @return string
+     */
+    public function getInstallUpgradeLog(): string
+    {
+        return $this->directoryList->getLog() . '/installUpgrade.log';
+    }
 }

--- a/src/Filesystem/FileList.php
+++ b/src/Filesystem/FileList.php
@@ -84,6 +84,6 @@ class FileList
      */
     public function getInstallUpgradeLog(): string
     {
-        return $this->directoryList->getLog() . '/installUpgrade.log';
+        return $this->directoryList->getLog() . '/install_upgrade.log';
     }
 }

--- a/src/Process/Deploy/InstallUpdate/Install/Setup.php
+++ b/src/Process/Deploy/InstallUpdate/Install/Setup.php
@@ -10,6 +10,7 @@ use Magento\MagentoCloud\Process\ProcessInterface;
 use Magento\MagentoCloud\Shell\ShellInterface;
 use Magento\MagentoCloud\Util\UrlManager;
 use Magento\MagentoCloud\Util\PasswordGenerator;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Psr\Log\LoggerInterface;
 
 class Setup implements ProcessInterface
@@ -35,6 +36,11 @@ class Setup implements ProcessInterface
     private $shell;
 
     /**
+     * @var FileList
+     */
+    private $fileList;
+
+    /**
      * @var PasswordGenerator
      */
     private $passwordGenerator;
@@ -45,19 +51,22 @@ class Setup implements ProcessInterface
      * @param Environment $environment
      * @param ShellInterface $shell
      * @param PasswordGenerator $passwordGenerator
+     * @param FileList $fileList
      */
     public function __construct(
         LoggerInterface $logger,
         UrlManager $urlManager,
         Environment $environment,
         ShellInterface $shell,
-        PasswordGenerator $passwordGenerator
+        PasswordGenerator $passwordGenerator,
+        FileList $fileList
     ) {
         $this->logger = $logger;
         $this->urlManager = $urlManager;
         $this->environment = $environment;
         $this->shell = $shell;
         $this->passwordGenerator = $passwordGenerator;
+        $this->fileList = $fileList;
     }
 
     /**
@@ -101,6 +110,10 @@ class Setup implements ProcessInterface
 
         $command .= $this->environment->getVerbosityLevel();
 
-        $this->shell->execute(escapeshellcmd($command));
+        $this->shell->execute(sprintf(
+            '/bin/bash -c "set -o pipefail; %s | tee -a %s"',
+            escapeshellcmd($command),
+            $this->fileList->getInstallUpgradeLog()
+        ));
     }
 }

--- a/src/Test/Unit/Filesystem/FileListTest.php
+++ b/src/Test/Unit/Filesystem/FileListTest.php
@@ -82,6 +82,6 @@ class FileListTest extends TestCase
 
     public function testGetInstallUpgradeLog()
     {
-        $this->assertSame('magento_root/var/log/installUpgrade.log', $this->fileList->getInstallUpgradeLog());
+        $this->assertSame('magento_root/var/log/install_upgrade.log', $this->fileList->getInstallUpgradeLog());
     }
 }

--- a/src/Test/Unit/Filesystem/FileListTest.php
+++ b/src/Test/Unit/Filesystem/FileListTest.php
@@ -79,4 +79,9 @@ class FileListTest extends TestCase
     {
         $this->assertSame('magento_root/init/var/log/cloud.log', $this->fileList->getInitCloudLog());
     }
+
+    public function testGetInstallUpgradeLog()
+    {
+        $this->assertSame('magento_root/var/log/installUpgrade.log', $this->fileList->getInstallUpgradeLog());
+    }
 }

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Install/SetupTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Install/SetupTest.php
@@ -10,6 +10,7 @@ use Magento\MagentoCloud\Process\Deploy\InstallUpdate\Install\Setup;
 use Magento\MagentoCloud\Shell\ShellInterface;
 use Magento\MagentoCloud\Util\UrlManager;
 use Magento\MagentoCloud\Util\PasswordGenerator;
+use Magento\MagentoCloud\Filesystem\FileList;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
 use Psr\Log\LoggerInterface;
@@ -42,6 +43,11 @@ class SetupTest extends TestCase
     private $passwordGeneratorMock;
 
     /**
+     * @var FileList|Mock
+     */
+    private $fileListMock;
+
+    /**
      * @var Setup
      */
     private $process;
@@ -58,13 +64,15 @@ class SetupTest extends TestCase
         $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
             ->getMockForAbstractClass();
         $this->passwordGeneratorMock = $this->createMock(PasswordGenerator::class);
+        $this->fileListMock = $this->createMock(FileList::class);
 
         $this->process = new Setup(
             $this->loggerMock,
             $this->urlManagerMock,
             $this->environmentMock,
             $this->shellMock,
-            $this->passwordGeneratorMock
+            $this->passwordGeneratorMock,
+            $this->fileListMock
         );
     }
 
@@ -94,6 +102,8 @@ class SetupTest extends TestCase
         $adminFirstnameExpected,
         $adminLastnameExpected
     ) {
+        $installUpgradeLog = '/tmp/log.log';
+
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Installing Magento.');
@@ -135,10 +145,15 @@ class SetupTest extends TestCase
             ->method('generateRandomPassword')
             ->willReturn($adminPasswordExpected);
 
+        $this->fileListMock->expects($this->once())
+            ->method('getInstallUpgradeLog')
+            ->willReturn($installUpgradeLog);
+
         $this->shellMock->expects($this->once())
             ->method('execute')
             ->with(
-                'php ./bin/magento setup:install --session-save=db --cleanup-database --currency=\'USD\''
+                '/bin/bash -c "set -o pipefail;'
+                . ' php ./bin/magento setup:install --session-save=db --cleanup-database --currency=\'USD\''
                 . ' --base-url=\'http://unsecure.url\' --base-url-secure=\'https://secure.url\' --language=\'fr_FR\''
                 . ' --timezone=America/Los_Angeles --db-host=\'localhost\' --db-name=\'magento\' --db-user=\'user\''
                 . ' --backend-frontname=\'' . $adminUrlExpected . '\' --admin-user=\'' . $adminNameExpected . '\''
@@ -146,6 +161,7 @@ class SetupTest extends TestCase
                 . '\' --admin-email=\'admin@example.com\' --admin-password=\'' . $adminPasswordExpected . '\''
                 . ' --use-secure-admin=1'
                 . ' --db-password=\'password\' -v'
+                . ' | tee -a ' . $installUpgradeLog . '"'
             );
 
         $this->process->execute();


### PR DESCRIPTION
### Description
A user can see installation/upgrading live progress in the installUpgrade.log file.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1253

### Zephyr Tests
https://jira.corp.magento.com/browse/MAGETWO-84790

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
