### PR TITLE
MAGECLOUD-982: Skip already applied patches

### DIFF
--- a/src/Patch/Applier.php
+++ b/src/Patch/Applier.php
@@ -80,7 +80,7 @@ class Applier
      * @return void
      * @throws \RuntimeException
      */
-    public function apply(string $path, $name, $packageName, $constraint)
+    public function apply(string $path, string $name = null, string $packageName = null, $constraint = null)
     {
         /**
          * Support for relative paths.
@@ -113,7 +113,7 @@ class Applier
                 throw $applyException;
             }
 
-            $this->logger->notice("Patch $name $constraint was already applied.");
+            $this->logger->notice("Patch $name was already applied.");
         }
 
         $this->logger->info('Done.');

--- a/src/Patch/Applier.php
+++ b/src/Patch/Applier.php
@@ -73,6 +73,8 @@ class Applier
     /**
      * Applies patch, using 'git apply' command.
      *
+     * If the patch fails to apply, checks if it has already been applied which is considered ok.
+     *
      * @param string $path Path to patch
      * @param string|null $name Name of patch
      * @param string|null $packageName Name of package to be patched
@@ -106,14 +108,12 @@ class Applier
             $this->shell->execute('git apply ' . $path);
         } catch (\RuntimeException $applyException) {
             try {
-                // Has this patch already been applied?
                 $this->shell->execute('git apply --check --reverse ' . $path);
             } catch (\RuntimeException $reverseException) {
-                // Applying the patch in reverse also failed, so something else was wrong
                 throw $applyException;
             }
 
-            $this->logger->notice("Patch $name was already applied.");
+            $this->logger->notice("Patch {$name} was already applied.");
         }
 
         $this->logger->info('Done.');

--- a/src/Test/Integration/ApplyPatchTest.php
+++ b/src/Test/Integration/ApplyPatchTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Integration;
+
+use Magento\MagentoCloud\Filesystem\FileList;
+use Magento\MagentoCloud\Patch\Applier;
+use Magento\MagentoCloud\Shell\ShellInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @inheritdoc
+ */
+class ApplyPatchTest extends TestCase
+{
+    private $bootstrap;
+
+    /**
+     * @var Applier
+     */
+    private $applier;
+
+    /**
+     * Path to patch file
+     *
+     * @var string
+     */
+    private $patchFile;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->bootstrap = Bootstrap::create();
+        $application = $this->bootstrap->createApplication([]);
+
+        $this->applier = $application->getContainer()
+            ->get(Applier::class);
+        $this->fileList = $application->getContainer()
+            ->get(FileList::class);
+
+        $this->patchFile  = realpath(__DIR__ . '/_files/patches/patch.diff');
+
+        // Make sure our target file is in its original state
+        $this->bootstrap->execute(sprintf(
+            'cp -f %s %s',
+            __DIR__ . '/_files/patches/target_file.md',
+            $this->bootstrap->getSandboxDir() . '/target_file.md'
+        ));
+    }
+
+    public function testApplyingPatch()
+    {
+        $this->applier->apply($this->patchFile);
+        $content = $this->getTargetFileContents();
+        $this->assertContains('# Hello Magento', $content);
+        $this->assertContains('## Additional Info', $content);
+    }
+
+    public function testApplyingExistingPatch()
+    {
+        $this->bootstrap->execute(sprintf(
+            'git apply -p0 --unsafe-paths --directory=%s %s',
+            $this->bootstrap->getSandboxDir(),
+            $this->patchFile
+        ));
+
+        $this->applier->apply($this->patchFile);
+
+        $content = $this->getTargetFileContents();
+        $this->assertContains('# Hello Magento', $content);
+        $this->assertContains('## Additional Info', $content);
+
+        $log = $this->getLogContent();
+        $this->assertContains("NOTICE: Patch $this->patchFile was already applied.", $log);
+    }
+
+    private function getTargetFileContents()
+    {
+        return file_get_contents($this->bootstrap->getSandboxDir() . '/target_file.md');
+    }
+
+    private function getLogContent()
+    {
+        return file_get_contents($this->fileList->getCloudLog());
+    }
+}

--- a/src/Test/Integration/Patch/ApplierTest.php
+++ b/src/Test/Integration/Patch/ApplierTest.php
@@ -3,17 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\MagentoCloud\Test\Integration;
+namespace Magento\MagentoCloud\Test\Integration\Patch;
 
 use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Patch\Applier;
 use Magento\MagentoCloud\Shell\ShellInterface;
+use Magento\MagentoCloud\Test\Integration\Bootstrap;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @inheritdoc
  */
-class ApplyPatchTest extends TestCase
+class ApplierTest extends TestCase
 {
     private $bootstrap;
 
@@ -42,12 +43,12 @@ class ApplyPatchTest extends TestCase
         $this->fileList = $application->getContainer()
             ->get(FileList::class);
 
-        $this->patchFile  = realpath(__DIR__ . '/_files/patches/patch.diff');
+        $this->patchFile  = realpath(__DIR__ . '/../_files/patches/patch.diff');
 
         // Make sure our target file is in its original state
         $this->bootstrap->execute(sprintf(
             'cp -f %s %s',
-            __DIR__ . '/_files/patches/target_file.md',
+            __DIR__ . '/../_files/patches/target_file.md',
             $this->bootstrap->getSandboxDir() . '/target_file.md'
         ));
     }
@@ -78,12 +79,18 @@ class ApplyPatchTest extends TestCase
         $this->assertContains("NOTICE: Patch $this->patchFile was already applied.", $log);
     }
 
-    private function getTargetFileContents()
+    /**
+     * @return string
+     */
+    private function getTargetFileContents(): string
     {
         return file_get_contents($this->bootstrap->getSandboxDir() . '/target_file.md');
     }
 
-    private function getLogContent()
+    /**
+     * @return string
+     */
+    private function getLogContent(): string
     {
         return file_get_contents($this->fileList->getCloudLog());
     }

--- a/src/Test/Integration/Patch/ApplierTest.php
+++ b/src/Test/Integration/Patch/ApplierTest.php
@@ -64,7 +64,7 @@ class ApplierTest extends TestCase
     public function testApplyingExistingPatch()
     {
         $this->bootstrap->execute(sprintf(
-            'git apply -p0 --unsafe-paths --directory=%s %s',
+            'patch --directory=%s < %s',
             $this->bootstrap->getSandboxDir(),
             $this->patchFile
         ));

--- a/src/Test/Integration/Patch/ApplierTest.php
+++ b/src/Test/Integration/Patch/ApplierTest.php
@@ -16,6 +16,9 @@ use PHPUnit\Framework\TestCase;
  */
 class ApplierTest extends TestCase
 {
+    /**
+     * @var Bootstrap
+     */
     private $bootstrap;
 
     /**

--- a/src/Test/Integration/_files/patches/patch.diff
+++ b/src/Test/Integration/_files/patches/patch.diff
@@ -1,0 +1,7 @@
+--- target_file.md	2018-01-26 16:04:11.000000000 -0600
++++ target_file.md	2018-01-26 16:04:45.000000000 -0600
+@@ -1 +1,3 @@
+-# Hello World
++# Hello Magento
++
++## Additional Info

--- a/src/Test/Integration/_files/patches/target_file.md
+++ b/src/Test/Integration/_files/patches/target_file.md
@@ -1,0 +1,1 @@
+# Hello World

--- a/src/Test/Unit/Patch/ApplierTest.php
+++ b/src/Test/Unit/Patch/ApplierTest.php
@@ -208,12 +208,12 @@ class ApplierTest extends TestCase
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
             ->withConsecutive(
-                ['Applying patch patchName 1.0.'],
+                ['Applying patch patchName (path/to/patch) 1.0.'],
                 ['Done.']
             );
         $this->loggerMock->expects($this->once())
             ->method('notice')
-            ->with("Patch {$name} was already applied.");
+            ->with("Patch patchName (path/to/patch) was already applied.");
 
         $this->applier->apply($path, $name, $packageName, $constraint);
     }
@@ -263,7 +263,7 @@ class ApplierTest extends TestCase
 
         $this->loggerMock->expects($this->once())
             ->method('info')
-            ->with('Applying patch patchName 1.0.');
+            ->with('Applying patch patchName (path/to/patch) 1.0.');
 
         $this->applier->apply($path, $name, $packageName, $constraint);
     }

--- a/src/Test/Unit/Patch/ApplierTest.php
+++ b/src/Test/Unit/Patch/ApplierTest.php
@@ -203,7 +203,7 @@ class ApplierTest extends TestCase
                 ['git apply ' . $path],
                 ['git apply --check --reverse ' . $path]
             )
-            ->will($this->returnCallback([$this, 'shellMockReverseCallback']));
+            ->willReturnCallback([$this, 'shellMockReverseCallback']);
 
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
@@ -213,22 +213,23 @@ class ApplierTest extends TestCase
             );
         $this->loggerMock->expects($this->once())
             ->method('notice')
-            ->with("Patch $name was already applied.");
+            ->with("Patch {$name} was already applied.");
 
         $this->applier->apply($path, $name, $packageName, $constraint);
     }
 
     /**
      * @param string $command
+     * @throws RuntimeException when the command isn't a reverse
      */
     public function shellMockReverseCallback(string $command)
     {
         if (strpos($command, '--reverse') !== false && strpos($command, '--check') !== false) {
-            // command was the reverse check, it's all good
+            // Command was the reverse check, it's all good.
             return;
         }
 
-        // Not a reverse, better throw an exception
+        // Not a reverse, better throw an exception.
         throw new \RuntimeException('Applying the patch has failed for some reason');
     }
 
@@ -267,14 +268,18 @@ class ApplierTest extends TestCase
         $this->applier->apply($path, $name, $packageName, $constraint);
     }
 
+    /**
+     * @param string $command
+     * @throws RuntimeException
+     */
     public function shellMockErrorCallback(string $command)
     {
         if (strpos($command, '--reverse') !== false && strpos($command, '--check') !== false) {
-            // command was the reverse check, still throw an error
+            // Command was the reverse check, still throw an error.
             throw new \RuntimeException('Checking the reverse of the patch has also failed for some reason');
         }
 
-        // Not a reverse, better throw an exception
+        // Not a reverse, better throw an exception.
         throw new \RuntimeException('Applying the patch has failed for some reason');
     }
 }

--- a/src/Test/Unit/Patch/ApplierTest.php
+++ b/src/Test/Unit/Patch/ApplierTest.php
@@ -213,7 +213,7 @@ class ApplierTest extends TestCase
             );
         $this->loggerMock->expects($this->once())
             ->method('notice')
-            ->with("Patch $name $constraint was already applied.");
+            ->with("Patch $name was already applied.");
 
         $this->applier->apply($path, $name, $packageName, $constraint);
     }


### PR DESCRIPTION
### Description

If applying a patch fails, ECE tools will check to see if the patch _in reverse_ would pass, in which case we know the patch was already applied earlier so we can continue without any errors.

### Fixed Issues (if relevant)

[MAGENTO-982](https://magento2.atlassian.net/browse/MAGECLOUD-982)

### Zephyr Tests



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
