### PR TITLE
MAGECLOUD-1372: Backup Critical Configuration Files to Recover On-Demand

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -154,6 +154,10 @@ class Container implements ContainerInterface
                         $this->container->make(DeployProcess\DisableGoogleAnalytics::class),
                         $this->container->make(DeployProcess\UnlockCronJobs::class),
                         /**
+                         * Remove this line after implementation post-deploy hook
+                         */
+                        $this->container->make(PostDeployProcess\Backup::class),
+                        /**
                          * Cache clean process must remain the last one in deploy chain.
                          * Do not add any processes after it.
                          */
@@ -306,6 +310,7 @@ class Container implements ContainerInterface
             ->give(function () {
                 return $this->container->make(ProcessComposite::class, [
                     'processes' => [
+                        $this->container->make(PostDeployProcess\Backup::class),
                         $this->container->make(PostDeployProcess\CleanCache::class),
                     ],
                 ]);

--- a/src/Application.php
+++ b/src/Application.php
@@ -6,6 +6,7 @@
 namespace Magento\MagentoCloud;
 
 use Composer\Composer;
+use Magento\MagentoCloud\Command\BackupRestore;
 use Magento\MagentoCloud\Command\Build;
 use Magento\MagentoCloud\Command\CronUnlock;
 use Magento\MagentoCloud\Command\Deploy;
@@ -59,6 +60,7 @@ class Application extends \Symfony\Component\Console\Application
                 $this->container->get(DbDump::class),
                 $this->container->get(PostDeploy::class),
                 $this->container->get(CronUnlock::class),
+                $this->container->get(BackupRestore::class),
             ]
         );
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -6,6 +6,7 @@
 namespace Magento\MagentoCloud;
 
 use Composer\Composer;
+use Magento\MagentoCloud\Command\BackupList;
 use Magento\MagentoCloud\Command\BackupRestore;
 use Magento\MagentoCloud\Command\Build;
 use Magento\MagentoCloud\Command\CronUnlock;
@@ -61,6 +62,7 @@ class Application extends \Symfony\Component\Console\Application
                 $this->container->get(PostDeploy::class),
                 $this->container->get(CronUnlock::class),
                 $this->container->get(BackupRestore::class),
+                $this->container->get(BackupList::class),
             ]
         );
     }

--- a/src/Backup/Restorer.php
+++ b/src/Backup/Restorer.php
@@ -51,7 +51,7 @@ class Restorer
         $backupList = $this->backupList->getList();
 
         if ($specificPath) {
-            if (isset($backupList[$specificPath])) {
+            if (empty($backupList[$specificPath])) {
                 $output->writeln(sprintf('<error>There is no %s file in the backup list.</error>'
                     . ' <comment>Run backup:list to show files from backup list.</comment>', $specificPath));
                 return;

--- a/src/Backup/Restorer.php
+++ b/src/Backup/Restorer.php
@@ -51,15 +51,15 @@ class Restorer
         $backupList = $this->backupList->getList();
 
         if ($specificPath) {
-            if (!in_array($specificPath, $backupList)) {
+            if (isset($backupList[$specificPath])) {
                 $output->writeln(sprintf('<error>There is no %s file in the backup list.</error>'
                     . ' <comment>Run backup:list to show files from backup list.</comment>', $specificPath));
                 return;
             }
-            $this->restore($input, $output, $specificPath);
+            $this->restore($input, $output, $specificPath, $backupList[$specificPath]);
         } else {
-            foreach ($backupList as $file) {
-                $this->restore($input, $output, $file);
+            foreach ($backupList as $alias => $file) {
+                $this->restore($input, $output, $alias, $file);
             }
         }
     }
@@ -69,23 +69,24 @@ class Restorer
      *
      * @param InputInterface $input
      * @param OutputInterface $output
+     * @param string $alias
      * @param string $file
      */
-    private function restore(InputInterface $input, OutputInterface $output, string $file)
+    private function restore(InputInterface $input, OutputInterface $output, string $alias, string $file)
     {
         $backup = $file . BackupList::BACKUP_SUFFIX;
         if (!$this->file->isExists($backup)) {
-            $output->writeln(sprintf('<info>Backup for %s does not exist.</info> <comment>Skipped.</comment>', $file));
+            $output->writeln(sprintf('<info>Backup for %s does not exist.</info> <comment>Skipped.</comment>', $alias));
             return;
         }
 
         if ($this->file->isExists($file) && !$input->getOption('force')) {
             $output->writeln(sprintf('<info>%s file exists!</info>'
-                . ' <comment>If you want to rewrite existed files use --force</comment>', $file));
+                . ' <comment>If you want to rewrite existed files use --force</comment>', $alias));
             return;
         }
 
         $this->file->copy($backup, $file);
-        $output->writeln(sprintf('<info>Backup file %s was restored.</info>', $file));
+        $output->writeln(sprintf('<info>Backup file %s was restored.</info>', $alias));
     }
 }

--- a/src/Backup/Restorer.php
+++ b/src/Backup/Restorer.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Backup;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\MagentoCloud\Filesystem\BackupList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+
+/**
+ * Class for restoring Magento files from backup
+ *
+ * @see \Magento\MagentoCloud\Filesystem\BackupList contains the list of files for restoring
+ */
+class Restorer
+{
+    /**
+     * @var BackupList
+     */
+    private $backupList;
+
+    /**
+     * @var File
+     */
+    private $file;
+
+    /**
+     * @param BackupList $backupList
+     * @param File $file
+     */
+    public function __construct(
+        BackupList $backupList,
+        File $file
+    ) {
+        $this->backupList = $backupList;
+        $this->file = $file;
+    }
+
+    /**
+     * Restores Magento files from backup
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    public function run(InputInterface $input, OutputInterface $output)
+    {
+        $specificPath = $input->getOption('file');
+        $backupList = $this->backupList->getList();
+
+        if ($specificPath) {
+            if (!in_array($specificPath, $backupList)) {
+                $output->writeln(sprintf('<error>There is no %s file in the backup list.</error>'
+                    . ' <comment>Run backup:list to show files from backup list.</comment>', $specificPath));
+                return;
+            }
+            $this->restore($input, $output, $specificPath);
+        } else {
+            foreach ($backupList as $file) {
+                $this->restore($input, $output, $file);
+            }
+        }
+    }
+
+    /**
+     * Restores a file
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param string $file
+     */
+    private function restore(InputInterface $input, OutputInterface $output, string $file)
+    {
+        $backup = $file . BackupList::BACKUP_SUFFIX;
+        if (!$this->file->isExists($backup)) {
+            $output->writeln(sprintf('<info>Backup for %s does not exist.</info> <comment>Skipped.</comment>', $file));
+            return;
+        }
+
+        if ($this->file->isExists($file) && !$input->getOption('force')) {
+            $output->writeln(sprintf('<info>%s file exists!</info>'
+                . ' <comment>If you want to rewrite existed files use --force</comment>', $file));
+            return;
+        }
+
+        $this->file->copy($backup, $file);
+        $output->writeln(sprintf('<info>Backup file %s was restored.</info>', $file));
+    }
+}

--- a/src/Command/Backup/FileList.php
+++ b/src/Command/Backup/FileList.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Command\Backup;
+
+use Magento\MagentoCloud\Filesystem\BackupList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+
+/**
+ * Class returns the list of files that are in backup
+ */
+class FileList
+{
+    /**
+     * @var BackupList
+     */
+    private $backupList;
+
+    /**
+     * @var File
+     */
+    private $file;
+
+    /**
+     * @param BackupList $backupList
+     * @param File $file
+     */
+    public function __construct(
+        BackupList $backupList,
+        File $file
+    ) {
+        $this->backupList = $backupList;
+        $this->file = $file;
+    }
+
+    /**
+     * Returns the list of alias path of existed backup files
+     *
+     * @return array
+     */
+    public function get(): array
+    {
+        $resultList = [];
+        foreach ($this->backupList->getList() as $aliasPath => $filePath) {
+            $backupPath = $filePath . BackupList::BACKUP_SUFFIX;
+            if ($this->file->isExists($backupPath)) {
+                $resultList[] = $aliasPath;
+            }
+        }
+
+        return $resultList;
+    }
+}

--- a/src/Command/Backup/Restore.php
+++ b/src/Command/Backup/Restore.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\MagentoCloud\Backup;
+namespace Magento\MagentoCloud\Command\Backup;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -15,7 +15,7 @@ use Magento\MagentoCloud\Filesystem\Driver\File;
  *
  * @see \Magento\MagentoCloud\Filesystem\BackupList contains the list of files for restoring
  */
-class Restorer
+class Restore
 {
     /**
      * @var BackupList
@@ -44,6 +44,7 @@ class Restorer
      *
      * @param InputInterface $input
      * @param OutputInterface $output
+     * @return void
      */
     public function run(InputInterface $input, OutputInterface $output)
     {
@@ -56,10 +57,10 @@ class Restorer
                     . ' <comment>Run backup:list to show files from backup list.</comment>', $specificPath));
                 return;
             }
-            $this->restore($input, $output, $specificPath, $backupList[$specificPath]);
+            $this->restore($input, $output, $backupList[$specificPath], $specificPath);
         } else {
-            foreach ($backupList as $alias => $file) {
-                $this->restore($input, $output, $alias, $file);
+            foreach ($backupList as $aliasPath => $filePath) {
+                $this->restore($input, $output, $filePath, $aliasPath);
             }
         }
     }
@@ -69,24 +70,26 @@ class Restorer
      *
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @param string $alias
-     * @param string $file
+     * @param string $aliasPath
+     * @param string $filePath
+     * @return void
      */
-    private function restore(InputInterface $input, OutputInterface $output, string $alias, string $file)
+    private function restore(InputInterface $input, OutputInterface $output, string $filePath, string $aliasPath)
     {
-        $backup = $file . BackupList::BACKUP_SUFFIX;
-        if (!$this->file->isExists($backup)) {
-            $output->writeln(sprintf('<info>Backup for %s does not exist.</info> <comment>Skipped.</comment>', $alias));
+        $backupPath = $filePath . BackupList::BACKUP_SUFFIX;
+        if (!$this->file->isExists($backupPath)) {
+            $output->writeln(sprintf('<info>Backup for %s does not exist.</info>'
+                . ' <comment>Skipped.</comment>', $aliasPath));
             return;
         }
 
-        if ($this->file->isExists($file) && !$input->getOption('force')) {
+        if ($this->file->isExists($filePath) && !$input->getOption('force')) {
             $output->writeln(sprintf('<info>%s file exists!</info>'
-                . ' <comment>If you want to rewrite existed files use --force</comment>', $alias));
+                . ' <comment>If you want to rewrite existed files use --force</comment>', $aliasPath));
             return;
         }
 
-        $this->file->copy($backup, $file);
-        $output->writeln(sprintf('<info>Backup file %s was restored.</info>', $alias));
+        $this->file->copy($backupPath, $filePath);
+        $output->writeln(sprintf('<info>Backup file %s was restored.</info>', $aliasPath));
     }
 }

--- a/src/Command/BackupList.php
+++ b/src/Command/BackupList.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\MagentoCloud\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\MagentoCloud\Filesystem\BackupList as BackupFilesList;
+use Psr\Log\LoggerInterface;
+
+class BackupList extends Command
+{
+    /**
+     * @var BackupFilesList
+     */
+    private $backupFilesList;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Command name
+     */
+    const NAME = 'backup:list';
+
+    public function __construct(
+        BackupFilesList $backupFilesList,
+        LoggerInterface $logger
+    ) {
+        $this->backupFilesList = $backupFilesList;
+        $this->logger = $logger;
+
+        parent::__construct();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this->setName(self::NAME)
+            ->setDescription('Shows the list of backup files');
+
+        parent::configure();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        try {
+            $output->writeln('<comment>The list of backup files:</comment>');
+            $output->writeln($this->backupFilesList->getList());
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception->getMessage());
+
+            throw $exception;
+        }
+    }
+}

--- a/src/Command/BackupList.php
+++ b/src/Command/BackupList.php
@@ -3,13 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\MagentoCloud\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Magento\MagentoCloud\Filesystem\BackupList as BackupFilesList;
+use Magento\MagentoCloud\Command\Backup\FileList as BackupFilesList;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -62,14 +61,12 @@ class BackupList extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-
         try {
             $output->writeln('<comment>The list of backup files:</comment>');
-            $output->writeln(array_keys($this->backupFilesList->getList()));
+            $output->writeln($this->backupFilesList->get() ?: 'There are no files in the backup');
         } catch (\Exception $exception) {
             $this->logger->critical($exception->getMessage());
-
-            throw $exception;
+            return 1;
         }
     }
 }

--- a/src/Command/BackupList.php
+++ b/src/Command/BackupList.php
@@ -59,15 +59,14 @@ class BackupList extends Command
     /**
      * @inheritdoc
      */
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         try {
             $output->writeln('<comment>The list of backup files:</comment>');
             $output->writeln($this->backupFilesList->get() ?: 'There are no files in the backup');
-            return 0;
         } catch (\Exception $exception) {
             $this->logger->critical($exception->getMessage());
-            return 1;
+            throw $exception;
         }
     }
 }

--- a/src/Command/BackupList.php
+++ b/src/Command/BackupList.php
@@ -65,7 +65,7 @@ class BackupList extends Command
 
         try {
             $output->writeln('<comment>The list of backup files:</comment>');
-            $output->writeln($this->backupFilesList->getList());
+            $output->writeln(array_keys($this->backupFilesList->getList()));
         } catch (\Exception $exception) {
             $this->logger->critical($exception->getMessage());
 

--- a/src/Command/BackupList.php
+++ b/src/Command/BackupList.php
@@ -12,6 +12,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Magento\MagentoCloud\Filesystem\BackupList as BackupFilesList;
 use Psr\Log\LoggerInterface;
 
+/**
+ * CLI command for showing the list of backup files.
+ */
 class BackupList extends Command
 {
     /**
@@ -29,6 +32,10 @@ class BackupList extends Command
      */
     const NAME = 'backup:list';
 
+    /**
+     * @param BackupFilesList $backupFilesList
+     * @param LoggerInterface $logger
+     */
     public function __construct(
         BackupFilesList $backupFilesList,
         LoggerInterface $logger

--- a/src/Command/BackupList.php
+++ b/src/Command/BackupList.php
@@ -59,11 +59,12 @@ class BackupList extends Command
     /**
      * @inheritdoc
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $output->writeln('<comment>The list of backup files:</comment>');
             $output->writeln($this->backupFilesList->get() ?: 'There are no files in the backup');
+            return 0;
         } catch (\Exception $exception) {
             $this->logger->critical($exception->getMessage());
             return 1;

--- a/src/Command/BackupRestore.php
+++ b/src/Command/BackupRestore.php
@@ -78,7 +78,7 @@ class BackupRestore extends Command
                 $helper = $this->getHelper('question');
                 $question = new ConfirmationQuestion(
                     'Command ' . self::NAME
-                    . ' with option --force rewrite your existed files. Do you want to continue [y/N]?',
+                    . ' with option --force will rewrite your existed files. Do you want to continue [y/N]?',
                     false
                 );
                 $restore = $helper->ask($input, $output, $question);

--- a/src/Command/BackupRestore.php
+++ b/src/Command/BackupRestore.php
@@ -70,27 +70,26 @@ class BackupRestore extends Command
     /**
      * @inheritdoc
      */
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $restore = true;
-        if ($input->getOption('force')) {
-            $helper = $this->getHelper('question');
-            $question = new ConfirmationQuestion(
-                'Command ' . self::NAME
-                . ' with option --force rewrite your existed files. Do you want to continue [y/N]?',
-                false
-            );
-            $restore = $helper->ask($input, $output, $question);
-        }
-
         try {
+            $restore = true;
+            if ($input->getOption('force')) {
+                $helper = $this->getHelper('question');
+                $question = new ConfirmationQuestion(
+                    'Command ' . self::NAME
+                    . ' with option --force rewrite your existed files. Do you want to continue [y/N]?',
+                    false
+                );
+                $restore = $helper->ask($input, $output, $question);
+            }
+
             if ($restore) {
                 $this->restore->run($input, $output);
             }
-            return 0;
         } catch (\Exception $exception) {
             $this->logger->critical($exception->getMessage());
-            return 1;
+            throw $exception;
         }
     }
 }

--- a/src/Command/BackupRestore.php
+++ b/src/Command/BackupRestore.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Magento\MagentoCloud\Backup\Restorer;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Psr\Log\LoggerInterface;
+
+/**
+ * CLI command for restoring Magento configuration files from backup.
+ */
+class BackupRestore extends Command
+{
+    /**
+     * @var Restorer
+     */
+    private $restorer;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Command name
+     */
+    const NAME = 'backup:restore';
+
+    /**
+     * @param Restorer $restorer
+     * @param LoggerInterface $logger
+     */
+    public function __construct(Restorer $restorer, LoggerInterface $logger)
+    {
+        $this->restorer = $restorer;
+        $this->logger = $logger;
+        parent::__construct();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this->setName(self::NAME)
+            ->setDescription('Restore important configuration files');
+        $this->addOption(
+            'force',
+            'f',
+            InputOption::VALUE_NONE,
+            'Overwrite existing files during restoring a backup'
+        );
+        $this->addOption(
+            'file',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'A specific file recovery path'
+        );
+
+        parent::configure();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $this->restorer->run($input, $output);
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception->getMessage());
+
+            throw $exception;
+        }
+    }
+}

--- a/src/Command/BackupRestore.php
+++ b/src/Command/BackupRestore.php
@@ -70,7 +70,7 @@ class BackupRestore extends Command
     /**
      * @inheritdoc
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $restore = true;
         if ($input->getOption('force')) {
@@ -87,6 +87,7 @@ class BackupRestore extends Command
             if ($restore) {
                 $this->restore->run($input, $output);
             }
+            return 0;
         } catch (\Exception $exception) {
             $this->logger->critical($exception->getMessage());
             return 1;

--- a/src/Filesystem/BackupList.php
+++ b/src/Filesystem/BackupList.php
@@ -36,8 +36,8 @@ class BackupList
     public function getList(): array
     {
         return [
-            realpath($this->fileList->getEnv()) ?: $this->fileList->getEnv(),
-            realpath($this->fileList->getConfig()) ?: $this->fileList->getConfig(),
+            'app/etc/env.php' => $this->fileList->getEnv(),
+            'app/etc/config.php' => $this->fileList->getConfig(),
         ];
     }
 }

--- a/src/Filesystem/BackupList.php
+++ b/src/Filesystem/BackupList.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Filesystem;
+
+/**
+ * Class contains the list of files for backup
+ */
+class BackupList
+{
+    /**
+     * @var FileList
+     */
+    private $fileList;
+
+    /**
+     * Suffix for backup files
+     */
+    const BACKUP_SUFFIX = '.bak';
+
+    /**
+     * @param FileList $fileList
+     */
+    public function __construct(FileList $fileList)
+    {
+        $this->fileList = $fileList;
+    }
+
+    /**
+     * Returns a list of files for backup
+     *
+     * @return array
+     */
+    public function getList(): array
+    {
+        return [
+            realpath($this->fileList->getEnv()),
+            realpath($this->fileList->getConfig()),
+        ];
+    }
+}

--- a/src/Filesystem/BackupList.php
+++ b/src/Filesystem/BackupList.php
@@ -36,8 +36,8 @@ class BackupList
     public function getList(): array
     {
         return [
-            realpath($this->fileList->getEnv()),
-            realpath($this->fileList->getConfig()),
+            realpath($this->fileList->getEnv()) ?: $this->fileList->getEnv(),
+            realpath($this->fileList->getConfig()) ?: $this->fileList->getConfig(),
         ];
     }
 }

--- a/src/Process/PostDeploy/Backup.php
+++ b/src/Process/PostDeploy/Backup.php
@@ -51,7 +51,7 @@ class Backup implements ProcessInterface
      */
     public function execute()
     {
-        $this->logger->info('Create backup important files.');
+        $this->logger->info('Create backup of important files.');
 
         foreach ($this->backupList->getList() as $file) {
             if (!$this->file->isExists($file)) {

--- a/src/Process/PostDeploy/Backup.php
+++ b/src/Process/PostDeploy/Backup.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Process\PostDeploy;
+
+use Magento\MagentoCloud\Process\ProcessInterface;
+use Magento\MagentoCloud\Filesystem\BackupList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Creates backup Magento files
+ * @see \Magento\MagentoCloud\Filesystem\BackupList contains the list of files for backup
+ */
+class Backup implements ProcessInterface
+{
+    /**
+     * @var BackupList
+     */
+    private $backupList;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var File
+     */
+    private $file;
+
+    /**
+     * @param BackupList $backupList
+     * @param File $file
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        BackupList $backupList,
+        File $file,
+        LoggerInterface $logger
+    ) {
+        $this->backupList = $backupList;
+        $this->file = $file;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        $this->logger->info('Create backup important files.');
+
+        foreach ($this->backupList->getList() as $file) {
+            if (!$this->file->isExists($file)) {
+                $this->logger->notice(sprintf('File %s does not exist. Skipped.', $file));
+                continue;
+            }
+
+            $backup = $file . BackupList::BACKUP_SUFFIX;
+            $this->file->copy($file, $backup);
+            $this->logger->info(sprintf('Backup %s for %s was created.', $backup, $file));
+        }
+    }
+}

--- a/src/Test/Unit/ApplicationTest.php
+++ b/src/Test/Unit/ApplicationTest.php
@@ -14,6 +14,7 @@ use Magento\MagentoCloud\Command\CronUnlock;
 use Magento\MagentoCloud\Command\Deploy;
 use Magento\MagentoCloud\Command\DbDump;
 use Magento\MagentoCloud\Command\PostDeploy;
+use Magento\MagentoCloud\Command\BackupRestore;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -66,24 +67,16 @@ class ApplicationTest extends TestCase
         $configDumpCommand = $this->createMock(ConfigDump::class);
         $postDeployCommand = $this->createMock(PostDeploy::class);
         $dbDumpCommand = $this->createMock(DbDump::class);
+        $cronUnlockCommand = $this->createMock(CronUnlock::class);
+        $backupRestoreCommand = $this->createMock(BackupRestore::class);
 
         $this->mockCommand($buildCommandMock, Build::NAME);
         $this->mockCommand($deployCommandMock, Deploy::NAME);
         $this->mockCommand($configDumpCommand, ConfigDump::NAME);
         $this->mockCommand($postDeployCommand, PostDeploy::NAME);
         $this->mockCommand($dbDumpCommand, DbDump::NAME);
-        /**
-         * Command mocks.
-         */
-        $buildCommandMock = $this->createMock(Build::class);
-        $deployCommandMock = $this->createMock(Deploy::class);
-        $configDumpCommand = $this->createMock(ConfigDump::class);
-        $cronUnlockCommand = $this->createMock(CronUnlock::class);
-
-        $this->mockCommand($buildCommandMock, Build::NAME);
-        $this->mockCommand($deployCommandMock, Deploy::NAME);
-        $this->mockCommand($configDumpCommand, ConfigDump::NAME);
         $this->mockCommand($cronUnlockCommand, CronUnlock::NAME);
+        $this->mockCommand($backupRestoreCommand, BackupRestore::class);
 
         $this->containerMock->method('get')
             ->willReturnMap([
@@ -93,10 +86,8 @@ class ApplicationTest extends TestCase
                 [ConfigDump::class, $configDumpCommand],
                 [PostDeploy::class, $postDeployCommand],
                 [DbDump::class, $dbDumpCommand],
-                [Build::class, $buildCommandMock],
-                [Deploy::class, $deployCommandMock],
-                [ConfigDump::class, $configDumpCommand],
                 [CronUnlock::class, $cronUnlockCommand],
+                [BackupRestore::class, $backupRestoreCommand]
             ]);
         $this->composerMock->method('getPackage')
             ->willReturn($this->packageMock);

--- a/src/Test/Unit/ApplicationTest.php
+++ b/src/Test/Unit/ApplicationTest.php
@@ -8,6 +8,7 @@ namespace Unit;
 use Composer\Composer;
 use Composer\Package\PackageInterface;
 use Magento\MagentoCloud\Application;
+use Magento\MagentoCloud\Command\BackupList;
 use Magento\MagentoCloud\Command\Build;
 use Magento\MagentoCloud\Command\ConfigDump;
 use Magento\MagentoCloud\Command\CronUnlock;
@@ -18,6 +19,9 @@ use Magento\MagentoCloud\Command\BackupRestore;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class ApplicationTest extends TestCase
 {
     /**
@@ -69,6 +73,7 @@ class ApplicationTest extends TestCase
         $dbDumpCommand = $this->createMock(DbDump::class);
         $cronUnlockCommand = $this->createMock(CronUnlock::class);
         $backupRestoreCommand = $this->createMock(BackupRestore::class);
+        $backupListCommand = $this->createMock(BackupList::class);
 
         $this->mockCommand($buildCommandMock, Build::NAME);
         $this->mockCommand($deployCommandMock, Deploy::NAME);
@@ -77,6 +82,7 @@ class ApplicationTest extends TestCase
         $this->mockCommand($dbDumpCommand, DbDump::NAME);
         $this->mockCommand($cronUnlockCommand, CronUnlock::NAME);
         $this->mockCommand($backupRestoreCommand, BackupRestore::class);
+        $this->mockCommand($backupListCommand, BackupList::class);
 
         $this->containerMock->method('get')
             ->willReturnMap([
@@ -87,7 +93,8 @@ class ApplicationTest extends TestCase
                 [PostDeploy::class, $postDeployCommand],
                 [DbDump::class, $dbDumpCommand],
                 [CronUnlock::class, $cronUnlockCommand],
-                [BackupRestore::class, $backupRestoreCommand]
+                [BackupRestore::class, $backupRestoreCommand],
+                [BackupList::class, $backupListCommand],
             ]);
         $this->composerMock->method('getPackage')
             ->willReturn($this->packageMock);

--- a/src/Test/Unit/Command/Backup/FileListTest.php
+++ b/src/Test/Unit/Command/Backup/FileListTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Command\Backup;
+
+use Magento\MagentoCloud\Command\Backup\FileList;
+use Magento\MagentoCloud\Filesystem\BackupList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+class FileListTest extends TestCase
+{
+    /**
+     * @var BackupList|Mock
+     */
+    private $backupListMock;
+
+    /**
+     * @var File|Mock
+     */
+    private $fileMock;
+
+    /**
+     * @var FileList
+     */
+    private $fileList;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->backupListMock = $this->createMock(BackupList::class);
+        $this->fileMock = $this->createMock(File::class);
+
+        $this->fileList = new FileList($this->backupListMock, $this->fileMock);
+    }
+
+    public function testGet()
+    {
+        $this->backupListMock->expects($this->once())
+            ->method('getList')
+            ->willReturn([
+                'config.php' => 'path/config.php',
+                'env.php' => 'path/env.php',
+            ]);
+        $this->fileMock->expects($this->exactly(2))
+            ->method('isExists')
+            ->willReturnMap([
+                ['path/config.php' . BackupList::BACKUP_SUFFIX, false],
+                ['path/env.php' . BackupList::BACKUP_SUFFIX, true],
+            ]);
+
+        $this->assertSame(['env.php'], $this->fileList->get());
+    }
+}

--- a/src/Test/Unit/Command/Backup/RestoreTest.php
+++ b/src/Test/Unit/Command/Backup/RestoreTest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Command\Backup;
+
+use Magento\MagentoCloud\Command\Backup\Restore;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\MagentoCloud\Filesystem\BackupList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+class RestoreTest extends TestCase
+{
+    /**
+     * @var BackupList|Mock
+     */
+    private $backupListMock;
+
+    /**
+     * @var File|Mock
+     */
+    private $fileMock;
+
+    /**
+     * @var Restore
+     */
+    private $restore;
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp()
+    {
+        $this->backupListMock = $this->createMock(BackupList::class);
+        $this->fileMock = $this->createMock(File::class);
+
+        $this->restore = new Restore($this->backupListMock, $this->fileMock);
+    }
+
+    /**
+     * @param int $getOptionExpects
+     * @param string $fileOption
+     * @param bool $forceOption
+     * @param int $isExistsExpects
+     * @param bool $backupExists
+     * @param bool $fileExists
+     * @param int $copyExpects
+     * @param string $writeLnMsg
+     * @dataProvider runDataProvider
+     */
+    public function testRun(
+        int $getOptionExpects,
+        string $fileOption,
+        bool $forceOption,
+        int $isExistsExpects,
+        bool $backupExists,
+        bool $fileExists,
+        int $copyExpects,
+        string $writeLnMsg
+    ) {
+        $aliasPath = 'config.php';
+        $filePath = 'path/config.php';
+        $backupPath = $filePath . BackupList::BACKUP_SUFFIX;
+
+        /** @var InputInterface|Mock $inputMock */
+        $inputMock = $this->getMockBuilder(InputInterface::class)
+            ->getMockForAbstractClass();
+        /** @var OutputInterface|Mock $outputMock */
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
+            ->getMockForAbstractClass();
+
+        $inputMock->expects($this->exactly($getOptionExpects))
+            ->method('getOption')
+            ->willReturnMap([
+                ['file', $fileOption],
+                ['force', $forceOption],
+            ]);
+        $this->backupListMock->expects($this->once())
+            ->method('getList')
+            ->willReturn([$aliasPath => $filePath]);
+        $this->fileMock->expects($this->exactly($isExistsExpects))
+            ->method('isExists')
+            ->willReturnMap([
+                [$backupPath, $backupExists],
+                [$filePath, $fileExists],
+            ]);
+        $this->fileMock->expects($this->exactly($copyExpects))
+            ->method('copy')
+            ->with($backupPath, $filePath);
+        $outputMock->expects($this->once())
+            ->method('writeln')
+            ->with($writeLnMsg);
+
+        $this->restore->run($inputMock, $outputMock);
+    }
+
+    /**
+     * @return array
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function runDataProvider(): array
+    {
+        return [
+            [
+                'getOptionExpects' => 2,
+                'fileOption' => '',
+                'forceOption' => false,
+                'isExistsExpects' => 2,
+                'backupExists' => true,
+                'fileExists' => true,
+                'copyExpects' => 0,
+                'writeLnMsg' => '<info>config.php file exists!</info>'
+                    . ' <comment>If you want to rewrite existed files use --force</comment>'
+            ],
+            [
+                'getOptionExpects' => 2,
+                'fileOption' => '',
+                'forceOption' => true,
+                'isExistsExpects' => 2,
+                'backupExists' => true,
+                'fileExists' => true,
+                'copyExpects' => 1,
+                'writeLnMsg' => '<info>Backup file config.php was restored.</info>'
+            ],
+            [
+                'getOptionExpects' => 1,
+                'fileOption' => '',
+                'forceOption' => true,
+                'isExistsExpects' => 2,
+                'backupExists' => true,
+                'fileExists' => false,
+                'copyExpects' => 1,
+                'writeLnMsg' => '<info>Backup file config.php was restored.</info>'
+            ],
+            [
+                'getOptionExpects' => 1,
+                'fileOption' => '',
+                'forceOption' => false,
+                'isExistsExpects' => 2,
+                'backupExists' => true,
+                'fileExists' => false,
+                'copyExpects' => 1,
+                'writeLnMsg' => '<info>Backup file config.php was restored.</info>'
+            ],
+            [
+                'getOptionExpects' => 1,
+                'fileOption' => '',
+                'forceOption' => false,
+                'isExistsExpects' => 1,
+                'backupExists' => false,
+                'fileExists' => false,
+                'copyExpects' => 0,
+                'writeLnMsg' => '<info>Backup for config.php does not exist.</info> <comment>Skipped.</comment>'
+            ],
+            [
+                'getOptionExpects' => 2,
+                'fileOption' => 'config.php',
+                'forceOption' => false,
+                'isExistsExpects' => 2,
+                'backupExists' => true,
+                'fileExists' => true,
+                'copyExpects' => 0,
+                'writeLnMsg' => '<info>config.php file exists!</info>'
+                    . ' <comment>If you want to rewrite existed files use --force</comment>'
+            ],
+            [
+                'getOptionExpects' => 2,
+                'fileOption' => 'config.php',
+                'forceOption' => true,
+                'isExistsExpects' => 2,
+                'backupExists' => true,
+                'fileExists' => true,
+                'copyExpects' => 1,
+                'writeLnMsg' => '<info>Backup file config.php was restored.</info>'
+            ],
+            [
+                'getOptionExpects' => 1,
+                'fileOption' => 'config.php',
+                'forceOption' => true,
+                'isExistsExpects' => 2,
+                'backupExists' => true,
+                'fileExists' => false,
+                'copyExpects' => 1,
+                'writeLnMsg' => '<info>Backup file config.php was restored.</info>'
+            ],
+            [
+                'getOptionExpects' => 1,
+                'fileOption' => 'config.php',
+                'forceOption' => false,
+                'isExistsExpects' => 2,
+                'backupExists' => true,
+                'fileExists' => false,
+                'copyExpects' => 1,
+                'writeLnMsg' => '<info>Backup file config.php was restored.</info>'
+            ],
+            [
+                'getOptionExpects' => 1,
+                'fileOption' => 'config.php',
+                'forceOption' => false,
+                'isExistsExpects' => 1,
+                'backupExists' => false,
+                'fileExists' => false,
+                'copyExpects' => 0,
+                'writeLnMsg' => '<info>Backup for config.php does not exist.</info> <comment>Skipped.</comment>'
+            ],
+            [
+                'getOptionExpects' => 1,
+                'fileOption' => 'some.php',
+                'forceOption' => false,
+                'isExistsExpects' => 0,
+                'backupExists' => false,
+                'fileExists' => false,
+                'copyExpects' => 0,
+                'writeLnMsg' => '<error>There is no some.php file in the backup list.</error>'
+                    . ' <comment>Run backup:list to show files from backup list.</comment>'
+            ],
+        ];
+    }
+}

--- a/src/Test/Unit/Command/BackupListTest.php
+++ b/src/Test/Unit/Command/BackupListTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Command;
+
+use Magento\MagentoCloud\Command\BackupList;
+use Symfony\Component\Console\Tester\CommandTester;
+use PHPUnit\Framework\TestCase;
+use Magento\MagentoCloud\Command\Backup\FileList as BackupFilesList;
+use Psr\Log\LoggerInterface;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+class BackupListTest extends TestCase
+{
+    /**
+     * @var BackupFilesList|Mock
+     */
+    private $backupFilesListMock;
+
+    /**
+     * @var LoggerInterface|Mock
+     */
+    private $loggerMock;
+
+    /**
+     * @var BackupList
+     */
+    private $command;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->backupFilesListMock = $this->createMock(BackupFilesList::class);
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->command = new BackupList($this->backupFilesListMock, $this->loggerMock);
+    }
+
+    /**
+     * @param array $backupList
+     * @param string $output
+     * @dataProvider executeDataProvider
+     */
+    public function testExecute(array $backupList, string $output)
+    {
+        $this->loggerMock->expects($this->never())
+            ->method('critical');
+        $this->backupFilesListMock->expects($this->once())
+            ->method('get')
+            ->willReturn($backupList);
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertSame($output, $tester->getDisplay());
+    }
+
+    /**
+     * @return array
+     */
+    public function executeDataProvider(): array
+    {
+        return [
+            [
+                'backupList' => [],
+                'output' => 'The list of backup files:' . PHP_EOL . 'There are no files in the backup' . PHP_EOL,
+            ],
+            [
+                'backupList' => ['app/etc/config.php', 'app/etc/env.php'],
+                'output' => 'The list of backup files:' . PHP_EOL . 'app/etc/config.php'
+                    . PHP_EOL . 'app/etc/env.php' . PHP_EOL,
+            ],
+        ];
+    }
+
+    public function testExecuteWithException()
+    {
+        $this->loggerMock->expects($this->once())
+            ->method('critical')
+            ->with('Sorry error');
+        $this->backupFilesListMock->expects($this->once())
+            ->method('get')
+            ->willThrowException(new \Exception('Sorry error'));
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        $this->assertSame(1, $tester->getStatusCode());
+    }
+}

--- a/src/Test/Unit/Command/BackupListTest.php
+++ b/src/Test/Unit/Command/BackupListTest.php
@@ -78,6 +78,10 @@ class BackupListTest extends TestCase
         ];
     }
 
+    /**
+     * @expectedExceptionMessage Sorry error
+     * @expectedException \Exception
+     */
     public function testExecuteWithException()
     {
         $this->loggerMock->expects($this->once())

--- a/src/Test/Unit/Command/BackupRestoreTest.php
+++ b/src/Test/Unit/Command/BackupRestoreTest.php
@@ -98,6 +98,10 @@ class BackupRestoreTest extends TestCase
         ];
     }
 
+    /**
+     * @expectedExceptionMessage Sorry error
+     * @expectedException \Exception
+     */
     public function testExecuteWithException()
     {
         $this->helperSetMock->expects($this->never())

--- a/src/Test/Unit/Command/BackupRestoreTest.php
+++ b/src/Test/Unit/Command/BackupRestoreTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Command;
+
+use Magento\MagentoCloud\Command\BackupRestore;
+use Magento\MagentoCloud\Command\Backup\Restore;
+use Psr\Log\LoggerInterface;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+
+class BackupRestoreTest extends TestCase
+{
+    /**
+     * @var Restore|Mock
+     */
+    private $restoreMock;
+
+    /**
+     * @var LoggerInterface|Mock
+     */
+    private $loggerMock;
+
+    /**
+     * @var HelperSet|Mock
+     */
+    private $helperSetMock;
+
+    /**
+     * @var QuestionHelper|Mock
+     */
+    private $questionMock;
+
+    /**
+     * @var BackupRestore
+     */
+    private $command;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->restoreMock = $this->createMock(Restore::class);
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->getMockForAbstractClass();
+        $this->questionMock = $this->getMockBuilder(QuestionHelper::class)
+            ->setMethods(['ask'])
+            ->getMock();
+        $this->helperSetMock = $this->createMock(HelperSet::class);
+
+        $this->command = new BackupRestore($this->restoreMock, $this->loggerMock);
+        $this->command->setHelperSet($this->helperSetMock);
+    }
+
+    /**
+     * @param int $askExpected
+     * @param bool $askAnswer
+     * @param array $options
+     * @param int $runExpected
+     * @dataProvider executeDataProvider
+     */
+    public function testExecute(int $askExpected, bool $askAnswer, array $options, int $runExpected)
+    {
+        $this->helperSetMock->expects($this->exactly($askExpected))
+            ->method('get')
+            ->with('question')
+            ->willReturn($this->questionMock);
+        $this->questionMock->expects($this->exactly($askExpected))
+            ->method('ask')
+            ->willReturn($askAnswer);
+        $this->restoreMock->expects($this->exactly($runExpected))
+            ->method('run');
+        $this->loggerMock->expects($this->never())
+            ->method('critical');
+        $tester = new CommandTester($this->command);
+        $tester->execute($options);
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    /**
+     * @return array
+     */
+    public function executeDataProvider(): array
+    {
+        return [
+            ['askExpected' => 0,'askAnswer' => true, 'options' => [], 'runExpected' => 1],
+            ['askExpected' => 0,'askAnswer' => false, 'options' => [], 'runExpected' => 1],
+            ['askExpected' => 1,'askAnswer' => false, 'options' => ['-f' => true], 'runExpected' => 0],
+            ['askExpected' => 1,'askAnswer' => true, 'options' => ['-f' => true], 'runExpected' => 1],
+            ['askExpected' => 1,'askAnswer' => false, 'options' => ['--force' => true], 'runExpected' => 0],
+            ['askExpected' => 1,'askAnswer' => true, 'options' => ['--force' => true], 'runExpected' => 1],
+        ];
+    }
+
+    public function testExecuteWithException()
+    {
+        $this->helperSetMock->expects($this->never())
+            ->method('get')
+            ->with('question')
+            ->willReturn($this->questionMock);
+        $this->questionMock->expects($this->never())
+            ->method('ask');
+        $this->restoreMock->expects($this->once())
+            ->method('run')
+            ->willThrowException(new \Exception('Sorry error'));
+        $this->loggerMock->expects($this->once())
+            ->method('critical')
+            ->with('Sorry error');
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+        $this->assertSame(1, $tester->getStatusCode());
+    }
+}

--- a/src/Test/Unit/Filesystem/BackupListTest.php
+++ b/src/Test/Unit/Filesystem/BackupListTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Filesystem;
+
+use PHPUnit\Framework\TestCase;
+use Magento\MagentoCloud\Filesystem\FileList;
+use Magento\MagentoCloud\Filesystem\BackupList;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+class BackupListTest extends TestCase
+{
+    /**
+     * @var FileList|Mock
+     */
+    private $fileListMock;
+
+    /**
+     * @var BackupList
+     */
+    private $fileBackupList;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->fileListMock = $this->createMock(FileList::class);
+        $this->fileBackupList = new BackupList($this->fileListMock);
+    }
+
+    public function testGetList()
+    {
+        $env = '/some/path/env.php';
+        $config = '/some/path/config.php';
+
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
+            ->willReturn($env);
+        $this->fileListMock->expects($this->once())
+            ->method('getConfig')
+            ->willReturn($config);
+
+        $this->assertSame(
+            [
+                'app/etc/env.php' => $env,
+                'app/etc/config.php' => $config,
+            ],
+            $this->fileBackupList->getList()
+        );
+    }
+}

--- a/src/Test/Unit/Process/PostDeploy/BackupTest.php
+++ b/src/Test/Unit/Process/PostDeploy/BackupTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Process\PostDeploy;
+
+use Magento\MagentoCloud\Process\PostDeploy\Backup;
+use Magento\MagentoCloud\Filesystem\BackupList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+class BackupTest extends TestCase
+{
+    /**
+     * @var BackupList|Mock
+     */
+    private $backupListMock;
+
+    /**
+     * @var LoggerInterface|Mock
+     */
+    private $loggerMock;
+
+    /**
+     * @var File|Mock
+     */
+    private $fileMock;
+
+    /**
+     * @var Backup
+     */
+    private $backup;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->backupListMock = $this->createMock(BackupList::class);
+        $this->fileMock = $this->createMock(File::class);
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->backup = new Backup(
+            $this->backupListMock,
+            $this->fileMock,
+            $this->loggerMock
+        );
+    }
+
+    public function testExecute()
+    {
+        $configPath = 'path/config.php';
+        $envPath = 'path/env.php';
+        $this->backupListMock->expects($this->once())
+            ->method('getList')
+            ->willReturn([
+                'config.php' => $configPath,
+                'env.php' => $envPath,
+            ]);
+        $this->fileMock->expects($this->exactly(2))
+            ->method('isExists')
+            ->willReturnMap([
+                [$configPath, false],
+                ['path/env.php', true],
+            ]);
+        $this->loggerMock->expects($this->once())
+            ->method('notice')
+            ->with('File ' . $configPath . ' does not exist. Skipped.');
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('info')
+            ->withConsecutive(
+                ['Create backup of important files.'],
+                ['Backup ' . $envPath . BackupList::BACKUP_SUFFIX . ' for ' . $envPath . ' was created.']
+            );
+        $this->fileMock->expects($this->once())
+            ->method('copy')
+            ->with($envPath, $envPath . BackupList::BACKUP_SUFFIX);
+
+        $this->backup->execute();
+    }
+}


### PR DESCRIPTION
### Description
After each redeploy will be created backup of configuration files: app/etc/config.php.bak app/etc/env.php.bak

If user removed or broke these files he can restore them using the next command:
./vendor/bin/ece-tools backup:restore

Also user can see available backup files using ./vendor/bin/ece-tools backup:list

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1372

### Zephyr Tests
https://jira.corp.magento.com/browse/MAGETWO-85289

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
