### PR TITLE
MAGECLOUD-1355: Cron Reset CLI Command for 2.2.x

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -6,6 +6,7 @@
 namespace Magento\MagentoCloud\App;
 
 use Magento\MagentoCloud\Command\Build;
+use Magento\MagentoCloud\Command\CronUnlock;
 use Magento\MagentoCloud\Command\Deploy;
 use Magento\MagentoCloud\Command\ConfigDump;
 use Magento\MagentoCloud\Process\ProcessInterface;
@@ -145,6 +146,15 @@ class Container extends \Illuminate\Container\Container implements ContainerInte
                 return $this->makeWith(ProcessPool::class, [
                     'processes' => [
                         $this->make(ConfigDumpProcess\Import::class),
+                    ],
+                ]);
+            });
+        $this->when(CronUnlock::class)
+            ->needs(ProcessInterface::class)
+            ->give(function () {
+                return $this->makeWith(ProcessPool::class, [
+                    'processes' => [
+                        $this->make(DeployProcess\UnlockCronJobs::class),
                     ],
                 ]);
             });

--- a/src/Application.php
+++ b/src/Application.php
@@ -7,6 +7,7 @@ namespace Magento\MagentoCloud;
 
 use Composer\Composer;
 use Magento\MagentoCloud\Command\Build;
+use Magento\MagentoCloud\Command\CronUnlock;
 use Magento\MagentoCloud\Command\Deploy;
 use Magento\MagentoCloud\Command\ConfigDump;
 use Psr\Container\ContainerInterface;
@@ -45,6 +46,7 @@ class Application extends \Symfony\Component\Console\Application
                 $this->container->get(Build::class),
                 $this->container->get(Deploy::class),
                 $this->container->get(ConfigDump::class),
+                $this->container->get(CronUnlock::class),
             ]
         );
     }

--- a/src/Command/CronUnlock.php
+++ b/src/Command/CronUnlock.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Command;
+
+use Magento\MagentoCloud\Process\ProcessInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * CLI command for unlocking cron jobs that stuck in "running" state.
+ */
+class CronUnlock extends Command
+{
+    const NAME = 'cron:unlock';
+
+    /**
+     * @var ProcessInterface
+     */
+    private $process;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ProcessInterface $process
+     * @param LoggerInterface $logger
+     */
+    public function __construct(ProcessInterface $process, LoggerInterface $logger)
+    {
+        $this->process = $process;
+        $this->logger = $logger;
+
+        parent::__construct();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this->setName(static::NAME)
+            ->setDescription('Unlock cron jobs that stuck in "running" state.');
+
+        parent::configure();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $this->logger->info('Starting unlocking.');
+            $this->process->execute();
+            $this->logger->info('Unlocking completed.');
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception->getMessage());
+
+            throw $exception;
+        }
+    }
+}

--- a/src/Test/Unit/ApplicationTest.php
+++ b/src/Test/Unit/ApplicationTest.php
@@ -10,6 +10,7 @@ use Composer\Package\PackageInterface;
 use Magento\MagentoCloud\Application;
 use Magento\MagentoCloud\Command\Build;
 use Magento\MagentoCloud\Command\ConfigDump;
+use Magento\MagentoCloud\Command\CronUnlock;
 use Magento\MagentoCloud\Command\Deploy;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -37,19 +38,14 @@ class ApplicationTest extends TestCase
     private $packageMock;
 
     /**
-     * @var Build|\PHPUnit_Framework_MockObject_MockObject
+     * @var string
      */
-    private $buildCommandMock;
+    private $applicationVersion = '1.0';
 
     /**
-     * @var Deploy|\PHPUnit_Framework_MockObject_MockObject
+     * @var string
      */
-    private $deployCommandMock;
-
-    /**
-     * @var ConfigDump|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $configDumpCommand;
+    private $applicationName = 'Magento Cloud Tools';
 
     /**
      * @inheritdoc
@@ -59,48 +55,56 @@ class ApplicationTest extends TestCase
         $this->containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
         $this->packageMock = $this->getMockForAbstractClass(PackageInterface::class);
         $this->composerMock = $this->createMock(Composer::class);
-        $this->buildCommandMock = $this->createMock(Build::class);
-        $this->deployCommandMock = $this->createMock(Deploy::class);
-        $this->configDumpCommand = $this->createMock(Deploy::class);
 
-        $this->buildCommandMock->method('getName')
-            ->willReturn(Build::NAME);
-        $this->buildCommandMock->method('isEnabled')
-            ->willReturn(true);
-        $this->buildCommandMock->method('getDefinition')
-            ->willReturn([]);
-        $this->buildCommandMock->method('getAliases')
-            ->willReturn([]);
-        $this->deployCommandMock->method('getName')
-            ->willReturn(Deploy::NAME);
-        $this->deployCommandMock->method('isEnabled')
-            ->willReturn(true);
-        $this->deployCommandMock->method('getDefinition')
-            ->willReturn([]);
-        $this->deployCommandMock->method('getAliases')
-            ->willReturn([]);
-        $this->configDumpCommand->method('getName')
-            ->willReturn(ConfigDump::NAME);
-        $this->configDumpCommand->method('isEnabled')
-            ->willReturn(true);
-        $this->configDumpCommand->method('getDefinition')
-            ->willReturn([]);
-        $this->configDumpCommand->method('getAliases')
-            ->willReturn([]);
+        /**
+         * Command mocks.
+         */
+        $buildCommandMock = $this->createMock(Build::class);
+        $deployCommandMock = $this->createMock(Deploy::class);
+        $configDumpCommand = $this->createMock(ConfigDump::class);
+        $cronUnlockCommand = $this->createMock(CronUnlock::class);
+
+        $this->mockCommand($buildCommandMock, Build::NAME);
+        $this->mockCommand($deployCommandMock, Deploy::NAME);
+        $this->mockCommand($configDumpCommand, ConfigDump::NAME);
+        $this->mockCommand($cronUnlockCommand, CronUnlock::NAME);
 
         $this->containerMock->method('get')
             ->willReturnMap([
                 [Composer::class, $this->composerMock],
-                [Build::class, $this->buildCommandMock],
-                [Deploy::class, $this->deployCommandMock],
-                [ConfigDump::class, $this->configDumpCommand],
+                [Build::class, $buildCommandMock],
+                [Deploy::class, $deployCommandMock],
+                [ConfigDump::class, $configDumpCommand],
+                [CronUnlock::class, $cronUnlockCommand],
             ]);
         $this->composerMock->method('getPackage')
             ->willReturn($this->packageMock);
+        $this->packageMock->expects($this->once())
+            ->method('getPrettyName')
+            ->willReturn($this->applicationName);
+        $this->packageMock->expects($this->once())
+            ->method('getPrettyVersion')
+            ->willReturn($this->applicationVersion);
 
         $this->application = new Application(
             $this->containerMock
         );
+    }
+
+    /**
+     * @param \PHPUnit_Framework_MockObject_MockObject $command
+     * @param string $name
+     */
+    private function mockCommand(\PHPUnit_Framework_MockObject_MockObject $command, string $name)
+    {
+        $command->method('getName')
+            ->willReturn($name);
+        $command->method('isEnabled')
+            ->willReturn(true);
+        $command->method('getDefinition')
+            ->willReturn([]);
+        $command->method('getAliases')
+            ->willReturn([]);
     }
 
     public function testHasCommand()
@@ -108,5 +112,22 @@ class ApplicationTest extends TestCase
         $this->assertTrue($this->application->has(Build::NAME));
         $this->assertTrue($this->application->has(Deploy::NAME));
         $this->assertTrue($this->application->has(ConfigDump::NAME));
+        $this->assertTrue($this->application->has(CronUnlock::NAME));
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame(
+            $this->applicationName,
+            $this->application->getName()
+        );
+    }
+
+    public function testGetVersion()
+    {
+        $this->assertSame(
+            $this->applicationVersion,
+            $this->application->getVersion()
+        );
     }
 }

--- a/src/Test/Unit/Command/CronUnlockTest.php
+++ b/src/Test/Unit/Command/CronUnlockTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Command;
+
+use Magento\MagentoCloud\Command\CronUnlock;
+use Magento\MagentoCloud\Process\ProcessInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+class CronUnlockTest extends TestCase
+{
+    /**
+     * @var ProcessInterface|Mock
+     */
+    private $processMock;
+
+    /**
+     * @var LoggerInterface|Mock
+     */
+    private $loggerMock;
+
+    /**
+     * @var CronUnlock
+     */
+    private $cronUnlockCommand;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->processMock = $this->getMockForAbstractClass(ProcessInterface::class);
+        $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
+
+        $this->cronUnlockCommand = new CronUnlock(
+            $this->processMock,
+            $this->loggerMock
+        );
+    }
+
+    public function testExecute()
+    {
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('info')
+            ->withConsecutive(
+                ['Starting unlocking.'],
+                ['Unlocking completed.']
+            );
+        $this->processMock->expects($this->once())
+            ->method('execute');
+
+        $tester = new CommandTester(
+            $this->cronUnlockCommand
+        );
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Some error
+     */
+    public function testExecuteWithException()
+    {
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Starting unlocking.');
+        $this->loggerMock->expects($this->once())
+            ->method('critical')
+            ->with('Some error');
+        $this->processMock->expects($this->once())
+            ->method('execute')
+            ->willThrowException(new \Exception('Some error'));
+
+        $tester = new CommandTester(
+            $this->cronUnlockCommand
+        );
+        $tester->execute([]);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Create CLI command in ece-tools to launch functionality, added in   MAGECLOUD-1343 CLOSED  as a separate function, helping to reset the stuck crons on demand

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1355

### Zephyr Tests
1. Install magento
2. Set status Running for several cron jobs
3. Run CLI command `php ./vendor/bin/ece-tools cron:unlock`
4. Check that cron jobs in state `running` switch to `missed`

https://jira.corp.magento.com/browse/MAGETWO-84828


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
