### PR TITLE
MAGECLOUD-1541: Additional skips for Magento 2.1.x

### DIFF
--- a/src/Command/CronUnlock.php
+++ b/src/Command/CronUnlock.php
@@ -6,6 +6,7 @@
 namespace Magento\MagentoCloud\Command;
 
 use Magento\MagentoCloud\Cron\JobUnlocker;
+use Magento\MagentoCloud\Package\MagentoVersion;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -34,13 +35,20 @@ class CronUnlock extends Command
     private $jobUnlocker;
 
     /**
+     * @var MagentoVersion
+     */
+    private $magentoVersion;
+
+    /**
      * @param JobUnlocker $jobUnlocker
      * @param LoggerInterface $logger
+     * @param MagentoVersion $version
      */
-    public function __construct(JobUnlocker $jobUnlocker, LoggerInterface $logger)
+    public function __construct(JobUnlocker $jobUnlocker, LoggerInterface $logger, MagentoVersion $version)
     {
         $this->jobUnlocker = $jobUnlocker;
         $this->logger = $logger;
+        $this->magentoVersion = $version;
 
         parent::__construct();
     }
@@ -68,6 +76,12 @@ class CronUnlock extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!$this->magentoVersion->isGreaterOrEqual('2.2')) {
+            $version = $this->magentoVersion->getVersion();
+            $this->logger->info(sprintf('Unlocking crons is not supported in Magento %s, skipping.', $version));
+            return;
+        }
+        
         try {
             $this->logger->info('Starting unlocking.');
 

--- a/src/Command/CronUnlock.php
+++ b/src/Command/CronUnlock.php
@@ -78,7 +78,7 @@ class CronUnlock extends Command
     {
         if (!$this->magentoVersion->isGreaterOrEqual('2.2')) {
             $version = $this->magentoVersion->getVersion();
-            $this->logger->info(sprintf('Unlocking crons is not supported in Magento %s, skipping.', $version));
+            $this->logger->error(sprintf('Unlocking crons is not supported in Magento %s.', $version));
             return;
         }
         

--- a/src/Test/Unit/Command/CronUnlockTest.php
+++ b/src/Test/Unit/Command/CronUnlockTest.php
@@ -147,8 +147,8 @@ class CronUnlockTest extends TestCase
             ->willReturn('2.1.7');
         
         $this->loggerMock->expects($this->once())
-            ->method('info')
-            ->with('Unlocking crons is not supported in Magento 2.1.7, skipping.');
+            ->method('error')
+            ->with('Unlocking crons is not supported in Magento 2.1.7.');
         
         $this->jobUnlockerMock->expects($this->never())
             ->method('unlockByJobCode');

--- a/src/Test/Unit/Process/Deploy/UnlockCronJobsTest.php
+++ b/src/Test/Unit/Process/Deploy/UnlockCronJobsTest.php
@@ -5,8 +5,9 @@
  */
 namespace Magento\MagentoCloud\Test\Unit\Process\Deploy;
 
-use Magento\MagentoCloud\Process\Deploy\UnlockCronJobs;
 use Magento\MagentoCloud\Cron\JobUnlocker;
+use Magento\MagentoCloud\Package\MagentoVersion;
+use Magento\MagentoCloud\Process\Deploy\UnlockCronJobs;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
 use Psr\Log\LoggerInterface;
@@ -24,6 +25,11 @@ class UnlockCronJobsTest extends TestCase
     private $jobUnlockerMock;
 
     /**
+     * @var MagentoVersion|Mock
+     */
+    private $magentoVersionMock;
+
+    /**
      * @var UnlockCronJobs
      */
     private $process;
@@ -33,14 +39,20 @@ class UnlockCronJobsTest extends TestCase
         $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
         $this->jobUnlockerMock = $this->createMock(JobUnlocker::class);
 
+        $this->magentoVersionMock = $this->createMock(MagentoVersion::class);
+        
         $this->process = new UnlockCronJobs(
             $this->jobUnlockerMock,
-            $this->loggerMock
+            $this->loggerMock,
+            $this->magentoVersionMock
         );
     }
 
     public function testExecute()
     {
+        $this->magentoVersionMock->method('isGreaterOrEqual')
+            ->willReturn(true);
+        
         $this->updateCronJobs(5);
         $this->loggerMock->expects($this->once())
             ->method('info')
@@ -51,10 +63,39 @@ class UnlockCronJobsTest extends TestCase
 
     public function testExecuteNoJobsUpdated()
     {
+        $this->magentoVersionMock->method('isGreaterOrEqual')
+            ->willReturn(true);
+        
         $this->updateCronJobs(0);
         $this->loggerMock->expects($this->never())
             ->method('info');
 
+        $this->process->execute();
+    }
+
+    public function testSkipExecute()
+    {
+        $this->magentoVersionMock->expects($this->once())
+            ->method('isGreaterOrEqual')
+            ->with('2.2')
+            ->willReturn(false);
+        
+        $this->magentoVersionMock->expects($this->once())
+            ->method('isGreaterOrEqual')
+            ->with('2.2')
+            ->willReturn(false);
+            
+        $this->magentoVersionMock->expects($this->once())
+            ->method('getVersion')
+            ->willReturn('2.1.7');
+        
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Unlocking cron jobs is not supported in Magento 2.1.7, skipping.');
+        
+        $this->jobUnlockerMock->expects($this->never())
+            ->method('unlockAll');
+        
         $this->process->execute();
     }
 


### PR DESCRIPTION
### Description

Skip unlocking cron jobs during deployment process for Magento 2.1, also emit an error and skip when a user tries to manually unlock crons through the command.

### Fixed Issues (if relevant)

[MAGECLOUD-1541](https://magento2.atlassian.net/browse/MAGECLOUD-1541)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
