### PR TITLE
MAGECLOUD-1389: Command "ece-tools deploy" running in interaction mode

### DIFF
--- a/src/Process/Deploy/InstallUpdate/Install/Setup.php
+++ b/src/Process/Deploy/InstallUpdate/Install/Setup.php
@@ -81,7 +81,7 @@ class Setup implements ProcessInterface
 
         $command =
             'php ./bin/magento setup:install'
-            . ' --session-save=db --cleanup-database'
+            . ' -n --session-save=db --cleanup-database'
             . ' --currency=' . escapeshellarg($this->environment->getDefaultCurrency())
             . ' --base-url=' . escapeshellarg($urlUnsecure)
             . ' --base-url-secure=' . escapeshellarg($urlSecure)

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Install/SetupTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Install/SetupTest.php
@@ -153,7 +153,7 @@ class SetupTest extends TestCase
             ->method('execute')
             ->with(
                 '/bin/bash -c "set -o pipefail;'
-                . ' php ./bin/magento setup:install --session-save=db --cleanup-database --currency=\'USD\''
+                . ' php ./bin/magento setup:install -n --session-save=db --cleanup-database --currency=\'USD\''
                 . ' --base-url=\'http://unsecure.url\' --base-url-secure=\'https://secure.url\' --language=\'fr_FR\''
                 . ' --timezone=America/Los_Angeles --db-host=\'localhost\' --db-name=\'magento\' --db-user=\'user\''
                 . ' --backend-frontname=\'' . $adminUrlExpected . '\' --admin-user=\'' . $adminNameExpected . '\''


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Installation fails when running  php vendor/magento/ece-tools/bin/ece-tools deploy with custom stores/websites in app/etc/config.php

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1389

### Zephyr Tests

- Add locally config.php with stores
- Push
- Uninstall magento
- Connect by ssh
- Run php vendor/magento/ece-tools/bin/ece-tools deploy

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
