### PR TITLE
MAGECLOUD-1410: Merchants are unable to use their own AMQP & Search servers

### DIFF
--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -434,7 +434,7 @@ class Environment
         $config = $this->getVariable($name, []);
 
         if (!is_array($config)) {
-            $config = json_decode($config, true);
+            $config = (array)json_decode($config, true);
         }
 
         return $config;

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -35,6 +35,8 @@ class Environment
     /**
      * Variables.
      */
+    const VAR_QUEUE_CONFIGURATION = 'QUEUE_CONFIGURATION';
+    const VAR_SEARCH_CONFIGURATION = 'SEARCH_CONFIGURATION';
     const VAR_REDIS_SESSION_DISABLE_LOCKING = 'REDIS_SESSION_DISABLE_LOCKING';
     const VAR_SCD_STRATEGY = Build::OPT_SCD_STRATEGY;
     const VAR_SCD_COMPRESSION_LEVEL = Build::OPT_SCD_COMPRESSION_LEVEL;
@@ -391,13 +393,7 @@ class Environment
      */
     public function getCronConsumersRunner(): array
     {
-        $config = $this->getVariable('CRON_CONSUMERS_RUNNER', []);
-
-        if (!is_array($config)) {
-            $config = json_decode($config, true);
-        }
-
-        return $config;
+        return $this->getJsonVariable('CRON_CONSUMERS_RUNNER');
     }
 
     /**
@@ -425,5 +421,22 @@ class Environment
     {
         return isset($_ENV['MAGENTO_CLOUD_ENVIRONMENT'])
             && preg_match(self::GIT_MASTER_BRANCH_RE, $_ENV['MAGENTO_CLOUD_ENVIRONMENT']);
+    }
+
+    /**
+     * Returns variable that was set in json format.
+     *
+     * @param string $name
+     * @return array
+     */
+    public function getJsonVariable(string $name): array
+    {
+        $config = $this->getVariable($name, []);
+
+        if (!is_array($config)) {
+            $config = json_decode($config, true);
+        }
+
+        return $config;
     }
 }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Amqp.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Amqp.php
@@ -64,9 +64,13 @@ class Amqp implements ProcessInterface
     public function execute()
     {
         $mqConfig = $this->getAmqpConfig();
+        $envQueueConfig = $this->environment->getJsonVariable(Environment::VAR_QUEUE_CONFIGURATION);
         $config = $this->configReader->read();
 
-        if (count($mqConfig)) {
+        if (count($envQueueConfig)) {
+            $this->logger->info('Updating env.php AMQP configuration.');
+            $config['queue'] = $envQueueConfig;
+        } elseif (count($mqConfig)) {
             $this->logger->info('Updating env.php AMQP configuration.');
             $amqpConfig = $mqConfig[0];
             $config['queue']['amqp']['host'] = $amqpConfig['host'];

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Amqp.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Amqp.php
@@ -59,7 +59,15 @@ class Amqp implements ProcessInterface
     }
 
     /**
-     * @inheritdoc
+     * Saves configuration for queue services.
+     *
+     * This method set queue configuration from environment variable QUEUE_CONFIGURATION.
+     * If QUEUE_CONFIGURATION variable is not set then configuration gets from relationships.
+     *
+     * Removes old queue configuration from env.php if there is no any queue configuration in
+     * relationships or environment variable.
+     *
+     * {@inheritdoc}
      */
     public function execute()
     {

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
@@ -64,7 +64,7 @@ class SearchEngine implements ProcessInterface
     private function getSearchConfiguration(): array
     {
         $envSearchConfiguration = $this->environment->getJsonVariable(Environment::VAR_SEARCH_CONFIGURATION);
-        if ($this->isValidSearchConfiguration($envSearchConfiguration)) {
+        if ($this->isSearchConfigurationValid($envSearchConfiguration)) {
             return $envSearchConfiguration;
         }
 
@@ -119,7 +119,7 @@ class SearchEngine implements ProcessInterface
      * @param array $searchConfiguration
      * @return bool
      */
-    private function isValidSearchConfiguration(array $searchConfiguration): bool
+    private function isSearchConfigurationValid(array $searchConfiguration): bool
     {
         return !empty($searchConfiguration) && isset($searchConfiguration['engine']);
     }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
@@ -51,6 +51,23 @@ class SearchEngine implements ProcessInterface
     {
         $this->logger->info('Updating search engine configuration.');
 
+        $searchConfig = $this->getSearchConfiguration();
+
+        $this->logger->info('Set search engine to: ' . $searchConfig['engine']);
+        $config['system']['default']['catalog']['search'] = $searchConfig;
+        $this->writer->update($config);
+    }
+
+    /**
+     * @return array
+     */
+    private function getSearchConfiguration(): array
+    {
+        $envSearchConfiguration = $this->environment->getJsonVariable(Environment::VAR_SEARCH_CONFIGURATION);
+        if ($this->isValidSearchConfiguration($envSearchConfiguration)) {
+            return $envSearchConfiguration;
+        }
+
         $relationships = $this->environment->getRelationships();
 
         if (isset($relationships['elasticsearch'])) {
@@ -61,9 +78,7 @@ class SearchEngine implements ProcessInterface
             $searchConfig = ['engine' => 'mysql'];
         }
 
-        $this->logger->info('Set search engine to: ' . $searchConfig['engine']);
-        $config['system']['default']['catalog']['search'] = $searchConfig;
-        $this->writer->update($config);
+        return $searchConfig;
     }
 
     /**
@@ -96,5 +111,16 @@ class SearchEngine implements ProcessInterface
             'elasticsearch_server_hostname' => $config['host'],
             'elasticsearch_server_port' => $config['port'],
         ];
+    }
+
+    /**
+     * Checks that given configuration is valid.
+     *
+     * @param array $searchConfiguration
+     * @return bool
+     */
+    private function isValidSearchConfiguration(array $searchConfiguration): bool
+    {
+        return !empty($searchConfiguration) && isset($searchConfiguration['engine']);
     }
 }

--- a/src/Test/Unit/Config/EnvironmentTest.php
+++ b/src/Test/Unit/Config/EnvironmentTest.php
@@ -404,5 +404,4 @@ class EnvironmentTest extends TestCase
             ],
         ];
     }
-
 }

--- a/src/Test/Unit/Config/EnvironmentTest.php
+++ b/src/Test/Unit/Config/EnvironmentTest.php
@@ -342,4 +342,37 @@ class EnvironmentTest extends TestCase
             ]
         ];
     }
+
+    /**
+     * @param array $variables
+     * @dataProvider getJsonVariableDataProvider
+     */
+    public function testGetJsonVariable(array $variables)
+    {
+        $this->setVariables($variables);
+
+        $this->assertEquals(
+            [
+                'option1' => 'value1',
+                'option2' => 'value2',
+            ],
+            $this->environment->getJsonVariable('SOME_VARIABLE')
+        );
+    }
+
+    public function getJsonVariableDataProvider()
+    {
+        return [
+            [['SOME_VARIABLE' => '{"option1":"value1", "option2":"value2"}']],
+            [
+                [
+                    'SOME_VARIABLE' => [
+                        'option1' => 'value1',
+                        'option2' => 'value2',
+                    ]
+                ]
+            ],
+        ];
+    }
+
 }

--- a/src/Test/Unit/Config/EnvironmentTest.php
+++ b/src/Test/Unit/Config/EnvironmentTest.php
@@ -345,17 +345,15 @@ class EnvironmentTest extends TestCase
 
     /**
      * @param array $variables
+     * @param array $expected
      * @dataProvider getJsonVariableDataProvider
      */
-    public function testGetJsonVariable(array $variables)
+    public function testGetJsonVariable(array $variables, array $expected)
     {
         $this->setVariables($variables);
 
         $this->assertEquals(
-            [
-                'option1' => 'value1',
-                'option2' => 'value2',
-            ],
+            $expected,
             $this->environment->getJsonVariable('SOME_VARIABLE')
         );
     }
@@ -363,13 +361,45 @@ class EnvironmentTest extends TestCase
     public function getJsonVariableDataProvider()
     {
         return [
-            [['SOME_VARIABLE' => '{"option1":"value1", "option2":"value2"}']],
+            [
+                [
+                    'SOME_VARIABLE' => ''
+                ],
+                []
+            ],
+            [
+                [
+                    'SOME_VARIABLE' => 'not json string'
+                ],
+                []
+            ],
+            [
+                [
+                    'SOME_VARIABLE' => 12345
+                ],
+                [
+                    12345
+                ]
+            ],
+            [
+                [
+                    'SOME_VARIABLE' => '{"option1":"value1", "option2":"value2"}'
+                ],
+                [
+                    'option1' => 'value1',
+                    'option2' => 'value2',
+                ]
+            ],
             [
                 [
                     'SOME_VARIABLE' => [
                         'option1' => 'value1',
                         'option2' => 'value2',
                     ]
+                ],
+                [
+                    'option1' => 'value1',
+                    'option2' => 'value2',
                 ]
             ],
         ];

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/AmqpTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/AmqpTest.php
@@ -130,6 +130,7 @@ class AmqpTest extends TestCase
 
     /**
      * @return array
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function executeAddUpdateDataProvider(): array
     {

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/AmqpTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/AmqpTest.php
@@ -67,6 +67,10 @@ class AmqpTest extends TestCase
     public function testExecuteWithoutAmqp()
     {
         $config = ['some config'];
+        $this->environmentMock->expects($this->once())
+            ->method('getJsonVariable')
+            ->with(Environment::VAR_QUEUE_CONFIGURATION)
+            ->willReturn([]);
         $this->environmentMock->expects($this->any())
             ->method('getRelationship')
             ->with($this->anything())
@@ -85,11 +89,22 @@ class AmqpTest extends TestCase
 
     /**
      * @param array $config
+     * @param array $envQueueConfig
+     * @param array $amqpConfig
+     * @param array $resultConfig
      * @return void
      * @dataProvider executeAddUpdateDataProvider
      */
-    public function testExecuteAddUpdate(array $config, array $amqpConfig, array $resultConfig)
-    {
+    public function testExecuteAddUpdate(
+        array $config,
+        array $envQueueConfig,
+        array $amqpConfig,
+        array $resultConfig
+    ) {
+        $this->environmentMock->expects($this->once())
+            ->method('getJsonVariable')
+            ->with(Environment::VAR_QUEUE_CONFIGURATION)
+            ->willReturn($envQueueConfig);
         $this->environmentMock->expects($this->exactly(2))
             ->method('getRelationship')
             ->withConsecutive(
@@ -121,6 +136,7 @@ class AmqpTest extends TestCase
         return [
             [
                 ['some config'],
+                [],
                 [[
                     'host' => 'localhost',
                     'port' => '777',
@@ -144,6 +160,7 @@ class AmqpTest extends TestCase
             ],
             [
                 ['some config'],
+                [],
                 [[
                     'host' => 'localhost',
                     'port' => '777',
@@ -178,6 +195,7 @@ class AmqpTest extends TestCase
                         ]
                     ],
                 ],
+                [],
                 [[
                     'host' => 'localhost',
                     'port' => '777',
@@ -198,7 +216,48 @@ class AmqpTest extends TestCase
                         ]
                     ],
                 ]
-            ]
+            ],
+            [
+                [
+                    'some config',
+                    'queue' => [
+                        'amqp' => [
+                            'host' => 'some-host',
+                            'port' => '888',
+                            'user' => 'mylogin',
+                            'password' => 'mysqwwd',
+                            'virtualhost' => 'virtualhost',
+                            'ssl' => '1',
+                        ]
+                    ],
+                ],
+                [
+                    'amqp' => [
+                        'host' => 'env-config-host',
+                        'port' => 'env-config-port',
+                        'user' => 'env-config-user',
+                        'password' => 'env-config-password',
+                    ]
+                ],
+                [[
+                    'host' => 'localhost',
+                    'port' => '777',
+                    'username' => 'login',
+                    'password' => 'pswd',
+                    'vhost' => 'virtualhost'
+                ]],
+                [
+                    'some config',
+                    'queue' => [
+                        'amqp' => [
+                            'host' => 'env-config-host',
+                            'port' => 'env-config-port',
+                            'user' => 'env-config-user',
+                            'password' => 'env-config-password',
+                        ]
+                    ],
+                ]
+            ],
         ];
     }
 
@@ -210,6 +269,10 @@ class AmqpTest extends TestCase
      */
     public function testExecuteRemoveAmqp(array $config, array $expectedConfig)
     {
+        $this->environmentMock->expects($this->once())
+            ->method('getJsonVariable')
+            ->with(Environment::VAR_QUEUE_CONFIGURATION)
+            ->willReturn([]);
         $this->environmentMock->expects($this->any())
             ->method('getRelationship')
             ->with($this->anything())

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngineTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngineTest.php
@@ -51,6 +51,10 @@ class SearchEngineTest extends TestCase
     {
         $config['system']['default']['catalog']['search'] = ['engine' => 'mysql'];
         $this->environmentMock->expects($this->once())
+            ->method('getJsonVariable')
+            ->with(Environment::VAR_SEARCH_CONFIGURATION)
+            ->willReturn([]);
+        $this->environmentMock->expects($this->once())
             ->method('getRelationships')
             ->willReturn([]);
         $this->writerMock->expects($this->once())
@@ -74,6 +78,10 @@ class SearchEngineTest extends TestCase
             'elasticsearch_server_port' => 1234
         ];
 
+        $this->environmentMock->expects($this->once())
+            ->method('getJsonVariable')
+            ->with(Environment::VAR_SEARCH_CONFIGURATION)
+            ->willReturn([]);
         $this->environmentMock->expects($this->once())
             ->method('getRelationships')
             ->willReturn(
@@ -108,6 +116,11 @@ class SearchEngineTest extends TestCase
             'solr_server_username' => 'scheme',
             'solr_server_path' => 'path'
         ];
+
+        $this->environmentMock->expects($this->once())
+            ->method('getJsonVariable')
+            ->with(Environment::VAR_SEARCH_CONFIGURATION)
+            ->willReturn([]);
         $this->environmentMock->expects($this->once())
             ->method('getRelationships')
             ->willReturn(
@@ -130,6 +143,38 @@ class SearchEngineTest extends TestCase
             ->withConsecutive(
                 ['Updating search engine configuration.'],
                 ['Set search engine to: solr']
+            );
+
+        $this->process->execute();
+    }
+
+    public function testExecuteEnvironmentConfiguration()
+    {
+        $config['system']['default']['catalog']['search'] = [
+            'engine' => 'elasticsearch',
+            'elasticsearch_server_hostname' => 'elasticsearch_host',
+            'elasticsearch_server_port' => 'elasticsearch_port'
+        ];
+
+        $this->environmentMock->expects($this->once())
+            ->method('getJsonVariable')
+            ->with(Environment::VAR_SEARCH_CONFIGURATION)
+            ->willReturn([
+                'engine' => 'elasticsearch',
+                'elasticsearch_server_hostname' => 'elasticsearch_host',
+                'elasticsearch_server_port' => 'elasticsearch_port'
+            ]);
+        $this->environmentMock->expects($this->never())
+            ->method('getRelationships');
+
+        $this->writerMock->expects($this->once())
+            ->method('update')
+            ->with($config);
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('info')
+            ->withConsecutive(
+                ['Updating search engine configuration.'],
+                ['Set search engine to: elasticsearch']
             );
 
         $this->process->execute();


### PR DESCRIPTION
### Description
Provides possibility to configure own queue and search services.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1410

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
https://jira.corp.magento.com/browse/MAGETWO-85543
https://jira.corp.magento.com/browse/MAGETWO-85547

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
