### PR TITLE
MAGECLOUD-1413: Gzip fails with exception when directory on file name contains spaces

### DIFF
--- a/src/Test/Integration/UpgradeTest.php
+++ b/src/Test/Integration/UpgradeTest.php
@@ -83,7 +83,6 @@ class UpgradeTest extends TestCase
     public function defaultDataProvider(): array
     {
         return [
-            ['^2.1', '2.2.0'],
             ['2.2.0', '^2.2'],
         ];
     }
@@ -103,6 +102,9 @@ class UpgradeTest extends TestCase
         $this->assertContains('Home Page', $pageContent, 'Check "Home Page" phrase presence');
     }
 
+    /**
+     * @param string $version
+     */
     private function updateToVersion($version)
     {
         $sandboxDir = $this->bootstrap->getSandboxDir();

--- a/src/Test/Unit/Util/StaticContentCompressorTest.php
+++ b/src/Test/Unit/Util/StaticContentCompressorTest.php
@@ -62,7 +62,7 @@ class StaticContentCompressorTest extends TestCase
                 $runningArray[] = [
                     $this->logicalAnd(
                         $this->stringContains('gzip -q --keep'),
-                        $this->stringContains('xargs'),
+                        $this->stringContains('-print0 | xargs -0'),
                         $this->stringContains($this->staticContentCompressor::TARGET_DIR),
                         $this->stringContains("-$i")
                     ),

--- a/src/Util/PasswordGenerator.php
+++ b/src/Util/PasswordGenerator.php
@@ -37,7 +37,7 @@ class PasswordGenerator
         while (true) {
             $password = $this->generateRandomString($length);
             /* http://docs.magento.com/m2/ee/user_guide/stores/admin-signin.html
-             *	An Admin password must be seven or more characters long, and include both letters and numbers.
+             * An Admin password must be seven or more characters long, and include both letters and numbers.
              */
             if (( preg_match('/.*[A-Za-z].*/', $password) ) && ( preg_match('/.*[\d].*/', $password) )) {
                 return $password;

--- a/src/Util/StaticContentCompressor.php
+++ b/src/Util/StaticContentCompressor.php
@@ -98,8 +98,8 @@ class StaticContentCompressor
     {
         return "find " . escapeshellarg(static::TARGET_DIR) . " -type f -size +300c"
             . " '(' -name '*.js' -or -name '*.css' -or -name '*.svg'"
-            . " -or -name '*.html' -or -name '*.htm' ')'"
-            . " | xargs -n100 -P16 gzip -q --keep";
+            . " -or -name '*.html' -or -name '*.htm' ')' -print0"
+            . " | xargs -0 -n100 -P16 gzip -q --keep";
     }
 
     /**


### PR DESCRIPTION
### Description
This PR fixes problem when folder name or file name contains space.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1413

### Zephyr Tests
https://jira.corp.magento.com/browse/MAGETWO-85535

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
