### PR TITLE
MAGECLOUD-1539: Move clearing generated code & metadata to PreBuild process

### DIFF
--- a/src/Filesystem/DirectoryList.php
+++ b/src/Filesystem/DirectoryList.php
@@ -21,6 +21,9 @@ class DirectoryList
     const DIR_INIT = 'init';
     const DIR_VAR = 'var';
     const DIR_LOG = 'log';
+    const DIR_GENERATED = 'generated';
+    const DIR_GENERATED_CODE = 'code';
+    const DIR_GENERATED_METADATA = 'metadata';
 
     /**
      * @var string
@@ -125,14 +128,41 @@ class DirectoryList
     }
 
     /**
+     * @return string
+     */
+    public function getGenerated(): string
+    {
+        return $this->getPath(static::DIR_GENERATED);
+    }
+
+    /**
+     * @return string
+     */
+    public function getGeneratedCode(): string
+    {
+        return $this->getPath(static::DIR_GENERATED_CODE);
+    }
+
+    /**
+     * @return string
+     */
+    public function getGeneratedMetadata(): string
+    {
+        return $this->getPath(static::DIR_GENERATED_METADATA);
+    }
+
+    /**
      * @return array
      */
     public static function getDefaultConfig(): array
     {
         return [
-            static::DIR_INIT => [static::PATH => 'init'],
-            static::DIR_VAR => [static::PATH => 'var'],
-            static::DIR_LOG => [static::PATH => 'var/log'],
+            static::DIR_INIT               => [static::PATH => 'init'],
+            static::DIR_VAR                => [static::PATH => 'var'],
+            static::DIR_LOG                => [static::PATH => 'var/log'],
+            static::DIR_GENERATED          => [static::PATH => 'generated'],
+            static::DIR_GENERATED_CODE     => [static::PATH => 'generated/code'],
+            static::DIR_GENERATED_METADATA => [static::PATH => 'generated/metadata'],
         ];
     }
 }

--- a/src/Process/Build/MarshallFiles.php
+++ b/src/Process/Build/MarshallFiles.php
@@ -45,17 +45,7 @@ class MarshallFiles implements ProcessInterface
     {
         $magentoRoot = $this->directoryList->getMagentoRoot();
         $enterpriseFolder = $magentoRoot . '/app/enterprise';
-        $generatedCode = $magentoRoot . '/generated/code/';
-        $generatedMetadata = $magentoRoot . '/generated/metadata/';
         $varCache = $magentoRoot . '/var/cache/';
-
-        if ($this->file->isExists($generatedCode)) {
-            $this->file->clearDirectory($generatedCode);
-        }
-
-        if ($this->file->isExists($generatedMetadata)) {
-            $this->file->clearDirectory($generatedMetadata);
-        }
 
         if ($this->file->isExists($varCache)) {
             $this->file->deleteDirectory($varCache);

--- a/src/Process/Build/PreBuild.php
+++ b/src/Process/Build/PreBuild.php
@@ -77,10 +77,9 @@ class PreBuild implements ProcessInterface
     public function execute()
     {
         $verbosityLevel = $this->stageConfig->get(BuildInterface::VAR_VERBOSE_COMMANDS);
-        $magentoRoot = $this->directoryList->getMagentoRoot();
         
-        $generatedCode = $magentoRoot . '/generated/code/';
-        $generatedMetadata = $magentoRoot . '/generated/metadata/';
+        $generatedCode     = $this->directoryList->getGeneratedCode();
+        $generatedMetadata = $this->directoryList->getGeneratedMetaData();
         
         $this->logger->info('Verbosity level is ' . ($verbosityLevel ?: 'not set'));
         

--- a/src/Process/Build/PreBuild.php
+++ b/src/Process/Build/PreBuild.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\MagentoCloud\Process\Build;
 
+use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Magento\MagentoCloud\Config\Stage\BuildInterface;
@@ -37,6 +39,16 @@ class PreBuild implements ProcessInterface
     private $flagManager;
 
     /**
+     * @var File
+     */
+    private $file;
+
+    /**
+     * @var DirectoryList
+     */
+    private $directoryList;
+
+    /**
      * PreBuild constructor.
      * @param BuildInterface $stageConfig
      * @param LoggerInterface $logger
@@ -47,12 +59,16 @@ class PreBuild implements ProcessInterface
         BuildInterface $stageConfig,
         LoggerInterface $logger,
         Manager $packageManager,
-        FlagManager $flagManager
+        FlagManager $flagManager,
+        File $file,
+        DirectoryList $directoryList
     ) {
         $this->stageConfig = $stageConfig;
         $this->logger = $logger;
         $this->packageManager = $packageManager;
         $this->flagManager = $flagManager;
+        $this->file = $file;
+        $this->directoryList = $directoryList;
     }
 
     /**
@@ -61,9 +77,23 @@ class PreBuild implements ProcessInterface
     public function execute()
     {
         $verbosityLevel = $this->stageConfig->get(BuildInterface::VAR_VERBOSE_COMMANDS);
-
+        $magentoRoot = $this->directoryList->getMagentoRoot();
+        
+        $generatedCode = $magentoRoot . '/generated/code/';
+        $generatedMetadata = $magentoRoot . '/generated/metadata/';
+        
         $this->logger->info('Verbosity level is ' . ($verbosityLevel ?: 'not set'));
+        
         $this->flagManager->delete(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD);
+        
+        if ($this->file->isExists($generatedCode)) {
+            $this->file->clearDirectory($generatedCode);
+        }
+
+        if ($this->file->isExists($generatedMetadata)) {
+            $this->file->clearDirectory($generatedMetadata);
+        }
+        
         $this->logger->info('Starting build. ' . $this->packageManager->getPrettyInfo());
     }
 }

--- a/src/Test/Unit/Filesystem/DirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/DirectoryListTest.php
@@ -113,4 +113,28 @@ class DirectoryListTest extends TestCase
             $this->directoryList->getLog()
         );
     }
+
+    public function testGetGenerated()
+    {
+        $this->assertSame(
+            __DIR__ . '/generated',
+            $this->directoryList->getGenerated()
+        );
+    }
+
+    public function testGetGeneratedCode()
+    {
+        $this->assertSame(
+            __DIR__ . '/generated/code',
+            $this->directoryList->getGeneratedCode()
+        );
+    }
+
+    public function testGetGeneratedMetadata()
+    {
+        $this->assertSame(
+            __DIR__ . '/generated/metadata',
+            $this->directoryList->getGeneratedMetadata()
+        );
+    }
 }

--- a/src/Test/Unit/Process/Build/MarshallFilesTest.php
+++ b/src/Test/Unit/Process/Build/MarshallFilesTest.php
@@ -53,25 +53,15 @@ class MarshallFilesTest extends TestCase
 
     /**
      * @param bool $isExist
-     * @param int $clearDirectory
      * @param int $deleteDirectory
      * @param int $createDirectory
      * @dataProvider executeDataProvider
      */
-    public function testExecute($isExist, $clearDirectory, $deleteDirectory, $createDirectory)
+    public function testExecute($isExist, $deleteDirectory, $createDirectory)
     {
         $enterpriseFolder = 'magento_root/app/enterprise';
-        $generatedCode = 'magento_root/generated/code/';
-        $generatedMetadata = 'magento_root/generated/metadata/';
         $varCache = 'magento_root/var/cache/';
 
-        $this->fileMock->expects($this->exactly($clearDirectory))
-            ->method('clearDirectory')
-            ->withConsecutive(
-                [$generatedCode],
-                [$generatedMetadata]
-            )
-            ->willReturn(true);
         $this->fileMock->expects($this->exactly($deleteDirectory))
             ->method('deleteDirectory')
             ->with($varCache)
@@ -86,11 +76,9 @@ class MarshallFilesTest extends TestCase
                 ['magento_root/app/etc/di.xml', 'magento_root/app/di.xml'],
                 ['magento_root/app/etc/enterprise/di.xml', 'magento_root/app/enterprise/di.xml']
             );
-        $this->fileMock->expects($this->exactly(5))
+        $this->fileMock->expects($this->exactly(3))
             ->method('isExists')
             ->willReturnMap([
-                [$generatedCode, $isExist],
-                [$generatedMetadata, $isExist],
                 [$varCache, $isExist],
                 [$enterpriseFolder, $isExist],
                 ['magento_root/app/etc/enterprise/di.xml', true],
@@ -105,8 +93,8 @@ class MarshallFilesTest extends TestCase
     public function executeDataProvider()
     {
         return [
-            ['isExist' => true, 'clearDirectory' => 2, 'deleteDirectory' => 1, 'createDirectory' => 0],
-            ['isExist' => false, 'clearDirectory' => 0, 'deleteDirectory' => 0, 'createDirectory' => 1],
+            ['isExist' => true, 'deleteDirectory' => 1, 'createDirectory' => 0],
+            ['isExist' => false, 'deleteDirectory' => 0, 'createDirectory' => 1],
         ];
     }
 }

--- a/src/Test/Unit/Process/Build/PreBuildTest.php
+++ b/src/Test/Unit/Process/Build/PreBuildTest.php
@@ -6,6 +6,8 @@
 namespace Magento\MagentoCloud\Test\Unit\Process\Build;
 
 use Magento\MagentoCloud\Config\Stage\BuildInterface;
+use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Process\Build\PreBuild;
 use Magento\MagentoCloud\Package\Manager;
@@ -42,6 +44,16 @@ class PreBuildTest extends TestCase
      * @var FlagManager|Mock
      */
     private $flagManagerMock;
+    
+    /**
+     * @var File|Mock
+     */
+    private $fileMock;
+
+    /**
+     * @var DirectoryList|Mock
+     */
+    private $directoryListMock;
 
     /**
      * @inheritdoc
@@ -54,21 +66,32 @@ class PreBuildTest extends TestCase
             ->getMockForAbstractClass();
         $this->packageManagerMock = $this->createMock(Manager::class);
         $this->flagManagerMock = $this->createMock(FlagManager::class);
+        $this->fileMock = $this->getMockBuilder(File::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->directoryListMock = $this->getMockBuilder(DirectoryList::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->directoryListMock->method('getMagentoRoot')
+            ->willReturn('magento_root');
 
         $this->process = new PreBuild(
             $this->stageConfigMock,
             $this->loggerMock,
             $this->packageManagerMock,
-            $this->flagManagerMock
+            $this->flagManagerMock,
+            $this->fileMock,
+            $this->directoryListMock
         );
     }
 
     /**
      * @param string $verbosity
      * @param string $expectedVerbosity
-     * @dataProvider executeDataProvider
+     * @dataProvider executeVerbosityDataProvider
      */
-    public function testExecute(string $verbosity, string $expectedVerbosity)
+    public function testExecuteVerbosity(string $verbosity, string $expectedVerbosity)
     {
         $this->stageConfigMock->expects($this->once())
             ->method('get')
@@ -93,11 +116,50 @@ class PreBuildTest extends TestCase
     /**
      * @return array
      */
-    public function executeDataProvider(): array
+    public function executeVerbosityDataProvider(): array
     {
         return [
-            'verbosity very' => [' -vvv', ' -vvv'],
-            'verbosity none' => ['', 'not set'],
+            'verbosity very' => ['input' => ' -vvv', 'output' => ' -vvv'],
+            'verbosity none' => ['input' => '',      'output' => 'not set'],
+        ];
+    }
+    
+    /**
+     * @param bool $istExists
+     * @param int $callCount
+     * @dataProvider executeClearDirectoriesDataProvider
+     */
+    public function testExecuteClearDirectories(bool $isExists, int $callCount)
+    {
+        $generatedCode = 'magento_root/generated/code/';
+        $generatedMetadata = 'magento_root/generated/metadata/';
+        
+        $this->fileMock->expects($this->exactly($callCount))
+            ->method('clearDirectory')
+            ->withConsecutive(
+                [$generatedCode],
+                [$generatedMetadata]
+            )
+            ->willReturn(true);
+        
+        $this->fileMock->expects($this->exactly(2))
+            ->method('isExists')
+            ->willReturnMap([
+                [$generatedCode, $isExists],
+                [$generatedMetadata, $isExists],
+            ]);
+        
+        $this->process->execute();
+    }
+    
+    /**
+     * @return array
+     */
+    public function executeClearDirectoriesDataProvider(): array
+    {
+        return [
+            ['isExist' => true, 'clearDirectories' => 2],
+            ['isExist' => false, 'clearDirectories' => 0],
         ];
     }
 }

--- a/src/Test/Unit/Process/Build/PreBuildTest.php
+++ b/src/Test/Unit/Process/Build/PreBuildTest.php
@@ -73,8 +73,11 @@ class PreBuildTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->directoryListMock->method('getMagentoRoot')
-            ->willReturn('magento_root');
+        $this->directoryListMock->method('getGeneratedCode')
+            ->willReturn('generated_code');
+
+        $this->directoryListMock->method('getGeneratedMetadata')
+            ->willReturn('generated_metadata');
 
         $this->process = new PreBuild(
             $this->stageConfigMock,
@@ -131,8 +134,8 @@ class PreBuildTest extends TestCase
      */
     public function testExecuteClearDirectories(bool $isExists, int $callCount)
     {
-        $generatedCode = 'magento_root/generated/code/';
-        $generatedMetadata = 'magento_root/generated/metadata/';
+        $generatedCode     = 'generated_code';
+        $generatedMetadata = 'generated_metadata';
         
         $this->fileMock->expects($this->exactly($callCount))
             ->method('clearDirectory')


### PR DESCRIPTION
### Description

Basically copy pasta from the `MarshallFiles` class to the `PreBuild` class.

### Fixed Issues (if relevant)

[MAGECLOUD-1539](https://magento2.atlassian.net/browse/MAGECLOUD-1539)
