### PR TITLE
MAGECLOUD-1446: Deploy static content in compact strategy shouldn't use process-per-locale

### DIFF
--- a/src/Process/Build/DeployStaticContent/Generate.php
+++ b/src/Process/Build/DeployStaticContent/Generate.php
@@ -84,13 +84,9 @@ class Generate implements ProcessInterface
 
             $this->logger->info($logMessage);
 
-            $parallelCommands = $this->commandFactory->createParallel($this->buildOption);
+            $command = $this->commandFactory->create($this->buildOption);
 
-            $this->shell->execute(sprintf(
-                "printf '%s' | xargs -I CMD -P %d bash -c CMD",
-                $parallelCommands,
-                $threadCount
-            ));
+            $this->shell->execute($command);
         } catch (\Exception $e) {
             throw new \Exception($e->getMessage(), 5);
         }

--- a/src/Test/Unit/Process/Build/DeployStaticContent/GenerateTest.php
+++ b/src/Test/Unit/Process/Build/DeployStaticContent/GenerateTest.php
@@ -71,6 +71,7 @@ class GenerateTest extends TestCase
 
     public function testExecute()
     {
+        $command = 'setup:static-content:deploy with locales';
         $this->optionMock->expects($this->once())
             ->method('getLocales')
             ->willReturn(['ua_UA', 'fr_FR', 'es_ES', 'en_US']);
@@ -82,14 +83,12 @@ class GenerateTest extends TestCase
                 ["Generating static content for locales: ua_UA fr_FR es_ES en_US\nUsing 3 Threads"]
             );
         $this->commandFactoryMock->expects($this->once())
-            ->method('createParallel')
+            ->method('create')
             ->with($this->optionMock)
-            ->willReturn('some parallel command');
+            ->willReturn($command);
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with(
-                "printf 'some parallel command' | xargs -I CMD -P 3 bash -c CMD"
-            );
+            ->with($command);
 
         $this->process->execute();
     }


### PR DESCRIPTION
[MAGECLOUD-1446](https://magento2.atlassian.net/browse/MAGECLOUD-1446)  Deploy static content in compact strategy shouldn't use process-per-locale

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Compact strategy for static-content deploy is optimized to work in one process with all locales provided as arguments. 

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. [MAGETWO-75682](https://jira.corp.magento.com/browse/MAGETWO-75682) SCD with different strategies on Build phase 
2. [MAGETWO-70956](https://jira.corp.magento.com/browse/MAGETWO-70956) SCD does not create data for admin specified locales on Build phase

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
