### PR TITLE
MAGECLOUD-1361: Ask confirmation before running db-dump command

### DIFF
--- a/src/Command/DbDump.php
+++ b/src/Command/DbDump.php
@@ -62,7 +62,7 @@ class DbDump extends Command
     {
         $helper = $this->getHelper('question');
         $question = new ConfirmationQuestion(
-            'We suggest to enable maintenance mode before running this command. Do you want to continue [y/n]?',
+            'We suggest to enable maintenance mode before running this command. Do you want to continue [y/N]?',
             false
         );
         if (!$helper->ask($input, $output, $question) && $input->isInteractive()) {

--- a/src/Command/DbDump.php
+++ b/src/Command/DbDump.php
@@ -10,6 +10,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * Class DbDump for safely creating backup of database
@@ -52,10 +53,21 @@ class DbDump extends Command
     }
 
     /**
-     * @inheritdoc
+     * Creates DB dump.
+     * Command requires confirmation before execution.
+     *
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion(
+            'We suggest to enable maintenance mode before running this command. Do you want to continue [y/n]?',
+            false
+        );
+        if (!$helper->ask($input, $output, $question) && $input->isInteractive()) {
+            return null;
+        }
         try {
             $this->logger->info('Starting backup.');
             $this->process->execute();

--- a/src/Test/Unit/Command/DbDumpTest.php
+++ b/src/Test/Unit/Command/DbDumpTest.php
@@ -60,7 +60,7 @@ class DbDumpTest extends TestCase
         $this->helperSetMock->expects($this->once())
             ->method('get')
             ->with('question')
-            ->will($this->returnValue($this->questionMock));
+            ->willReturn($this->questionMock);
 
         $this->command = new DbDump(
             $this->processMock,
@@ -73,7 +73,7 @@ class DbDumpTest extends TestCase
     {
         $this->questionMock->expects($this->once())
             ->method('ask')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
@@ -96,7 +96,7 @@ class DbDumpTest extends TestCase
     {
         $this->questionMock->expects($this->once())
             ->method('ask')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->loggerMock->expects($this->never())
             ->method('info');
@@ -119,7 +119,7 @@ class DbDumpTest extends TestCase
     {
         $this->questionMock->expects($this->once())
             ->method('ask')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Starting backup.');


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-1361

### Description
vendor/bin/ece-tools db-dump command should ask confirmation before running this script, because this command may affect work of the site and its performance.

### Zephyr Tests
https://jira.corp.magento.com/browse/MAGETWO-83527

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
