### PR TITLE
MAGECLOUD-1618: Temporary Workaround to Clean-up "disable_locking" Parameter

### DIFF
--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
@@ -104,6 +104,11 @@ class Redis implements ProcessInterface
                     $redisSessionConfig
                 ),
             ];
+
+            if (isset($config['session']['redis']['disable_locking'])) {
+                $this->logger->info('Removing disable_locking configuration.');
+                unset($config['session']['redis'] ['disable_locking']);
+            }
         } else {
             $config = $this->removeRedisConfiguration($config);
         }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
@@ -106,7 +106,7 @@ class Redis implements ProcessInterface
             ];
 
             if (isset($config['session']['redis']['disable_locking'])) {
-                $this->logger->info('Removing disable_locking configuration.');
+                $this->logger->info('Removing disable_locking env.php.');
                 unset($config['session']['redis'] ['disable_locking']);
             }
         } else {

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Redis.php
@@ -107,7 +107,7 @@ class Redis implements ProcessInterface
 
             if (isset($config['session']['redis']['disable_locking'])) {
                 $this->logger->info('Removing disable_locking env.php.');
-                unset($config['session']['redis'] ['disable_locking']);
+                unset($config['session']['redis']['disable_locking']);
             }
         } else {
             $config = $this->removeRedisConfiguration($config);

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/RedisTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/RedisTest.php
@@ -262,4 +262,85 @@ class RedisTest extends TestCase
 
         $this->process->execute();
     }
+
+    public function testRemoveDisableLocking()
+    {
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('info')
+            ->withConsecutive(
+                [
+                    'Updating env.php Redis cache configuration.',
+                ],
+                [
+                    'Removing disable_locking configuration.'
+                ]
+            );
+        $this->environmentMock->expects($this->any())
+            ->method('getRelationships')
+            ->willReturn([
+                'redis' => [
+                    0 => [
+                        'host' => '127.0.0.1',
+                        'port' => '6379',
+                    ],
+                ],
+            ]);
+        $this->environmentMock->expects($this->any())
+            ->method('getAdminUrl')
+            ->willReturn('admin');
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn([
+                'session' => [
+                    'redis' => [
+                        'max_concurrency' => 10,
+                        'bot_first_lifetime' => 100,
+                        'bot_lifetime' => 10000,
+                        'min_lifetime' => 100,
+                        'max_lifetime' => 10000,
+                        'disable_locking' => '1',
+                    ],
+                ],
+            ]);
+
+        $this->configWriterMock->expects($this->once())
+            ->method('write')
+            ->with([
+                'cache' => [
+                    'frontend' => [
+                        'default' => [
+                            'backend' => 'Cm_Cache_Backend_Redis',
+                            'backend_options' => [
+                                'server' => '127.0.0.1',
+                                'port' => '6379',
+                                'database' => 1,
+                            ],
+                        ],
+                        'page_cache' => [
+                            'backend' => 'Cm_Cache_Backend_Redis',
+                            'backend_options' => [
+                                'server' => '127.0.0.1',
+                                'port' => '6379',
+                                'database' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+                'session' => [
+                    'save' => 'redis',
+                    'redis' => [
+                        'host' => '127.0.0.1',
+                        'port' => '6379',
+                        'database' => 0,
+                        'max_concurrency' => 10,
+                        'bot_first_lifetime' => 100,
+                        'bot_lifetime' => 10000,
+                        'min_lifetime' => 100,
+                        'max_lifetime' => 10000,
+                    ],
+                ],
+            ]);
+
+        $this->process->execute();
+    }
 }

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/RedisTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/RedisTest.php
@@ -272,7 +272,7 @@ class RedisTest extends TestCase
                     'Updating env.php Redis cache configuration.',
                 ],
                 [
-                    'Removing disable_locking configuration.'
+                    'Removing disable_locking env.php.'
                 ]
             );
         $this->environmentMock->expects($this->any())
@@ -293,11 +293,6 @@ class RedisTest extends TestCase
             ->willReturn([
                 'session' => [
                     'redis' => [
-                        'max_concurrency' => 10,
-                        'bot_first_lifetime' => 100,
-                        'bot_lifetime' => 10000,
-                        'min_lifetime' => 100,
-                        'max_lifetime' => 10000,
                         'disable_locking' => '1',
                     ],
                 ],
@@ -332,11 +327,6 @@ class RedisTest extends TestCase
                         'host' => '127.0.0.1',
                         'port' => '6379',
                         'database' => 0,
-                        'max_concurrency' => 10,
-                        'bot_first_lifetime' => 100,
-                        'bot_lifetime' => 10000,
-                        'min_lifetime' => 100,
-                        'max_lifetime' => 10000,
                     ],
                 ],
             ]);


### PR DESCRIPTION
### Description
Removing disable_locking parameter if present in env.php

### Fixed Issues (if relevant)
1. Removing disable_locking parameter if present in env.php

### Zephyr Tests
1. None

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
