### PR TITLE
MAGECLOUD-1162: [GitHub] Deleting var/log while still writing to var/log/cloud.log

### DIFF
--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\MagentoCloud\Process\Build;
 
+use Magento\MagentoCloud\App\Logger\Pool as LoggerPool;
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
@@ -41,21 +42,29 @@ class BackupData implements ProcessInterface
     private $directoryList;
 
     /**
+     * @var LoggerPool
+     */
+    private $loggerPool;
+
+    /**
      * @param File $file
      * @param LoggerInterface $logger
      * @param Environment $environment
      * @param DirectoryList $directoryList
+     * @param LoggerPool $loggerPool
      */
     public function __construct(
         File $file,
         LoggerInterface $logger,
         Environment $environment,
-        DirectoryList $directoryList
+        DirectoryList $directoryList,
+        LoggerPool $loggerPool
     ) {
         $this->file = $file;
         $this->logger = $logger;
         $this->environment = $environment;
         $this->directoryList = $directoryList;
+        $this->loggerPool = $loggerPool;
     }
 
     /**
@@ -96,6 +105,8 @@ class BackupData implements ProcessInterface
 
         $this->logger->info('Copying writable directories to temp directory.');
 
+        $this->stopLogging();
+
         foreach ($this->environment->getWritableDirectories() as $dir) {
             $originalDir = $magentoRoot . $dir;
             $initDir = $rootInitDir . $dir;
@@ -105,7 +116,30 @@ class BackupData implements ProcessInterface
 
             if (count($this->file->scanDir($originalDir)) > 2) {
                 $this->file->copyDirectory($originalDir, $initDir);
+                $this->file->deleteDirectory($originalDir);
+                $this->file->createDirectory($originalDir);
             }
         }
+
+        $this->restoreLogging();
+    }
+
+    /**
+     * Removes all log handlers for closing all connections to files that are opened for logging.
+     *
+     * It's done for avoiding file system exceptions while file opened for writing is not physically exists
+     * and some process trying to write into that file.
+     */
+    private function stopLogging()
+    {
+        $this->logger->setHandlers([]);
+    }
+
+    /**
+     * Restore all log handlers.
+     */
+    private function restoreLogging()
+    {
+        $this->logger->setHandlers($this->loggerPool->getHandlers());
     }
 }

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -105,8 +105,6 @@ class BackupData implements ProcessInterface
 
             if (count($this->file->scanDir($originalDir)) > 2) {
                 $this->file->copyDirectory($originalDir, $initDir);
-                $this->file->deleteDirectory($originalDir);
-                $this->file->createDirectory($originalDir);
             }
         }
     }

--- a/src/Test/Unit/Process/Build/BackupDataTest.php
+++ b/src/Test/Unit/Process/Build/BackupDataTest.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\MagentoCloud\Test\Unit\Process\Build;
 
+use Magento\MagentoCloud\App\Logger\Pool as LoggerPool;
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
@@ -43,6 +44,11 @@ class BackupDataTest extends TestCase
     private $directoryListMock;
 
     /**
+     * @var LoggerPool|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $loggerPoolMock;
+
+    /**
      * @inheritdoc
      */
     protected function setUp()
@@ -51,6 +57,7 @@ class BackupDataTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->setMethods(['setHandlers', 'info'])
             ->getMockForAbstractClass();
         $this->environmentMock = $this->getMockBuilder(Environment::class)
             ->disableOriginalConstructor()
@@ -58,6 +65,7 @@ class BackupDataTest extends TestCase
         $this->directoryListMock = $this->getMockBuilder(DirectoryList::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->loggerPoolMock = $this->createMock(LoggerPool::class);
 
         $this->directoryListMock->expects($this->once())
             ->method('getMagentoRoot')
@@ -66,11 +74,22 @@ class BackupDataTest extends TestCase
             ->method('getInit')
             ->willReturn('magento_root/init');
 
+        $this->loggerPoolMock->expects($this->once())
+            ->method('getHandlers')
+            ->willReturn(['handler1', 'handler2']);
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('setHandlers')
+            ->withConsecutive(
+                [[]],
+                [['handler1', 'handler2']]
+            );
+
         $this->process = new BackupData(
             $this->fileMock,
             $this->loggerMock,
             $this->environmentMock,
-            $this->directoryListMock
+            $this->directoryListMock,
+            $this->loggerPoolMock
         );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
During the build phase of m2-ece-build, one of the build processes attempts to delete the var/log dir while another process still has var/log/cloud.log open for writing.
On an NFS system, this will cause an .nfsXXX file to be created when cloud.log is unlinked from one process while the other is still running. Consequently, a file system exception is thrown, and m2-ece-build is aborted.
While this may not be an issue in the Platform.sh containers, it is an error in the logic (to have one process delete a file that another is actively writing to), and we have to modify the code to use it locally.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
https://magento2.atlassian.net/browse/MAGECLOUD-1162

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. Run build and deploy scripts from ece-tools on NFS file system.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
