### PR TITLE
MAGECLOUD-1513: Ensure 2.1.x Environment Variables Support

### DIFF
--- a/src/Config/Stage/Deploy.php
+++ b/src/Config/Stage/Deploy.php
@@ -125,6 +125,7 @@ class Deploy implements DeployInterface
             self::VAR_CLEAN_STATIC_FILES,
             self::VAR_STATIC_CONTENT_SYMLINK,
             self::VAR_UPDATE_URLS,
+            self::VAR_GENERATED_CODE_SYMLINK,
         ];
 
         foreach ($disabledFlow as $disabledVar) {
@@ -188,6 +189,7 @@ class Deploy implements DeployInterface
             self::VAR_STATIC_CONTENT_EXCLUDE_THEMES => '',
             self::VAR_SKIP_SCD => false,
             self::VAR_SCD_THREADS => 1,
+            self::VAR_GENERATED_CODE_SYMLINK => true,
         ];
     }
 }

--- a/src/Config/Stage/DeployInterface.php
+++ b/src/Config/Stage/DeployInterface.php
@@ -19,4 +19,9 @@ interface DeployInterface extends StageConfigInterface
     const VAR_STATIC_CONTENT_SYMLINK = 'STATIC_CONTENT_SYMLINK';
     const VAR_UPDATE_URLS = 'UPDATE_URLS';
     const VAR_STATIC_CONTENT_EXCLUDE_THEMES = 'STATIC_CONTENT_EXCLUDE_THEMES';
+
+    /**
+     * @deprecated 2.1 specific variable
+     */
+    const VAR_GENERATED_CODE_SYMLINK = 'GENERATED_CODE_SYMLINK';
 }

--- a/src/Config/Stage/DeployInterface.php
+++ b/src/Config/Stage/DeployInterface.php
@@ -21,7 +21,7 @@ interface DeployInterface extends StageConfigInterface
     const VAR_STATIC_CONTENT_EXCLUDE_THEMES = 'STATIC_CONTENT_EXCLUDE_THEMES';
 
     /**
-     * @deprecated 2.1 specific variable
+     * @deprecated 2.1 specific variable.
      */
     const VAR_GENERATED_CODE_SYMLINK = 'GENERATED_CODE_SYMLINK';
 }

--- a/src/Filesystem/DirectoryList.php
+++ b/src/Filesystem/DirectoryList.php
@@ -208,15 +208,15 @@ class DirectoryList
     public function getDefault22Config(): array
     {
         return [
-            static::DIR_INIT               => [static::PATH => 'init'],
-            static::DIR_VAR                => [static::PATH => 'var'],
-            static::DIR_LOG                => [static::PATH => 'var/log'],
-            static::DIR_VIEW_PREPROCESSED  => [static::PATH => 'var/view_preprocessed'],
-            static::DIR_GENERATED          => [static::PATH => 'generated'],
-            static::DIR_GENERATED_CODE     => [static::PATH => 'generated/code'],
+            static::DIR_INIT => [static::PATH => 'init'],
+            static::DIR_VAR => [static::PATH => 'var'],
+            static::DIR_LOG => [static::PATH => 'var/log'],
+            static::DIR_VIEW_PREPROCESSED => [static::PATH => 'var/view_preprocessed'],
+            static::DIR_GENERATED => [static::PATH => 'generated'],
+            static::DIR_GENERATED_CODE => [static::PATH => 'generated/code'],
             static::DIR_GENERATED_METADATA => [static::PATH => 'generated/metadata'],
-            static::DIR_ETC                => [static::PATH => 'app/etc'],
-            static::DIR_MEDIA              => [static::PATH => 'pub/media'],
+            static::DIR_ETC => [static::PATH => 'app/etc'],
+            static::DIR_MEDIA => [static::PATH => 'pub/media'],
         ];
     }
 
@@ -226,14 +226,14 @@ class DirectoryList
     public function getDefault21Config(): array
     {
         return [
-            static::DIR_INIT               => [static::PATH => 'init'],
-            static::DIR_VAR                => [static::PATH => 'var'],
-            static::DIR_LOG                => [static::PATH => 'var/log'],
-            static::DIR_GENERATED_CODE     => [static::PATH => 'var/generation'],
+            static::DIR_INIT => [static::PATH => 'init'],
+            static::DIR_VAR => [static::PATH => 'var'],
+            static::DIR_LOG => [static::PATH => 'var/log'],
+            static::DIR_GENERATED_CODE => [static::PATH => 'var/generation'],
             static::DIR_GENERATED_METADATA => [static::PATH => 'var/di'],
-            static::DIR_VIEW_PREPROCESSED  => [static::PATH => 'var/view_preprocessed'],
-            static::DIR_ETC                => [static::PATH => 'app/etc'],
-            static::DIR_MEDIA              => [static::PATH => 'pub/media'],
+            static::DIR_VIEW_PREPROCESSED => [static::PATH => 'var/view_preprocessed'],
+            static::DIR_ETC => [static::PATH => 'app/etc'],
+            static::DIR_MEDIA => [static::PATH => 'pub/media'],
         ];
     }
 }

--- a/src/Filesystem/RecoverableDirectoryList.php
+++ b/src/Filesystem/RecoverableDirectoryList.php
@@ -93,7 +93,7 @@ class RecoverableDirectoryList
         /**
          * Magento 2.1 related directories.
          */
-        if ($this->magentoVersion->isBetween('2.1', '2.2')) {
+        if ($this->magentoVersion->satisfies('~2.1')) {
             $diStrategy = $this->stageConfig->get(DeployInterface::VAR_GENERATED_CODE_SYMLINK)
                 ? StrategyInterface::STRATEGY_SYMLINK
                 : StrategyInterface::STRATEGY_COPY;

--- a/src/Filesystem/RecoverableDirectoryList.php
+++ b/src/Filesystem/RecoverableDirectoryList.php
@@ -93,7 +93,7 @@ class RecoverableDirectoryList
         /**
          * Magento 2.1 related directories.
          */
-        if ($this->magentoVersion->satisfies('~2.1')) {
+        if ($this->magentoVersion->satisfies('2.1.*')) {
             $diStrategy = $this->stageConfig->get(DeployInterface::VAR_GENERATED_CODE_SYMLINK)
                 ? StrategyInterface::STRATEGY_SYMLINK
                 : StrategyInterface::STRATEGY_COPY;

--- a/src/Filesystem/RecoverableDirectoryList.php
+++ b/src/Filesystem/RecoverableDirectoryList.php
@@ -39,7 +39,7 @@ class RecoverableDirectoryList
      * @var MagentoVersion
      */
     private $magentoVersion;
-    
+
     /**
      * @param Environment $environment
      * @param FlagManager $flagManager
@@ -70,34 +70,41 @@ class RecoverableDirectoryList
         $recoverableDirs = [
             [
                 self::OPTION_DIRECTORY => 'app/etc',
-                self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
+                self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY,
             ],
             [
                 self::OPTION_DIRECTORY => 'pub/media',
-                self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
-            ]
+                self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY,
+            ],
         ];
-        
-        if ($this->magentoVersion->isGreaterOrEqual('2.1') && !$this->magentoVersion->isGreaterOrEqual('2.2')) {
-            $recoverableDirs[] = [
-                self::OPTION_DIRECTORY => 'var/di',
-                self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
-            ];
-            $recoverableDirs[] = [
-                self::OPTION_DIRECTORY => 'var/generation',
-                self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
-            ];
-        }
 
         if ($this->flagManager->exists(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)) {
             $recoverableDirs[] = [
                 self::OPTION_DIRECTORY => 'var/view_preprocessed',
-                self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY
+                self::OPTION_STRATEGY => StrategyInterface::STRATEGY_COPY,
             ];
             $recoverableDirs[] = [
                 self::OPTION_DIRECTORY => 'pub/static',
                 self::OPTION_STRATEGY => $isSymlinkEnabled ?
-                    StrategyInterface::STRATEGY_SUB_SYMLINK : StrategyInterface::STRATEGY_COPY
+                    StrategyInterface::STRATEGY_SUB_SYMLINK : StrategyInterface::STRATEGY_COPY,
+            ];
+        }
+
+        /**
+         * Magento 2.1 related directories.
+         */
+        if ($this->magentoVersion->isBetween('2.1', '2.2')) {
+            $diStrategy = $this->stageConfig->get(DeployInterface::VAR_GENERATED_CODE_SYMLINK)
+                ? StrategyInterface::STRATEGY_SYMLINK
+                : StrategyInterface::STRATEGY_COPY;
+
+            $recoverableDirs[] = [
+                self::OPTION_DIRECTORY => 'var/di',
+                self::OPTION_STRATEGY => $diStrategy,
+            ];
+            $recoverableDirs[] = [
+                self::OPTION_DIRECTORY => 'var/generation',
+                self::OPTION_STRATEGY => $diStrategy,
             ];
         }
 

--- a/src/Package/MagentoVersion.php
+++ b/src/Package/MagentoVersion.php
@@ -61,6 +61,19 @@ class MagentoVersion
     }
 
     /**
+     * Compares version between 2 constraints.
+     *
+     * @param string $versionFrom
+     * @param string $versionTo
+     * @return bool
+     */
+    public function isBetween(string $versionFrom, string $versionTo): bool
+    {
+        return $this->comparator::compare($this->getVersion(), '>=', $versionFrom)
+            && $this->comparator::compare($this->getVersion(), '<', $versionTo);
+    }
+
+    /**
      * Check the current Magento version against Composer-style constraints.
      *
      * @param string $constraints

--- a/src/Package/MagentoVersion.php
+++ b/src/Package/MagentoVersion.php
@@ -9,9 +9,7 @@ use Composer\Semver\Comparator;
 use Composer\Semver\Semver;
 
 /**
- * Class MagentoVersion
- *
- * @package Magento\MagentoCloud\Package
+ * Defines methods for comparing version constraints with base Magento package.
  */
 class MagentoVersion
 {
@@ -58,19 +56,6 @@ class MagentoVersion
     public function isGreaterOrEqual(string $version): bool
     {
         return $this->comparator::compare($this->getVersion(), '>=', $version);
-    }
-
-    /**
-     * Compares version between 2 constraints.
-     *
-     * @param string $versionFrom
-     * @param string $versionTo
-     * @return bool
-     */
-    public function isBetween(string $versionFrom, string $versionTo): bool
-    {
-        return $this->comparator::compare($this->getVersion(), '>=', $versionFrom)
-            && $this->comparator::compare($this->getVersion(), '<', $versionTo);
     }
 
     /**

--- a/src/Test/Unit/Filesystem/RecoverableDirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/RecoverableDirectoryListTest.php
@@ -78,7 +78,7 @@ class RecoverableDirectoryListTest extends TestCase
         $this->magentoVersionMock->expects($this->once())
             ->method('satisfies')
             ->willReturnMap([
-                ['~2.1', false],
+                ['2.1.*', false],
             ]);
         $this->flagManagerMock->expects($this->once())
             ->method('exists')
@@ -176,7 +176,7 @@ class RecoverableDirectoryListTest extends TestCase
         $this->magentoVersionMock->expects($this->once())
             ->method('satisfies')
             ->willReturnMap([
-                ['~2.1', true],
+                ['2.1.*', true],
             ]);
         $this->flagManagerMock->expects($this->once())
             ->method('exists')

--- a/src/Test/Unit/Filesystem/RecoverableDirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/RecoverableDirectoryListTest.php
@@ -76,9 +76,9 @@ class RecoverableDirectoryListTest extends TestCase
                 [DeployInterface::VAR_STATIC_CONTENT_SYMLINK, $isSymlinkOn],
             ]);
         $this->magentoVersionMock->expects($this->once())
-            ->method('isBetween')
+            ->method('satisfies')
             ->willReturnMap([
-                ['2.1', '2.2', false],
+                ['~2.1', false],
             ]);
         $this->flagManagerMock->expects($this->once())
             ->method('exists')
@@ -174,9 +174,9 @@ class RecoverableDirectoryListTest extends TestCase
                 [DeployInterface::VAR_GENERATED_CODE_SYMLINK, $isGeneratedSymlinkOn],
             ]);
         $this->magentoVersionMock->expects($this->once())
-            ->method('isBetween')
+            ->method('satisfies')
             ->willReturnMap([
-                ['2.1', '2.2', true],
+                ['~2.1', true],
             ]);
         $this->flagManagerMock->expects($this->once())
             ->method('exists')

--- a/src/Test/Unit/Filesystem/RecoverableDirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/RecoverableDirectoryListTest.php
@@ -7,6 +7,7 @@ namespace Magento\MagentoCloud\Test\Unit\Filesystem;
 
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\Stage\DeployInterface;
+use Magento\MagentoCloud\Filesystem\DirectoryCopier\StrategyInterface;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Filesystem\RecoverableDirectoryList;
 use Magento\MagentoCloud\Package\MagentoVersion;
@@ -42,7 +43,7 @@ class RecoverableDirectoryListTest extends TestCase
      * @var MagentoVersion|Mock
      */
     private $magentoVersionMock;
-    
+
     /**
      * @inheritdoc
      */
@@ -66,22 +67,24 @@ class RecoverableDirectoryListTest extends TestCase
      * @param bool $isStaticInBuild
      * @param array $expected
      * @dataProvider getListDataProvider22
-     * @dataProvider getListDataProvider21
      */
-    public function testGetList(bool $isSymlinkOn, bool $isStaticInBuild, bool $is22, bool $is21, array $expected)
+    public function testGetList22(bool $isSymlinkOn, bool $isStaticInBuild, array $expected)
     {
-        $this->stageConfigMock->expects($this->once())
+        $this->stageConfigMock->expects($this->any())
             ->method('get')
-            ->with(DeployInterface::VAR_STATIC_CONTENT_SYMLINK)
-            ->willReturn($isSymlinkOn);
-        $this->magentoVersionMock->expects($this->exactly(2))
-            ->method('isGreaterOrEqual')
-            ->withConsecutive(['2.1'], ['2.2'])
-            ->willReturnOnConsecutiveCalls($is21, $is22);
+            ->willReturnMap([
+                [DeployInterface::VAR_STATIC_CONTENT_SYMLINK, $isSymlinkOn],
+            ]);
+        $this->magentoVersionMock->expects($this->once())
+            ->method('isBetween')
+            ->willReturnMap([
+                ['2.1', '2.2', false],
+            ]);
         $this->flagManagerMock->expects($this->once())
             ->method('exists')
             ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
             ->willReturn($isStaticInBuild);
+
         $this->assertEquals(
             $expected,
             $this->recoverableDirectoryList->getList()
@@ -94,161 +97,210 @@ class RecoverableDirectoryListTest extends TestCase
     public function getListDataProvider22(): array
     {
         return [
-            [
-                true, // $isSymlinkOn
-                true, // $isStaticInBuild
-                true, // $is22
-                true, // $is21
-                [
+            'symlink and static in build' => [
+                'isSymlinkOn' => true,
+                'isStaticInBuild' => true,
+                'expected' => [
                     [
                         'directory' => 'app/etc',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'pub/media',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'var/view_preprocessed',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'pub/static',
-                        'strategy' => 'sub_symlink',
+                        'strategy' => StrategyInterface::STRATEGY_SUB_SYMLINK,
                     ],
                 ],
             ],
-            [
-                false, // $isSymlinkOn
-                true, // $isStaticInBuild
-                true, // $is22
-                true, // $is21
-                [
+            'no symlink and static in build' => [
+                'isSymlinkOn' => false,
+                'isStaticInBuild' => true,
+                'expected' => [
                     [
                         'directory' => 'app/etc',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'pub/media',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'var/view_preprocessed',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'pub/static',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                 ],
             ],
-            [
-                true, // $isSymlinkOn
-                false, // $isStaticInBuild
-                true, // $is22
-                true, // $is21
-                [
+            'symlink and no static in build' => [
+                'isSymlinkOn' => true,
+                'isStaticInBuild' => false,
+                'expected' => [
                     [
                         'directory' => 'app/etc',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'pub/media',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                 ],
             ],
         ];
     }
 
+    /**
+     * @param bool $isSymlinkOn
+     * @param bool $isStaticInBuild
+     * @param bool $isGeneratedSymlinkOn
+     * @param array $expected
+     * @dataProvider getListDataProvider21
+     */
+    public function testGetList21(bool $isSymlinkOn, bool $isGeneratedSymlinkOn, bool $isStaticInBuild, array $expected)
+    {
+        $this->stageConfigMock->expects($this->any())
+            ->method('get')
+            ->willReturnMap([
+                [DeployInterface::VAR_STATIC_CONTENT_SYMLINK, $isSymlinkOn],
+                [DeployInterface::VAR_GENERATED_CODE_SYMLINK, $isGeneratedSymlinkOn],
+            ]);
+        $this->magentoVersionMock->expects($this->once())
+            ->method('isBetween')
+            ->willReturnMap([
+                ['2.1', '2.2', true],
+            ]);
+        $this->flagManagerMock->expects($this->once())
+            ->method('exists')
+            ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
+            ->willReturn($isStaticInBuild);
+
+        $this->assertEquals(
+            $expected,
+            $this->recoverableDirectoryList->getList()
+        );
+    }
+
+    /**
+     * @return array
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
     public function getListDataProvider21(): array
     {
         return [
-            [
-                true, // $isSymlinkOn
-                true, // $isStaticInBuild
-                false, // $is22
-                true, // $is21
-                [
+            'static symlink, no generated symlink, static in build' => [
+                'isSymlinkOn' => true,
+                'isGeneratedSymlinkOn' => false,
+                'isStaticInBuild' => true,
+                'expected' => [
                     [
                         'directory' => 'app/etc',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'pub/media',
-                        'strategy' => 'copy',
-                    ],
-                    [
-                        'directory' => 'var/di',
-                        'strategy' => 'copy',
-                    ],
-                    [
-                        'directory' => 'var/generation',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'var/view_preprocessed',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'pub/static',
-                        'strategy' => 'sub_symlink',
-                    ],
-                ],
-            ],
-            [
-                false, // $isSymlinkOn
-                true, // $isStaticInBuild
-                false, // $is22
-                true, // $is21
-                [
-                    [
-                        'directory' => 'app/etc',
-                        'strategy' => 'copy',
-                    ],
-                    [
-                        'directory' => 'pub/media',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_SUB_SYMLINK,
                     ],
                     [
                         'directory' => 'var/di',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'var/generation',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
+                    ],
+                ],
+            ],
+            'no static symlink, no generated symlink, static in build' => [
+                'isSymlinkOn' => false,
+                'isGeneratedSymlinkOn' => false,
+                'isStaticInBuild' => true,
+                'expected' => [
+                    [
+                        'directory' => 'app/etc',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
+                    ],
+                    [
+                        'directory' => 'pub/media',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'var/view_preprocessed',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'pub/static',
-                        'strategy' => 'copy',
-                    ],
-                ],
-            ],
-            [
-                true, // $isSymlinkOn
-                false, // $isStaticInBuild
-                false, // $is22
-                true, // $is21
-                [
-                    [
-                        'directory' => 'app/etc',
-                        'strategy' => 'copy',
-                    ],
-                    [
-                        'directory' => 'pub/media',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'var/di',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
                     ],
                     [
                         'directory' => 'var/generation',
-                        'strategy' => 'copy',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
+                    ],
+                ],
+            ],
+            'static symlink, no generated symlink, no static in build' => [
+                'isSymlinkOn' => true,
+                'isGeneratedSymlinkOn' => false,
+                'isStaticInBuild' => false,
+                'expected' => [
+                    [
+                        'directory' => 'app/etc',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
+                    ],
+                    [
+                        'directory' => 'pub/media',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
+                    ],
+                    [
+                        'directory' => 'var/di',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
+                    ],
+                    [
+                        'directory' => 'var/generation',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
+                    ],
+                ],
+            ],
+            'static symlink, generated symlink, no static in build' => [
+                'isSymlinkOn' => true,
+                'isGeneratedSymlinkOn' => true,
+                'isStaticInBuild' => false,
+                'expected' => [
+                    [
+                        'directory' => 'app/etc',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
+                    ],
+                    [
+                        'directory' => 'pub/media',
+                        'strategy' => StrategyInterface::STRATEGY_COPY,
+                    ],
+                    [
+                        'directory' => 'var/di',
+                        'strategy' => StrategyInterface::STRATEGY_SYMLINK,
+                    ],
+                    [
+                        'directory' => 'var/generation',
+                        'strategy' => StrategyInterface::STRATEGY_SYMLINK,
                     ],
                 ],
             ],

--- a/src/Test/Unit/Package/MagentoVersionTest.php
+++ b/src/Test/Unit/Package/MagentoVersionTest.php
@@ -104,20 +104,23 @@ class MagentoVersionTest extends TestCase
     /**
      * Test the constraint matcher using various Composer-style version constraints.
      *
-     * @param string $assertion Method name of the assertion to call
      * @param string $constraint Composer-style version constraint string
+     * @param bool $expected Method name of the assertion to call
      * @dataProvider satisfiesDataProvider
      */
-    public function testSatisfies(string $assertion, string $constraint)
+    public function testSatisfies(string $constraint, string $packageVersion, bool $expected)
     {
         $this->managerMock->expects($this->exactly(1))
             ->method('get')
             ->willReturn($this->packageMock);
         $this->packageMock->expects($this->exactly(1))
             ->method('getVersion')
-            ->willReturn('2.2.1');
+            ->willReturn($packageVersion);
 
-        $this->$assertion($this->magentoVersion->satisfies($constraint));
+        $this->assertSame(
+            $expected,
+            $this->magentoVersion->satisfies($constraint)
+        );
     }
 
     /**
@@ -126,47 +129,15 @@ class MagentoVersionTest extends TestCase
     public function satisfiesDataProvider()
     {
         return [
-            ['assertTrue', '2.2.1'],
-            ['assertTrue', '2.2.*'],
-            ['assertTrue', '~2.2.0'],
-            ['assertFalse', '2.2.0'],
-            ['assertFalse', '2.1.*'],
-            ['assertFalse', '~2.1.0'],
-        ];
-    }
-
-    /**
-     * @param string $versionFrom
-     * @param string $versionTo
-     * @param string $packageVersion
-     * @param bool $expected
-     * @dataProvider isBetweenDataDataProvider
-     */
-    public function testIsBetween(string $versionFrom, string $versionTo, string $packageVersion, bool $expected)
-    {
-        $this->managerMock->method('get')
-            ->with('magento/magento2-base')
-            ->willReturn($this->packageMock);
-        $this->packageMock->expects($this->exactly(2))
-            ->method('getVersion')
-            ->willReturn($packageVersion);
-
-        $this->assertSame(
-            $expected,
-            $this->magentoVersion->isBetween($versionFrom, $versionTo)
-        );
-    }
-
-    /**
-     * @return array
-     */
-    public function isBetweenDataDataProvider(): array
-    {
-        return [
-            ['2.1', '2.2', '2.1.9', true],
-            ['2.1', '2.2', '2.2', false],
-            ['2.1', '2.2', '2.1', true],
-            ['2.1', '2.2', '2.2-dev', true],
+            ['2.2.1', '2.2.1', true],
+            ['2.2.*', '2.2.1', true],
+            ['~2.2.0', '2.2.1', true],
+            ['2.2.0', '2.2.1', false],
+            ['2.1.*', '2.2.1', false],
+            ['~2.1.0', '2.2.1', false],
+            ['~2.1.0', '2.1.1', true],
+            ['~2.2.0', '2.1.1', false],
+            ['~2.2', '2.1', false],
         ];
     }
 }

--- a/src/Test/Unit/Package/MagentoVersionTest.php
+++ b/src/Test/Unit/Package/MagentoVersionTest.php
@@ -97,7 +97,7 @@ class MagentoVersionTest extends TestCase
         $this->packageMock->expects($this->once())
             ->method('getVersion')
             ->willReturn('2.2.1');
-        
+
         $this->assertSame('2.2.1', $this->magentoVersion->getVersion());
     }
 
@@ -132,6 +132,41 @@ class MagentoVersionTest extends TestCase
             ['assertFalse', '2.2.0'],
             ['assertFalse', '2.1.*'],
             ['assertFalse', '~2.1.0'],
+        ];
+    }
+
+    /**
+     * @param string $versionFrom
+     * @param string $versionTo
+     * @param string $packageVersion
+     * @param bool $expected
+     * @dataProvider isBetweenDataDataProvider
+     */
+    public function testIsBetween(string $versionFrom, string $versionTo, string $packageVersion, bool $expected)
+    {
+        $this->managerMock->method('get')
+            ->with('magento/magento2-base')
+            ->willReturn($this->packageMock);
+        $this->packageMock->expects($this->exactly(2))
+            ->method('getVersion')
+            ->willReturn($packageVersion);
+
+        $this->assertSame(
+            $expected,
+            $this->magentoVersion->isBetween($versionFrom, $versionTo)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function isBetweenDataDataProvider(): array
+    {
+        return [
+            ['2.1', '2.2', '2.1.9', true],
+            ['2.1', '2.2', '2.2', false],
+            ['2.1', '2.2', '2.1', true],
+            ['2.1', '2.2', '2.2-dev', true],
         ];
     }
 }

--- a/src/Test/Unit/Package/MagentoVersionTest.php
+++ b/src/Test/Unit/Package/MagentoVersionTest.php
@@ -137,7 +137,7 @@ class MagentoVersionTest extends TestCase
             ['~2.1.0', '2.2.1', false],
             ['~2.1.0', '2.1.1', true],
             ['~2.2.0', '2.1.1', false],
-            ['~2.2', '2.1', false],
+            ['2.1.*', '2.2', false],
         ];
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
2.1.x Cloud environment variables should be supported on ece-tools. In this task we need a list of all known environment variables used in 2.1.x/mcc. Where the variable has been redefined ece-tools should be re-factored to handle either variable name.

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
1. Adds `GENERATED_CODE_SYMLINKS` variable

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. https://jira.corp.magento.com/browse/MAGETWO-67598

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
