### PR TITLE
MAGECLOUD-1603: Magento 2.1 Writable Directories

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -11,4 +11,4 @@ require_once __DIR__ . '/autoload.php';
 $handler = new \Magento\MagentoCloud\App\ErrorHandler();
 set_error_handler([$handler, 'handle']);
 
-return new \Magento\MagentoCloud\App\Container();
+return new \Magento\MagentoCloud\App\Container(ECE_BP, BP);

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -11,6 +11,4 @@ require_once __DIR__ . '/autoload.php';
 $handler = new \Magento\MagentoCloud\App\ErrorHandler();
 set_error_handler([$handler, 'handle']);
 
-$config = $_SERVER['DIRS_CONFIG'] ?? [];
-
 return new \Magento\MagentoCloud\App\Container();

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -13,6 +13,4 @@ set_error_handler([$handler, 'handle']);
 
 $config = $_SERVER['DIRS_CONFIG'] ?? [];
 
-return new \Magento\MagentoCloud\App\Container(
-    new \Magento\MagentoCloud\Filesystem\DirectoryList(ECE_BP, BP, $config)
-);
+return new \Magento\MagentoCloud\App\Container();

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -46,7 +46,7 @@ class Container implements ContainerInterface
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function __construct()
+    public function __construct(string $eceBasePath, $magentoBasePath)
     {
         /**
          * Creating concrete container.
@@ -59,10 +59,10 @@ class Container implements ContainerInterface
         $this->container->instance(ContainerInterface::class, $this);
         $this->container->singleton(
             \Magento\MagentoCloud\Filesystem\DirectoryList::class,
-            function () {
+            function () use ($eceBasePath, $magentoBasePath) {
                 return new \Magento\MagentoCloud\Filesystem\DirectoryList(
-                    ECE_BP,
-                    BP,
+                    $eceBasePath,
+                    $magentoBasePath,
                     $this->get(\Magento\MagentoCloud\Package\MagentoVersion::class),
                     $_SERVER['DIRS_CONFIG'] ?? []
                 );

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -69,12 +69,16 @@ class Container implements ContainerInterface
             }
         );
         $this->container->singleton(\Magento\MagentoCloud\Filesystem\FileList::class);
-        $this->container->singleton(\Composer\Composer::class, function () {
-            $fileList = $this->get(\Magento\MagentoCloud\Filesystem\FileList::class);
+        $this->container->singleton(\Composer\Composer::class, function () use ($eceBasePath, $magentoBasePath) {
+            $composerJson = $magentoBasePath . '/composer.json';
+
+            if (!file_exists($composerJson)) {
+                $composerJson = $eceBasePath . '/composer.json';
+            }
 
             return \Composer\Factory::create(
                 new \Composer\IO\BufferIO(),
-                $fileList->getComposer()
+                $composerJson
             );
         });
         $this->container->singleton(

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -46,7 +46,7 @@ class Container implements ContainerInterface
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function __construct(DirectoryList $directoryList)
+    public function __construct()
     {
         /**
          * Creating concrete container.
@@ -59,8 +59,8 @@ class Container implements ContainerInterface
         $this->container->instance(ContainerInterface::class, $this);
         $this->container->singleton(
             \Magento\MagentoCloud\Filesystem\DirectoryList::class,
-            function () use ($directoryList) {
-                return $directoryList;
+            function () {
+                return new \Magento\MagentoCloud\Filesystem\DirectoryList(ECE_BP, BP, $_SERVER['DIRS_CONFIG'] ?? []);
             }
         );
         $this->container->singleton(\Magento\MagentoCloud\Filesystem\FileList::class);

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -60,7 +60,12 @@ class Container implements ContainerInterface
         $this->container->singleton(
             \Magento\MagentoCloud\Filesystem\DirectoryList::class,
             function () {
-                return new \Magento\MagentoCloud\Filesystem\DirectoryList(ECE_BP, BP, $_SERVER['DIRS_CONFIG'] ?? []);
+                return new \Magento\MagentoCloud\Filesystem\DirectoryList(
+                    ECE_BP,
+                    BP,
+                    $this->get(\Magento\MagentoCloud\Package\MagentoVersion::class),
+                    $_SERVER['DIRS_CONFIG'] ?? []
+                );
             }
         );
         $this->container->singleton(\Magento\MagentoCloud\Filesystem\FileList::class);

--- a/src/App/Logger.php
+++ b/src/App/Logger.php
@@ -66,7 +66,10 @@ class Logger extends \Monolog\Logger
 
         $this->file->createDirectory($this->directoryList->getLog());
 
-        if ($deployLogFileExists && !$this->isBuildLogApplied($deployLogPath, $buildPhaseLogContent)) {
+        if ($deployLogFileExists &&
+            !empty($buildPhaseLogContent) &&
+            !$this->isBuildLogApplied($deployLogPath, $buildPhaseLogContent)
+        ) {
             $this->file->filePutContents($deployLogPath, $buildPhaseLogContent, FILE_APPEND);
         } elseif (!$deployLogFileExists && $buildLogFileExists) {
             $this->file->copy($buildPhaseLogPath, $deployLogPath);

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -170,16 +170,6 @@ class Environment
     }
 
     /**
-     * Retrieves writable directories.
-     *
-     * @return array
-     */
-    public function getWritableDirectories(): array
-    {
-        return ['var', 'app/etc', 'pub/media'];
-    }
-
-    /**
      * @return bool
      */
     public function isDeployStaticContent(): bool

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -6,7 +6,6 @@
 namespace Magento\MagentoCloud\Process\Build;
 
 use Magento\MagentoCloud\App\Logger\Pool as LoggerPool;
-use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
@@ -32,11 +31,6 @@ class BackupData implements ProcessInterface
     private $logger;
 
     /**
-     * @var Environment
-     */
-    private $environment;
-
-    /**
      * @var DirectoryList
      */
     private $directoryList;
@@ -56,7 +50,6 @@ class BackupData implements ProcessInterface
      *
      * @param File $file
      * @param LoggerInterface $logger
-     * @param Environment $environment
      * @param DirectoryList $directoryList
      * @param FlagManager $flagManager
      * @param LoggerPool $loggerPool
@@ -64,14 +57,12 @@ class BackupData implements ProcessInterface
     public function __construct(
         File $file,
         LoggerInterface $logger,
-        Environment $environment,
         DirectoryList $directoryList,
         FlagManager $flagManager,
         LoggerPool $loggerPool
     ) {
         $this->file = $file;
         $this->logger = $logger;
-        $this->environment = $environment;
         $this->directoryList = $directoryList;
         $this->flagManager = $flagManager;
         $this->loggerPool = $loggerPool;
@@ -114,7 +105,7 @@ class BackupData implements ProcessInterface
 
         $this->stopLogging();
 
-        foreach ($this->environment->getWritableDirectories() as $dir) {
+        foreach ($this->directoryList->getWritableDirectories() as $dir) {
             $originalDir = $magentoRoot . $dir;
             $initDir = $rootInitDir . $dir;
 

--- a/src/Test/Integration/Bootstrap.php
+++ b/src/Test/Integration/Bootstrap.php
@@ -8,7 +8,6 @@ namespace Magento\MagentoCloud\Test\Integration;
 use Illuminate\Config\Repository;
 use Magento\MagentoCloud\App\Container;
 use Magento\MagentoCloud\Application;
-use Magento\MagentoCloud\Filesystem\DirectoryList;
 
 /**
  * Integration testing bootstrap.
@@ -134,11 +133,7 @@ class Bootstrap
             )),
         ]);
 
-        $container = new Container(new DirectoryList(
-            ECE_BP,
-            $this->getSandboxDir(),
-            []
-        ));
+        $container = new Container(ECE_BP, $this->getSandboxDir());
 
         return new Application($container);
     }

--- a/src/Test/Unit/Config/EnvironmentTest.php
+++ b/src/Test/Unit/Config/EnvironmentTest.php
@@ -117,14 +117,6 @@ class EnvironmentTest extends TestCase
         ];
     }
 
-    public function testGetWritableDirectories()
-    {
-        $this->assertSame(
-            ['var', 'app/etc', 'pub/media'],
-            $this->environment->getWritableDirectories()
-        );
-    }
-
     /**
      * @param bool $isExists
      * @dataProvider isDeployStaticContentToBeEnabledDataProvider

--- a/src/Test/Unit/Filesystem/DirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/DirectoryListTest.php
@@ -6,6 +6,7 @@
 namespace Magento\MagentoCloud\Test\Unit\Filesystem;
 
 use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Package\MagentoVersion;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,46 +15,17 @@ use PHPUnit\Framework\TestCase;
 class DirectoryListTest extends TestCase
 {
     /**
-     * @var DirectoryList
-     */
-    private $directoryList;
-
-    /**
-     * @inheritdoc
-     */
-    protected function setUp()
-    {
-        $this->directoryList = new DirectoryList(
-            __DIR__ . '/_files/bp',
-            __DIR__,
-            ['empty_path' => [], 'test_var' => [DirectoryList::PATH => '_files/test/var']]
-        );
-    }
-
-    /**
      * @param string $code
      * @param string $expected
-     * @dataProvider getPathDataProvider
      */
-    public function testGetPath(string $code, string $expected)
+    public function testGetPath()
     {
-        $this->assertSame(
-            $expected,
-            $this->directoryList->getPath($code)
-        );
-    }
+        $directoryList = $this->get22DirectoryList();
 
-    /**
-     * @return array
-     */
-    public function getPathDataProvider(): array
-    {
-        return [
-            'test var' => [
-                'test_var',
-                __DIR__ . '/_files/test/var',
-            ],
-        ];
+        $this->assertSame(
+            __DIR__ . '/_files/test/var',
+            $directoryList->getPath('test_var')
+        );
     }
 
     /**
@@ -62,7 +34,7 @@ class DirectoryListTest extends TestCase
      */
     public function testGetPathWithException()
     {
-        $this->directoryList->getPath('some_code');
+        $this->get22DirectoryList()->getPath('some_code');
     }
 
     /**
@@ -71,70 +43,165 @@ class DirectoryListTest extends TestCase
      */
     public function testGetPathWithEmptyPathException()
     {
-        $this->directoryList->getPath('empty_path');
+        $this->get22DirectoryList()->getPath('empty_path');
     }
 
     public function testGetRoot()
     {
+        $directoryList = $this->get22DirectoryList();
+
         $this->assertSame(
             __DIR__ . '/_files/bp',
-            $this->directoryList->getRoot()
+            $directoryList->getRoot()
         );
     }
 
     public function testGetMagentoRoot()
     {
+        $directoryList = $this->get22DirectoryList();
+
         $this->assertSame(
             __DIR__,
-            $this->directoryList->getMagentoRoot()
+            $directoryList->getMagentoRoot()
         );
     }
 
     public function testGetInit()
     {
+        $directoryList = $this->get22DirectoryList();
+
         $this->assertSame(
             __DIR__ . '/init',
-            $this->directoryList->getInit()
+            $directoryList->getInit()
         );
     }
 
     public function testGetVar()
     {
+        $directoryList = $this->get22DirectoryList();
+
         $this->assertSame(
             __DIR__ . '/var',
-            $this->directoryList->getVar()
+            $directoryList->getVar()
         );
     }
 
     public function testGetLog()
     {
+        $directoryList = $this->get22DirectoryList();
+
         $this->assertSame(
             __DIR__ . '/var/log',
-            $this->directoryList->getLog()
+            $directoryList->getLog()
         );
     }
 
     public function testGetGenerated()
     {
+        $directoryList = $this->get22DirectoryList();
+
         $this->assertSame(
             __DIR__ . '/generated',
-            $this->directoryList->getGenerated()
+            $directoryList->getGenerated()
         );
     }
 
-    public function testGetGeneratedCode()
+    /**
+     * @param DirectoryList $directoryList
+     * @param string $path
+     * @dataProvider getGeneratedCodeDataProvider
+     */
+    public function testGetGeneratedCode(DirectoryList $directoryList, string $path)
     {
-        $this->assertSame(
-            __DIR__ . '/generated/code',
-            $this->directoryList->getGeneratedCode()
+        $this->assertSame($path, $directoryList->getGeneratedCode());
+    }
+
+    public function getGeneratedCodeDataProvider(): array
+    {
+        return [
+            [$this->get21DirectoryList(), __DIR__ . '/var/generation'],
+            [$this->get22DirectoryList(), __DIR__ . '/generated/code'],
+        ];
+    }
+
+    /**
+     * @param DirectoryList $directoryList
+     * @param string $path
+     * @dataProvider getGeneratedMetadataDataProvider
+     */
+    public function testGetGeneratedMetadata(DirectoryList $directoryList, string $path)
+    {
+        $this->assertSame($path, $directoryList->getGeneratedMetadata());
+    }
+
+    public function getGeneratedMetadataDataProvider(): array
+    {
+        return [
+            [$this->get21DirectoryList(), __DIR__ . '/var/di'],
+            [$this->get22DirectoryList(), __DIR__ . '/generated/metadata'],
+        ];
+    }
+
+    /**
+     * @param DirectoryList $directoryList
+     * @param array $paths
+     * @dataProvider getWritableDirectoriesDataProvider
+     */
+    public function testGetGetWritableDirectories(DirectoryList $directoryList, array $paths)
+    {
+        $result = $directoryList->getWritableDirectories();
+        sort($result);
+        sort($paths);
+        $this->assertEquals($paths, $result);
+    }
+
+    public function getWritableDirectoriesDataProvider()
+    {
+        $paths21 = [
+            __DIR__ . '/var/di',
+            __DIR__ . '/var/generation',
+            __DIR__ . '/var/view_preprocessed',
+            __DIR__ . '/app/etc',
+            __DIR__ . '/pub/media'
+        ];
+
+        $paths22 = [__DIR__ . '/var', __DIR__ . '/app/etc', __DIR__ . '/pub/media'];
+
+        return [
+            [$this->get21DirectoryList(), $paths21],
+            [$this->get22DirectoryList(), $paths22],
+        ];
+    }
+
+    private function get21DirectoryList()
+    {
+        $magentoVersionMock = $this->createMock(MagentoVersion::class);
+
+        $magentoVersionMock->method('isGreaterOrEqual')
+            ->with('2.2')
+            ->willReturn(false);
+
+        return new DirectoryList(
+            __DIR__ . '/_files/bp',
+            __DIR__,
+            $magentoVersionMock,
+            ['empty_path' => [], 'test_var' => [DirectoryList::PATH => '_files/test/var']]
         );
     }
 
-    public function testGetGeneratedMetadata()
+    private function get22DirectoryList()
     {
-        $this->assertSame(
-            __DIR__ . '/generated/metadata',
-            $this->directoryList->getGeneratedMetadata()
+        $magentoVersionMock = $this->createMock(MagentoVersion::class);
+
+        $magentoVersionMock->method('isGreaterOrEqual')
+            ->with('2.2')
+            ->willReturn(true);
+
+        return new DirectoryList(
+            __DIR__ . '/_files/bp',
+            __DIR__,
+            $magentoVersionMock,
+            ['empty_path' => [], 'test_var' => [DirectoryList::PATH => '_files/test/var']]
         );
     }
 }

--- a/src/Test/Unit/Process/Build/BackupDataTest.php
+++ b/src/Test/Unit/Process/Build/BackupDataTest.php
@@ -6,7 +6,6 @@
 namespace Magento\MagentoCloud\Test\Unit\Process\Build;
 
 use Magento\MagentoCloud\App\Logger\Pool as LoggerPool;
-use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
@@ -34,11 +33,6 @@ class BackupDataTest extends TestCase
      * @var LoggerInterface|Mock
      */
     private $loggerMock;
-
-    /**
-     * @var Environment|Mock
-     */
-    private $environmentMock;
 
     /**
      * @var DirectoryList|Mock
@@ -88,7 +82,6 @@ class BackupDataTest extends TestCase
         $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
             ->setMethods(['setHandlers', 'info'])
             ->getMockForAbstractClass();
-        $this->environmentMock = $this->createMock(Environment::class);
         $this->directoryListMock = $this->createMock(DirectoryList::class);
         $this->flagManagerMock = $this->createMock(FlagManager::class);
         $this->rootInitDir = 'magento_root/init';
@@ -96,9 +89,6 @@ class BackupDataTest extends TestCase
         $this->initPubStatic = 'magento_root/init/pub/static/';
         $this->someDir = 'magento_root/some_dir';
         $this->initSomeDir = 'magento_root/init/some_dir';
-        $this->environmentMock = $this->getMockBuilder(Environment::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->directoryListMock = $this->getMockBuilder(DirectoryList::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -127,7 +117,6 @@ class BackupDataTest extends TestCase
         $this->process = new BackupData(
             $this->fileMock,
             $this->loggerMock,
-            $this->environmentMock,
             $this->directoryListMock,
             $this->flagManagerMock,
             $this->loggerPoolMock
@@ -177,7 +166,7 @@ class BackupDataTest extends TestCase
                 [$this->pubStatic, $this->initPubStatic],
                 [$this->someDir, $this->initSomeDir]
             );
-        $this->environmentMock->expects($this->once())
+        $this->directoryListMock->expects($this->once())
             ->method('getWritableDirectories')
             ->willReturn(['some_dir']);
         $this->fileMock->expects($this->once())
@@ -201,7 +190,7 @@ class BackupDataTest extends TestCase
                 ['SCD not performed during build'],
                 ['Copying writable directories to temp directory.']
             );
-        $this->environmentMock->expects($this->once())
+        $this->directoryListMock->expects($this->once())
             ->method('getWritableDirectories')
             ->willReturn(['some_dir']);
         $this->fileMock->expects($this->exactly(3))
@@ -259,7 +248,7 @@ class BackupDataTest extends TestCase
         $this->fileMock->expects($this->once())
             ->method('copyDirectory')
             ->with($this->pubStatic, $this->initPubStatic);
-        $this->environmentMock->expects($this->once())
+        $this->directoryListMock->expects($this->once())
             ->method('getWritableDirectories')
             ->willReturn([]);
         $this->fileMock->expects($this->never())


### PR DESCRIPTION
### Description

Provides the following changes:
1. Move the `getWritableDirectories()` method to the `DirectoryList` class
1. Update the default directory list configuration for Magento 2.1
1. Add logic to get writable directories for Magento 2.1
1. Update the container constructor to no longer require an instance of `DirectoryList` (complete dependency inversion!)

### Fixed Issues (if relevant)

[MAGECLOUD-1603](https://magento2.atlassian.net/browse/MAGECLOUD-1603)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
