### PR TITLE
MAGECLOUD-1578: Option skip_csd doesn't work if set using build_options.ini file

### DIFF
--- a/src/Config/Stage/Build.php
+++ b/src/Config/Stage/Build.php
@@ -130,7 +130,7 @@ class Build implements BuildInterface
         }
 
         if (isset($buildConfig['skip_scd'])) {
-            $result[self::VAR_SKIP_SCD] = $buildConfig['skip_scd'] === 'yes';
+            $result[self::VAR_SKIP_SCD] = $buildConfig['skip_scd'] === '1';
         }
 
         if (isset($buildConfig['VERBOSE_COMMANDS'])) {

--- a/src/Test/Unit/Config/Stage/BuildTest.php
+++ b/src/Test/Unit/Config/Stage/BuildTest.php
@@ -318,7 +318,7 @@ class BuildTest extends TestCase
                     ],
                 ],
                 [
-                    'skip_scd' => 'yes',
+                    'skip_scd' => '1',
                 ],
                 true,
             ],


### PR DESCRIPTION
### Description
It was the wrong data mapping from ``build_options.ini``
After parsing ``build_options.ini`` the variable skip_scd is '1' instead of 'yes'

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1578

### Zephyr Tests
https://jira.corp.magento.com/browse/MAGETWO-75820

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
