### PR TITLE
MAGECLOUD-1541: Skip unnecessary processes in Magento 2.1

### DIFF
--- a/src/Package/MagentoVersion.php
+++ b/src/Package/MagentoVersion.php
@@ -35,8 +35,14 @@ class MagentoVersion
      */
     public function isGreaterOrEqual(string $version): bool
     {
-        $package = $this->manager->get('magento/magento2-base');
-
-        return $this->comparator::compare($package->getVersion(), '>=', $version);
+        return $this->comparator::compare($this->getVersion(), '>=', $version);
+    }
+    
+    /**
+     * @return string
+     */
+    public function getVersion(): string
+    {
+        return $this->manager->get('magento/magento2-base')->getVersion();
     }
 }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunner.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunner.php
@@ -83,7 +83,10 @@ class CronConsumersRunner implements ProcessInterface
     public function execute()
     {
         if (!$this->magentoVersion->isGreaterOrEqual('2.2')) {
-            $this->logger->info('Skipping update to cron consumer configuration.');
+            $version = $this->magentoVersion->getVersion();
+            $this->logger->info(
+                sprintf('Updating cron consumer runner is not supported in Magento %s, skipping.', $version)
+            );
             return;
         }
         

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunner.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunner.php
@@ -5,13 +5,14 @@
  */
 namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate;
 
-use Magento\MagentoCloud\Config\Stage\DeployInterface;
-use Psr\Log\LoggerInterface;
-use Magento\MagentoCloud\Process\ProcessInterface;
-use Magento\MagentoCloud\Config\Environment;
+use Illuminate\Config\Repository;
 use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
 use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
-use Illuminate\Config\Repository;
+use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Config\Stage\DeployInterface;
+use Magento\MagentoCloud\Package\MagentoVersion;
+use Magento\MagentoCloud\Process\ProcessInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * @inheritdoc
@@ -44,6 +45,11 @@ class CronConsumersRunner implements ProcessInterface
     private $stageConfig;
 
     /**
+     * @var MagentoVersion
+     */
+    private $magentoVersion;
+
+    /**
      * Max messages that will be processed by each consumer
      */
     const DEFAULT_MAX_MESSAGES = 10000;
@@ -60,13 +66,15 @@ class CronConsumersRunner implements ProcessInterface
         ConfigReader $configReader,
         ConfigWriter $configWriter,
         LoggerInterface $logger,
-        DeployInterface $stageConfig
+        DeployInterface $stageConfig,
+        MagentoVersion $version
     ) {
         $this->environment = $environment;
         $this->configReader = $configReader;
         $this->configWriter = $configWriter;
         $this->logger = $logger;
         $this->stageConfig = $stageConfig;
+        $this->magentoVersion = $version;
     }
 
     /**
@@ -74,6 +82,11 @@ class CronConsumersRunner implements ProcessInterface
      */
     public function execute()
     {
+        if (!$this->magentoVersion->isGreaterOrEqual('2.2')) {
+            $this->logger->info('Skipping update to cron consumer configuration.');
+            return;
+        }
+        
         $this->logger->info('Updating env.php cron consumers runner configuration.');
         $config = $this->configReader->read();
         $runnerConfig = new Repository(

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
@@ -5,10 +5,11 @@
  */
 namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate;
 
+use Magento\MagentoCloud\Config\Deploy\Writer;
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\Stage\DeployInterface;
+use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\Process\ProcessInterface;
-use Magento\MagentoCloud\Config\Deploy\Writer;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -37,6 +38,11 @@ class SearchEngine implements ProcessInterface
     private $stageConfig;
 
     /**
+     * @var MagentoVersion
+     */
+    private $magentoVersion;
+
+    /**
      * @param Environment $environment
      * @param LoggerInterface $logger
      * @param Writer $writer
@@ -46,12 +52,14 @@ class SearchEngine implements ProcessInterface
         Environment $environment,
         LoggerInterface $logger,
         Writer $writer,
-        DeployInterface $stageConfig
+        DeployInterface $stageConfig,
+        MagentoVersion $version
     ) {
         $this->environment = $environment;
         $this->logger = $logger;
         $this->writer = $writer;
         $this->stageConfig = $stageConfig;
+        $this->magentoVersion = $version;
     }
 
     /**
@@ -61,6 +69,11 @@ class SearchEngine implements ProcessInterface
      */
     public function execute()
     {
+        if (!$this->magentoVersion->isGreaterOrEqual('2.2')) {
+            $this->logger->info('Skipping update to search engine configuration.');
+            return;
+        }
+        
         $this->logger->info('Updating search engine configuration.');
 
         $searchConfig = $this->getSearchConfiguration();

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
@@ -70,7 +70,10 @@ class SearchEngine implements ProcessInterface
     public function execute()
     {
         if (!$this->magentoVersion->isGreaterOrEqual('2.2')) {
-            $this->logger->info('Skipping update to search engine configuration.');
+            $version = $this->magentoVersion->getVersion();
+            $this->logger->info(
+                sprintf('Updating search engine configuration is not supported in Magento %s, skipping.', $version)
+            );
             return;
         }
         

--- a/src/Process/Deploy/InstallUpdate/Install/ConfigImport.php
+++ b/src/Process/Deploy/InstallUpdate/Install/ConfigImport.php
@@ -53,7 +53,8 @@ class ConfigImport implements ProcessInterface
     public function execute()
     {
         if (!$this->magentoVersion->isGreaterOrEqual('2.2')) {
-            $this->logger->info('Skipping config import.');
+            $version = $this->magentoVersion->getVersion();
+            $this->logger->info(sprintf('Importing config is not supported in Magento %s, skipping.', $version));
             return;
         }
         

--- a/src/Process/Deploy/InstallUpdate/Install/ConfigImport.php
+++ b/src/Process/Deploy/InstallUpdate/Install/ConfigImport.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\Install;
 
+use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Magento\MagentoCloud\Shell\ShellInterface;
 use Psr\Log\LoggerInterface;
@@ -27,15 +28,23 @@ class ConfigImport implements ProcessInterface
     private $logger;
 
     /**
+     * @var MagentoVersion
+     */
+    private $magentoVersion;
+
+    /**
      * @param ShellInterface $shell
      * @param LoggerInterface $logger
+     * @param MagentoVersion $version
      */
     public function __construct(
         ShellInterface $shell,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        MagentoVersion $version
     ) {
         $this->shell = $shell;
         $this->logger = $logger;
+        $this->magentoVersion = $version;
     }
 
     /**
@@ -43,6 +52,11 @@ class ConfigImport implements ProcessInterface
      */
     public function execute()
     {
+        if (!$this->magentoVersion->isGreaterOrEqual('2.2')) {
+            $this->logger->info('Skipping config import.');
+            return;
+        }
+        
         $this->logger->info('Run app:config:import command');
         $this->shell->execute('php ./bin/magento app:config:import -n');
     }

--- a/src/Test/Unit/Package/MagentoVersionTest.php
+++ b/src/Test/Unit/Package/MagentoVersionTest.php
@@ -83,4 +83,16 @@ class MagentoVersionTest extends TestCase
             ['2.2-dev', '2.2-dev', true],
         ];
     }
+    
+    public function testGetVersion()
+    {
+        $this->managerMock->method('get')
+            ->with('magento/magento2-base')
+            ->willReturn($this->packageMock);
+        $this->packageMock->expects($this->once())
+            ->method('getVersion')
+            ->willReturn('2.2.1');
+        
+        $this->assertSame('2.2.1', $this->magentoVersion->getVersion());
+    }
 }

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunnerTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunnerTest.php
@@ -5,14 +5,15 @@
  */
 namespace Magento\MagentoCloud\Test\Unit\Process\Deploy\InstallUpdate\ConfigUpdate;
 
-use Magento\MagentoCloud\Config\Stage\DeployInterface;
-use Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate\CronConsumersRunner;
-use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
-use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
 use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
+use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Config\Stage\DeployInterface;
+use Magento\MagentoCloud\Package\MagentoVersion;
+use Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate\CronConsumersRunner;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
+use Psr\Log\LoggerInterface;
 
 /**
  * @inheritdoc
@@ -50,6 +51,11 @@ class CronConsumersRunnerTest extends TestCase
     private $stageConfigMock;
 
     /**
+     * @var MagentoVersion|Mock
+     */
+    private $magentoVersionMock;
+
+    /**
      * @inheritdoc
      */
     protected function setUp()
@@ -59,13 +65,15 @@ class CronConsumersRunnerTest extends TestCase
         $this->configWriterMock = $this->createMock(ConfigWriter::class);
         $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
         $this->stageConfigMock = $this->getMockForAbstractClass(DeployInterface::class);
+        $this->magentoVersionMock = $this->createMock(MagentoVersion::class);
 
         $this->cronConsumersRunner = new CronConsumersRunner(
             $this->environmentMock,
             $this->configReaderMock,
             $this->configWriterMock,
             $this->loggerMock,
-            $this->stageConfigMock
+            $this->stageConfigMock,
+            $this->magentoVersionMock
         );
     }
 
@@ -77,6 +85,9 @@ class CronConsumersRunnerTest extends TestCase
      */
     public function testExecute(array $config, array $configFromVariable, array $expectedResult)
     {
+        $this->magentoVersionMock->method('isGreaterOrEqual')
+            ->willReturn(true);
+        
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Updating env.php cron consumers runner configuration.');
@@ -192,5 +203,25 @@ class CronConsumersRunnerTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testSkipExecute()
+    {
+        $this->magentoVersionMock->expects($this->once())
+            ->method('isGreaterOrEqual')
+            ->with('2.2')
+            ->willReturn(false);
+        
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Skipping update to cron consumer configuration.');
+        $this->configReaderMock->expects($this->never())
+            ->method('read');
+        $this->stageConfigMock->expects($this->never())
+            ->method('get');
+        $this->configWriterMock->expects($this->never())
+            ->method('write');
+        
+        $this->cronConsumersRunner->execute();
     }
 }

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunnerTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunnerTest.php
@@ -211,10 +211,14 @@ class CronConsumersRunnerTest extends TestCase
             ->method('isGreaterOrEqual')
             ->with('2.2')
             ->willReturn(false);
+
+        $this->magentoVersionMock->expects($this->once())
+            ->method('getVersion')
+            ->willReturn('2.1.7');
         
         $this->loggerMock->expects($this->once())
             ->method('info')
-            ->with('Skipping update to cron consumer configuration.');
+            ->with('Updating cron consumer runner is not supported in Magento 2.1.7, skipping.');
         $this->configReaderMock->expects($this->never())
             ->method('read');
         $this->stageConfigMock->expects($this->never())

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngineTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngineTest.php
@@ -220,10 +220,14 @@ class SearchEngineTest extends TestCase
             ->method('isGreaterOrEqual')
             ->with('2.2')
             ->willReturn(false);
+
+        $this->magentoVersionMock->expects($this->once())
+            ->method('getVersion')
+            ->willReturn('2.1.7');
         
         $this->loggerMock->expects($this->once())
             ->method('info')
-            ->with('Skipping update to search engine configuration.');
+            ->with('Updating search engine configuration is not supported in Magento 2.1.7, skipping.');
         $this->stageConfigMock->expects($this->never())
             ->method('get');
         $this->environmentMock->expects($this->never())

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Install/ConfigImportTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Install/ConfigImportTest.php
@@ -74,9 +74,13 @@ class ConfigImportTest extends TestCase
             ->with('2.2')
             ->willReturn(false);
 
+        $this->magentoVersionMock->expects($this->once())
+            ->method('getVersion')
+            ->willReturn('2.1.7');
+
         $this->loggerMock->expects($this->once())
             ->method('info')
-            ->with('Skipping config import.');
+            ->with('Importing config is not supported in Magento 2.1.7, skipping.');
         $this->shellMock->expects($this->never())
             ->method('execute');
         

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Install/ConfigImportTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Install/ConfigImportTest.php
@@ -5,11 +5,12 @@
  */
 namespace Magento\MagentoCloud\Test\Unit\Process\Deploy\InstallUpdate\Install;
 
+use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\Process\Deploy\InstallUpdate\Install\ConfigImport;
-use PHPUnit\Framework\TestCase;
 use Magento\MagentoCloud\Shell\ShellInterface;
-use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
+use Psr\Log\LoggerInterface;
 
 class ConfigImportTest extends TestCase
 {
@@ -29,6 +30,11 @@ class ConfigImportTest extends TestCase
     private $configImport;
 
     /**
+     * @var MagentoVersion|Mock
+     */
+    private $magentoVersionMock;
+
+    /**
      * @inheritdoc
      */
     protected function setUp()
@@ -38,7 +44,9 @@ class ConfigImportTest extends TestCase
         $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
             ->getMockForAbstractClass();
 
-        $this->configImport = new ConfigImport($this->shellMock, $this->loggerMock);
+        $this->magentoVersionMock = $this->createMock(MagentoVersion::class);
+
+        $this->configImport = new ConfigImport($this->shellMock, $this->loggerMock, $this->magentoVersionMock);
     }
 
     /**
@@ -46,6 +54,9 @@ class ConfigImportTest extends TestCase
      */
     public function testExecute()
     {
+        $this->magentoVersionMock->method('isGreaterOrEqual')
+            ->willReturn(true);
+        
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Run app:config:import command');
@@ -53,6 +64,22 @@ class ConfigImportTest extends TestCase
             ->method('execute')
             ->with('php ./bin/magento app:config:import -n');
 
+        $this->configImport->execute();
+    }
+    
+    public function testSkipExecute()
+    {
+        $this->magentoVersionMock->expects($this->once())
+            ->method('isGreaterOrEqual')
+            ->with('2.2')
+            ->willReturn(false);
+
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Skipping config import.');
+        $this->shellMock->expects($this->never())
+            ->method('execute');
+        
         $this->configImport->execute();
     }
 }


### PR DESCRIPTION
### Description

Skip `Deploy\InstallUpdate\ConfigUpdate\CronConsumerRunner`, `Deploy\InstallUpdate\ConfigUpdate\SearchEngine`, and `Deploy\Install\ConfigImport` if the Magento version is less than 2.2.

### Fixed Issues (if relevant)

[MAGECLOUD-1541](https://magento2.atlassian.net/browse/MAGECLOUD-1541)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
