### PR TITLE
MAGECLOUD-1520: Initial builds failing

### DIFF
--- a/src/DB/Connection.php
+++ b/src/DB/Connection.php
@@ -137,7 +137,7 @@ class Connection implements ConnectionInterface
         try {
             $this->pdo->query('SELECT 1');
         } catch (\Exception $e) {
-            if ($this->pdo->errorCode() !== self::MYSQL_ERROR_CODE_SERVER_GONE_AWAY) {
+            if ($this->pdo->errorInfo()[1] !== self::MYSQL_ERROR_CODE_SERVER_GONE_AWAY) {
                 throw $e;
             }
 

--- a/src/DB/Connection.php
+++ b/src/DB/Connection.php
@@ -13,6 +13,8 @@ use Psr\Log\LoggerInterface;
  */
 class Connection implements ConnectionInterface
 {
+    const MYSQL_ERROR_CODE_SERVER_GONE_AWAY = 2006;
+
     /**
      * @var \PDO
      */
@@ -135,10 +137,11 @@ class Connection implements ConnectionInterface
         try {
             $this->pdo->query('SELECT 1');
         } catch (\Exception $e) {
-            if (stripos($e->getMessage(), 'server has gone away') === false) {
+            if ($this->pdo->errorCode() !== self::MYSQL_ERROR_CODE_SERVER_GONE_AWAY) {
                 throw $e;
             }
 
+            $this->logger->notice('Lost connection to Mysql server. Reconnecting.');
             $this->pdo = null;
             $this->connect();
         }

--- a/src/DB/Connection.php
+++ b/src/DB/Connection.php
@@ -133,7 +133,7 @@ class Connection implements ConnectionInterface
         $this->connect();
 
         try {
-            $this->pdo->prepare('SELECT 1')->execute();
+            $this->pdo->query('SELECT 1');
         } catch (\Exception $e) {
             if (stripos($e->getMessage(), 'server has gone away') === false) {
                 throw $e;

--- a/src/DB/Connection.php
+++ b/src/DB/Connection.php
@@ -134,7 +134,7 @@ class Connection implements ConnectionInterface
 
         try {
             $this->pdo->prepare('SELECT 1')->execute();
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             if (stripos($e->getMessage(), 'server has gone away') === false) {
                 throw $e;
             }

--- a/src/Test/Unit/DB/ConnectionTest.php
+++ b/src/Test/Unit/DB/ConnectionTest.php
@@ -119,8 +119,12 @@ class ConnectionTest extends TestCase
             ->with('SELECT 1')
             ->willThrowException(new \Exception('Some exception'));
         $this->pdoMock->expects($this->once())
-            ->method('errorCode')
-            ->willReturn(0);
+            ->method('errorInfo')
+            ->willReturn([
+                'HY000',
+                2000,
+                'Some message'
+            ]);
 
         $this->connection->getPdo();
     }

--- a/src/Test/Unit/DB/ConnectionTest.php
+++ b/src/Test/Unit/DB/ConnectionTest.php
@@ -107,4 +107,18 @@ class ConnectionTest extends TestCase
     {
         $this->assertSame($this->pdoMock, $this->connection->getPdo());
     }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Some exception
+     */
+    public function testGetPdoWithException()
+    {
+        $this->pdoMock->expects($this->once())
+            ->method('query')
+            ->with('SELECT 1')
+            ->willThrowException(new \Exception('Some exception'));
+
+        $this->connection->getPdo();
+    }
 }

--- a/src/Test/Unit/DB/ConnectionTest.php
+++ b/src/Test/Unit/DB/ConnectionTest.php
@@ -118,6 +118,9 @@ class ConnectionTest extends TestCase
             ->method('query')
             ->with('SELECT 1')
             ->willThrowException(new \Exception('Some exception'));
+        $this->pdoMock->expects($this->once())
+            ->method('errorCode')
+            ->willReturn(0);
 
         $this->connection->getPdo();
     }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Lost connection during deploy phase.
 `Warning: PDOStatement::execute(): MySQL server has gone away in /app/vendor/magento/ece-tools/src/DB/Connection.php on line 93`

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1520

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
From @JacobBrownAustin 
Steps I took to reproduce issue locally:

1. Started with my vagrant environment.
2. Modified MAGENTO_CLOUD_RELATIONSHIPS variable so that the database connection uses 127.0.0.1 instead of localhost. (When it is localhost, it automatically connects via unix domain socket instead of TCP)
3. Modified wait_timeout = 20 in /etc/mysql/my.cnf
4. /etc/init.d/mysql restart
5. Added 'sleep 30' after setup:upgrade in vendor/magento/ece-tools/src/Process/Deploy/InstallUpdate/Update/Setup.php
6. Ran vendor/bin/m2-ece-deploy from /app

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

  