### PR TITLE
MAGECLOUD-1540: Adding support for recovering 2.1.x DI directories

### DIFF
--- a/src/Filesystem/RecoverableDirectoryList.php
+++ b/src/Filesystem/RecoverableDirectoryList.php
@@ -9,6 +9,7 @@ use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\Stage\DeployInterface;
 use Magento\MagentoCloud\Filesystem\DirectoryCopier\StrategyInterface;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
+use Magento\MagentoCloud\Package\MagentoVersion;
 
 /**
  * Returns list of recoverable directories
@@ -34,18 +35,27 @@ class RecoverableDirectoryList
     private $stageConfig;
 
     /**
+     *
+     * @var MagentoVersion
+     */
+    private $magentoVersion;
+    
+    /**
      * @param Environment $environment
      * @param FlagManager $flagManager
      * @param DeployInterface $stageConfig
+     * @param MagentoVersion $magentoVersion
      */
     public function __construct(
         Environment $environment,
         FlagManager $flagManager,
-        DeployInterface $stageConfig
+        DeployInterface $stageConfig,
+        MagentoVersion $magentoVersion
     ) {
         $this->environment = $environment;
         $this->flagManager = $flagManager;
         $this->stageConfig = $stageConfig;
+        $this->magentoVersion = $magentoVersion;
     }
 
     /**
@@ -67,6 +77,17 @@ class RecoverableDirectoryList
                 self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
             ]
         ];
+        
+        if ($this->magentoVersion->isGreaterOrEqual('2.1') && !$this->magentoVersion->isGreaterOrEqual('2.2')) {
+            $recoverableDirs[] = [
+                    self::OPTION_DIRECTORY => 'var/di',
+                    self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
+            ];
+            $recoverableDirs[] = [
+                    self::OPTION_DIRECTORY => 'var/generation',
+                    self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
+            ];
+        }
 
         if ($this->flagManager->exists(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)) {
             $recoverableDirs[] = [

--- a/src/Filesystem/RecoverableDirectoryList.php
+++ b/src/Filesystem/RecoverableDirectoryList.php
@@ -80,12 +80,12 @@ class RecoverableDirectoryList
         
         if ($this->magentoVersion->isGreaterOrEqual('2.1') && !$this->magentoVersion->isGreaterOrEqual('2.2')) {
             $recoverableDirs[] = [
-                    self::OPTION_DIRECTORY => 'var/di',
-                    self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
+                self::OPTION_DIRECTORY => 'var/di',
+                self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
             ];
             $recoverableDirs[] = [
-                    self::OPTION_DIRECTORY => 'var/generation',
-                    self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
+                self::OPTION_DIRECTORY => 'var/generation',
+                self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
             ];
         }
 

--- a/src/Test/Unit/Filesystem/RecoverableDirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/RecoverableDirectoryListTest.php
@@ -67,7 +67,6 @@ class RecoverableDirectoryListTest extends TestCase
      * @param array $expected
      * @dataProvider getListDataProvider22
      * @dataProvider getListDataProvider21
-     * @group 2.1
      */
     public function testGetList(bool $isSymlinkOn, bool $isStaticInBuild, bool $is22, bool $is21, array $expected)
     {

--- a/src/Test/Unit/Filesystem/RecoverableDirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/RecoverableDirectoryListTest.php
@@ -67,6 +67,7 @@ class RecoverableDirectoryListTest extends TestCase
      * @param array $expected
      * @dataProvider getListDataProvider22
      * @dataProvider getListDataProvider21
+     * @group 2.1
      */
     public function testGetList(bool $isSymlinkOn, bool $isStaticInBuild, bool $is22, bool $is21, array $expected)
     {
@@ -95,10 +96,10 @@ class RecoverableDirectoryListTest extends TestCase
     {
         return [
             [
-                true,
-                true,
-                true,
-                true,
+                true, // $isSymlinkOn
+                true, // $isStaticInBuild
+                true, // $is22
+                true, // $is21
                 [
                     [
                         'directory' => 'app/etc',
@@ -119,10 +120,10 @@ class RecoverableDirectoryListTest extends TestCase
                 ],
             ],
             [
-                false,
-                true,
-                true,
-                true,
+                false, // $isSymlinkOn
+                true, // $isStaticInBuild
+                true, // $is22
+                true, // $is21
                 [
                     [
                         'directory' => 'app/etc',
@@ -143,10 +144,10 @@ class RecoverableDirectoryListTest extends TestCase
                 ],
             ],
             [
-                true,
-                false,
-                true,
-                true,
+                true, // $isSymlinkOn
+                false, // $isStaticInBuild
+                true, // $is22
+                true, // $is21
                 [
                     [
                         'directory' => 'app/etc',
@@ -160,15 +161,15 @@ class RecoverableDirectoryListTest extends TestCase
             ],
         ];
     }
-    
+
     public function getListDataProvider21(): array
     {
         return [
             [
-                true,
-                true,
-                false,
-                true,
+                true, // $isSymlinkOn
+                true, // $isStaticInBuild
+                false, // $is22
+                true, // $is21
                 [
                     [
                         'directory' => 'app/etc',
@@ -197,10 +198,10 @@ class RecoverableDirectoryListTest extends TestCase
                 ],
             ],
             [
-                false,
-                true,
-                false,
-                true,
+                false, // $isSymlinkOn
+                true, // $isStaticInBuild
+                false, // $is22
+                true, // $is21
                 [
                     [
                         'directory' => 'app/etc',
@@ -229,10 +230,10 @@ class RecoverableDirectoryListTest extends TestCase
                 ],
             ],
             [
-                true,
-                false,
-                false,
-                true,
+                true, // $isSymlinkOn
+                false, // $isStaticInBuild
+                false, // $is22
+                true, // $is21
                 [
                     [
                         'directory' => 'app/etc',


### PR DESCRIPTION
### Description
Adding var/di and var/generation into recoverable directories

### Fixed Issues (if relevant)
1. Added var/di to recoverable directories
2. Added var/generation into recoverable directories

### Zephyr Tests
1. https://jira.corp.magento.com/browse/MAGETWO-86801

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
