### PR TITLE
MAGECLOUD-1362: view_preprocessed is a file not a directory

### DIFF
--- a/src/Test/Unit/Util/StaticContentCleanerTest.php
+++ b/src/Test/Unit/Util/StaticContentCleanerTest.php
@@ -203,6 +203,46 @@ class StaticContentCleanerTest extends TestCase
             ->method('isExists')
             ->with($magentoVarDir . '/view_preprocessed')
             ->willReturn(false);
+        $this->fileMock->expects($this->once())
+            ->method('isLink')
+            ->with($magentoVarDir . '/view_preprocessed')
+            ->willReturn(false);
+
+        $this->fileMock->expects($this->never())
+            ->method('rename');
+        $this->fileMock->expects($this->never())
+            ->method('unLink');
+        $this->shellMock->expects($this->never())
+            ->method('backgroundExecute');
+        $this->loggerMock->expects($this->never())
+            ->method('info');
+
+        $this->staticContentCleaner->cleanViewPreprocessed();
+    }
+
+    public function testCleanViewPreprocessedIsLink()
+    {
+        $magentoRootDir = '/magento/';
+        $magentoVarDir = $magentoRootDir . '/var';
+
+        $this->directoryListMock->expects($this->once())
+            ->method('getMagentoRoot')
+            ->willReturn($magentoRootDir);
+        $this->fileMock->expects($this->once())
+            ->method('getRealPath')
+            ->with($magentoVarDir)
+            ->willReturn($magentoVarDir);
+        $this->fileMock->expects($this->once())
+            ->method('isExists')
+            ->with($magentoVarDir . '/view_preprocessed')
+            ->willReturn(false);
+        $this->fileMock->expects($this->once())
+            ->method('isLink')
+            ->with($magentoVarDir . '/view_preprocessed')
+            ->willReturn(true);
+        $this->fileMock->expects($this->once())
+            ->method('unLink')
+            ->with($magentoVarDir . '/view_preprocessed');
 
         $this->fileMock->expects($this->never())
             ->method('rename');

--- a/src/Util/StaticContentCleaner.php
+++ b/src/Util/StaticContentCleaner.php
@@ -89,6 +89,8 @@ class StaticContentCleaner
             $this->file->rename($preprocessedLocation, $oldPreprocessedLocation);
             $this->logger->info('Removing '.  $oldPreprocessedLocation . ' in the background');
             $this->shell->backgroundExecute('rm -rf ' . $oldPreprocessedLocation);
+        } elseif ($this->file->isLink($preprocessedLocation)) {
+            $this->file->unLink($preprocessedLocation);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Fix a problem when view_preprocessed folder is a link to non-existence folder in init directory and static content generates during build phase with enabled html minification/

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1362

### Zephyr Tests
https://jira.corp.magento.com/browse/MAGETWO-83803

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
