### PR TITLE
MAGECLOUD-1603: Fix BackupData::execute()

### DIFF
--- a/src/Filesystem/DirectoryList.php
+++ b/src/Filesystem/DirectoryList.php
@@ -70,9 +70,9 @@ class DirectoryList
      * @param string $code
      * @return string
      */
-    public function getPath(string $code): string
+    public function getPath(string $code, bool $relativePath = false): string
     {
-        $magentoRoot = $this->getMagentoRoot();
+        $magentoRoot = $relativePath ? '' : $this->getMagentoRoot();
         $directories = $this->getDirectories();
 
         if (!array_key_exists($code, $directories)) {
@@ -168,7 +168,7 @@ class DirectoryList
      *
      * @return array
      */
-    public function getWritableDirectories(): array
+    public function getWritableDirectories(bool $relativePath = false): array
     {
         $writableDirs = [static::DIR_ETC, static::DIR_MEDIA];
 
@@ -186,7 +186,9 @@ class DirectoryList
             $writableDirs[] = static::DIR_VAR;
         }
 
-        return array_map([$this, 'getPath'], $writableDirs);
+        return array_map(function ($path) use ($relativePath) {
+            return $this->getPath($path, $relativePath);
+        }, $writableDirs);
     }
 
     /**

--- a/src/Filesystem/DirectoryList.php
+++ b/src/Filesystem/DirectoryList.php
@@ -172,7 +172,7 @@ class DirectoryList
     {
         $writableDirs = [static::DIR_ETC, static::DIR_MEDIA];
 
-        if ($this->magentoVersion->satisfies('2.1.*')) {
+        if (!$this->magentoVersion->isGreaterOrEqual('2.2')) {
             $magento21Dirs = [
                 static::DIR_GENERATED_METADATA,
                 static::DIR_GENERATED_CODE,
@@ -180,9 +180,7 @@ class DirectoryList
             ];
 
             $writableDirs = array_merge($writableDirs, $magento21Dirs);
-        }
-
-        if ($this->magentoVersion->satisfies('2.2.*')) {
+        } else {
             $writableDirs[] = static::DIR_VAR;
         }
 
@@ -200,14 +198,6 @@ class DirectoryList
             return $this->getDefault21Config();
         }
 
-        return $this->getDefault22Config();
-    }
-
-    /**
-     * @return array
-     */
-    public function getDefault22Config(): array
-    {
         return [
             static::DIR_INIT               => [static::PATH => 'init'],
             static::DIR_VAR                => [static::PATH => 'var'],
@@ -224,7 +214,7 @@ class DirectoryList
     /**
      * @return array
      */
-    public function getDefault21Config(): array
+    private function getDefault21Config(): array
     {
         return [
             static::DIR_INIT               => [static::PATH => 'init'],

--- a/src/Filesystem/DirectoryList.php
+++ b/src/Filesystem/DirectoryList.php
@@ -170,24 +170,23 @@ class DirectoryList
      */
     public function getWritableDirectories(): array
     {
-        $writableDirs = [static::DIR_VAR, static::DIR_ETC, static::DIR_MEDIA];
+        $writableDirs = [static::DIR_ETC, static::DIR_MEDIA];
 
-        if (!$this->magentoVersion->isGreaterOrEqual(2.2)) {
-            $writableDirs = [
+        if ($this->magentoVersion->satisfies('2.1.*')) {
+            $magento21Dirs = [
                 static::DIR_GENERATED_METADATA,
                 static::DIR_GENERATED_CODE,
-                static::DIR_ETC,
-                static::DIR_MEDIA,
                 static::DIR_VIEW_PREPROCESSED,
             ];
+
+            $writableDirs = array_merge($writableDirs, $magento21Dirs);
         }
 
-        return array_map(
-            [$this, 'getPath'],
-            array_filter(array_keys($this->getDirectories()), function ($key) use ($writableDirs) {
-                return in_array($key, $writableDirs);
-            })
-        );
+        if ($this->magentoVersion->satisfies('2.2.*')) {
+            $writableDirs[] = static::DIR_VAR;
+        }
+
+        return array_map([$this, 'getPath'], $writableDirs);
     }
 
     /**

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -105,9 +105,8 @@ class BackupData implements ProcessInterface
 
         $this->stopLogging();
 
-        foreach ($this->directoryList->getWritableDirectories() as $dir) {
-            $originalDir = $magentoRoot . $dir;
-            $initDir = $rootInitDir . $dir;
+        foreach ($this->directoryList->getWritableDirectories() as $originalDir) {
+            $initDir = $rootInitDir . substr($originalDir, strlen($magentoRoot));
 
             $this->file->createDirectory($initDir);
             $this->file->createDirectory($originalDir);

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -105,8 +105,9 @@ class BackupData implements ProcessInterface
 
         $this->stopLogging();
 
-        foreach ($this->directoryList->getWritableDirectories() as $originalDir) {
-            $initDir = $rootInitDir . substr($originalDir, strlen($magentoRoot));
+        foreach ($this->directoryList->getWritableDirectories(true) as $dir) {
+            $originalDir = $magentoRoot . $dir;
+            $initDir     = $rootInitDir . $dir;
 
             $this->file->createDirectory($initDir);
             $this->file->createDirectory($originalDir);

--- a/src/Test/Unit/Filesystem/DirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/DirectoryListTest.php
@@ -16,7 +16,7 @@ class DirectoryListTest extends TestCase
 {
     public function testGetPath()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreater();
+        $directoryList = $this->get22DirectoryList();
 
         $this->assertSame(
             __DIR__ . '/_files/test/var',
@@ -35,7 +35,7 @@ class DirectoryListTest extends TestCase
      */
     public function testGetPathWithException()
     {
-        $this->get22DirectoryListWithIsGreater()->getPath('some_code');
+        $this->get22DirectoryList()->getPath('some_code');
     }
 
     /**
@@ -44,12 +44,12 @@ class DirectoryListTest extends TestCase
      */
     public function testGetPathWithEmptyPathException()
     {
-        $this->get22DirectoryListWithIsGreater()->getPath('empty_path');
+        $this->get22DirectoryList()->getPath('empty_path');
     }
 
     public function testGetRoot()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreater();
+        $directoryList = $this->get22DirectoryList();
 
         $this->assertSame(
             __DIR__ . '/_files/bp',
@@ -59,7 +59,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetMagentoRoot()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreater();
+        $directoryList = $this->get22DirectoryList();
 
         $this->assertSame(
             __DIR__,
@@ -69,7 +69,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetInit()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreater();
+        $directoryList = $this->get22DirectoryList();
 
         $this->assertSame(
             __DIR__ . '/init',
@@ -79,7 +79,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetVar()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreater();
+        $directoryList = $this->get22DirectoryList();
 
         $this->assertSame(
             __DIR__ . '/var',
@@ -89,7 +89,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetLog()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreater();
+        $directoryList = $this->get22DirectoryList();
 
         $this->assertSame(
             __DIR__ . '/var/log',
@@ -99,7 +99,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetGenerated()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreater();
+        $directoryList = $this->get22DirectoryList();
 
         $this->assertSame(
             __DIR__ . '/generated',
@@ -120,8 +120,8 @@ class DirectoryListTest extends TestCase
     public function getGeneratedCodeDataProvider(): array
     {
         return [
-            [$this->get21DirectoryListWithIsGreater(), __DIR__ . '/var/generation'],
-            [$this->get22DirectoryListWithIsGreater(), __DIR__ . '/generated/code'],
+            [$this->get21DirectoryList(), __DIR__ . '/var/generation'],
+            [$this->get22DirectoryList(), __DIR__ . '/generated/code'],
         ];
     }
 
@@ -138,8 +138,8 @@ class DirectoryListTest extends TestCase
     public function getGeneratedMetadataDataProvider(): array
     {
         return [
-            [$this->get21DirectoryListWithIsGreater(), __DIR__ . '/var/di'],
-            [$this->get22DirectoryListWithIsGreater(), __DIR__ . '/generated/metadata'],
+            [$this->get21DirectoryList(), __DIR__ . '/var/di'],
+            [$this->get22DirectoryList(), __DIR__ . '/generated/metadata'],
         ];
     }
 
@@ -177,14 +177,14 @@ class DirectoryListTest extends TestCase
         $relative22Paths = ['var', 'app/etc', 'pub/media'];
 
         return [
-            [$this->get21DirectoryListWithSatisfies(), $abs21Paths,      false],
-            [$this->get22DirectoryListWithSatisfies(), $abs22Paths,      false],
-            [$this->get21DirectoryListWithSatisfies(), $relative21Paths, true],
-            [$this->get22DirectoryListWithSatisfies(), $relative22Paths, true],
+            [$this->get21DirectoryList(), $abs21Paths,      false],
+            [$this->get22DirectoryList(), $abs22Paths,      false],
+            [$this->get21DirectoryList(), $relative21Paths, true],
+            [$this->get22DirectoryList(), $relative22Paths, true],
         ];
     }
 
-    private function get21DirectoryListWithIsGreater()
+    private function get21DirectoryList()
     {
         $magentoVersionMock = $this->createMock(MagentoVersion::class);
 
@@ -200,49 +200,13 @@ class DirectoryListTest extends TestCase
         );
     }
 
-    private function get21DirectoryListWithSatisfies()
-    {
-        $magentoVersionMock = $this->createMock(MagentoVersion::class);
-
-        $magentoVersionMock->method('satisfies')
-            ->willReturnMap([
-                ['2.1.*', true],
-                ['2.2.*', false],
-            ]);
-
-        return new DirectoryList(
-            __DIR__ . '/_files/bp',
-            __DIR__,
-            $magentoVersionMock,
-            ['empty_path' => [], 'test_var' => [DirectoryList::PATH => '_files/test/var']]
-        );
-    }
-
-    private function get22DirectoryListWithIsGreater()
+    private function get22DirectoryList()
     {
         $magentoVersionMock = $this->createMock(MagentoVersion::class);
 
         $magentoVersionMock->method('isGreaterOrEqual')
             ->with('2.2')
             ->willReturn(true);
-
-        return new DirectoryList(
-            __DIR__ . '/_files/bp',
-            __DIR__,
-            $magentoVersionMock,
-            ['empty_path' => [], 'test_var' => [DirectoryList::PATH => '_files/test/var']]
-        );
-    }
-
-    private function get22DirectoryListWithSatisfies()
-    {
-        $magentoVersionMock = $this->createMock(MagentoVersion::class);
-
-        $magentoVersionMock->method('satisfies')
-            ->willReturnMap([
-                ['2.1.*', false],
-                ['2.2.*', true],
-            ]);
 
         return new DirectoryList(
             __DIR__ . '/_files/bp',

--- a/src/Test/Unit/Filesystem/DirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/DirectoryListTest.php
@@ -14,17 +14,18 @@ use PHPUnit\Framework\TestCase;
  */
 class DirectoryListTest extends TestCase
 {
-    /**
-     * @param string $code
-     * @param string $expected
-     */
     public function testGetPath()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreator();
+        $directoryList = $this->get22DirectoryListWithIsGreater();
 
         $this->assertSame(
             __DIR__ . '/_files/test/var',
             $directoryList->getPath('test_var')
+        );
+
+        $this->assertSame(
+            '_files/test/var',
+            $directoryList->getPath('test_var', true)
         );
     }
 
@@ -34,7 +35,7 @@ class DirectoryListTest extends TestCase
      */
     public function testGetPathWithException()
     {
-        $this->get22DirectoryListWithIsGreator()->getPath('some_code');
+        $this->get22DirectoryListWithIsGreater()->getPath('some_code');
     }
 
     /**
@@ -43,12 +44,12 @@ class DirectoryListTest extends TestCase
      */
     public function testGetPathWithEmptyPathException()
     {
-        $this->get22DirectoryListWithIsGreator()->getPath('empty_path');
+        $this->get22DirectoryListWithIsGreater()->getPath('empty_path');
     }
 
     public function testGetRoot()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreator();
+        $directoryList = $this->get22DirectoryListWithIsGreater();
 
         $this->assertSame(
             __DIR__ . '/_files/bp',
@@ -58,7 +59,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetMagentoRoot()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreator();
+        $directoryList = $this->get22DirectoryListWithIsGreater();
 
         $this->assertSame(
             __DIR__,
@@ -68,7 +69,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetInit()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreator();
+        $directoryList = $this->get22DirectoryListWithIsGreater();
 
         $this->assertSame(
             __DIR__ . '/init',
@@ -78,7 +79,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetVar()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreator();
+        $directoryList = $this->get22DirectoryListWithIsGreater();
 
         $this->assertSame(
             __DIR__ . '/var',
@@ -88,7 +89,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetLog()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreator();
+        $directoryList = $this->get22DirectoryListWithIsGreater();
 
         $this->assertSame(
             __DIR__ . '/var/log',
@@ -98,7 +99,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetGenerated()
     {
-        $directoryList = $this->get22DirectoryListWithIsGreator();
+        $directoryList = $this->get22DirectoryListWithIsGreater();
 
         $this->assertSame(
             __DIR__ . '/generated',
@@ -119,8 +120,8 @@ class DirectoryListTest extends TestCase
     public function getGeneratedCodeDataProvider(): array
     {
         return [
-            [$this->get21DirectoryListWithIsGreator(), __DIR__ . '/var/generation'],
-            [$this->get22DirectoryListWithIsGreator(), __DIR__ . '/generated/code'],
+            [$this->get21DirectoryListWithIsGreater(), __DIR__ . '/var/generation'],
+            [$this->get22DirectoryListWithIsGreater(), __DIR__ . '/generated/code'],
         ];
     }
 
@@ -137,8 +138,8 @@ class DirectoryListTest extends TestCase
     public function getGeneratedMetadataDataProvider(): array
     {
         return [
-            [$this->get21DirectoryListWithIsGreator(), __DIR__ . '/var/di'],
-            [$this->get22DirectoryListWithIsGreator(), __DIR__ . '/generated/metadata'],
+            [$this->get21DirectoryListWithIsGreater(), __DIR__ . '/var/di'],
+            [$this->get22DirectoryListWithIsGreater(), __DIR__ . '/generated/metadata'],
         ];
     }
 
@@ -147,33 +148,43 @@ class DirectoryListTest extends TestCase
      * @param array $paths
      * @dataProvider getWritableDirectoriesDataProvider
      */
-    public function testGetGetWritableDirectories(DirectoryList $directoryList, array $paths)
+    public function testGetGetWritableDirectories(DirectoryList $directoryList, array $paths, bool $relativePath)
     {
-        $result = $directoryList->getWritableDirectories();
+        $result = $directoryList->getWritableDirectories($relativePath);
         sort($result);
         sort($paths);
-        $this->assertEquals($paths, $result);
+        $this->assertSame($paths, $result);
     }
 
     public function getWritableDirectoriesDataProvider()
     {
-        $paths21 = [
+        $abs21Paths = [
             __DIR__ . '/var/di',
             __DIR__ . '/var/generation',
             __DIR__ . '/var/view_preprocessed',
             __DIR__ . '/app/etc',
             __DIR__ . '/pub/media'
         ];
+        $relative21Paths = [
+            'var/di',
+            'var/generation',
+            'var/view_preprocessed',
+            'app/etc',
+            'pub/media'
+        ];
 
-        $paths22 = [__DIR__ . '/var', __DIR__ . '/app/etc', __DIR__ . '/pub/media'];
+        $abs22Paths      = [__DIR__ . '/var', __DIR__ . '/app/etc', __DIR__ . '/pub/media'];
+        $relative22Paths = ['var', 'app/etc', 'pub/media'];
 
         return [
-            [$this->get21DirectoryListWithSatisfies(), $paths21],
-            [$this->get22DirectoryListWithSatisfies(), $paths22],
+            [$this->get21DirectoryListWithSatisfies(), $abs21Paths,      false],
+            [$this->get22DirectoryListWithSatisfies(), $abs22Paths,      false],
+            [$this->get21DirectoryListWithSatisfies(), $relative21Paths, true],
+            [$this->get22DirectoryListWithSatisfies(), $relative22Paths, true],
         ];
     }
 
-    private function get21DirectoryListWithIsGreator()
+    private function get21DirectoryListWithIsGreater()
     {
         $magentoVersionMock = $this->createMock(MagentoVersion::class);
 
@@ -207,7 +218,7 @@ class DirectoryListTest extends TestCase
         );
     }
 
-    private function get22DirectoryListWithIsGreator()
+    private function get22DirectoryListWithIsGreater()
     {
         $magentoVersionMock = $this->createMock(MagentoVersion::class);
 

--- a/src/Test/Unit/Filesystem/DirectoryListTest.php
+++ b/src/Test/Unit/Filesystem/DirectoryListTest.php
@@ -20,7 +20,7 @@ class DirectoryListTest extends TestCase
      */
     public function testGetPath()
     {
-        $directoryList = $this->get22DirectoryList();
+        $directoryList = $this->get22DirectoryListWithIsGreator();
 
         $this->assertSame(
             __DIR__ . '/_files/test/var',
@@ -34,7 +34,7 @@ class DirectoryListTest extends TestCase
      */
     public function testGetPathWithException()
     {
-        $this->get22DirectoryList()->getPath('some_code');
+        $this->get22DirectoryListWithIsGreator()->getPath('some_code');
     }
 
     /**
@@ -43,12 +43,12 @@ class DirectoryListTest extends TestCase
      */
     public function testGetPathWithEmptyPathException()
     {
-        $this->get22DirectoryList()->getPath('empty_path');
+        $this->get22DirectoryListWithIsGreator()->getPath('empty_path');
     }
 
     public function testGetRoot()
     {
-        $directoryList = $this->get22DirectoryList();
+        $directoryList = $this->get22DirectoryListWithIsGreator();
 
         $this->assertSame(
             __DIR__ . '/_files/bp',
@@ -58,7 +58,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetMagentoRoot()
     {
-        $directoryList = $this->get22DirectoryList();
+        $directoryList = $this->get22DirectoryListWithIsGreator();
 
         $this->assertSame(
             __DIR__,
@@ -68,7 +68,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetInit()
     {
-        $directoryList = $this->get22DirectoryList();
+        $directoryList = $this->get22DirectoryListWithIsGreator();
 
         $this->assertSame(
             __DIR__ . '/init',
@@ -78,7 +78,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetVar()
     {
-        $directoryList = $this->get22DirectoryList();
+        $directoryList = $this->get22DirectoryListWithIsGreator();
 
         $this->assertSame(
             __DIR__ . '/var',
@@ -88,7 +88,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetLog()
     {
-        $directoryList = $this->get22DirectoryList();
+        $directoryList = $this->get22DirectoryListWithIsGreator();
 
         $this->assertSame(
             __DIR__ . '/var/log',
@@ -98,7 +98,7 @@ class DirectoryListTest extends TestCase
 
     public function testGetGenerated()
     {
-        $directoryList = $this->get22DirectoryList();
+        $directoryList = $this->get22DirectoryListWithIsGreator();
 
         $this->assertSame(
             __DIR__ . '/generated',
@@ -119,8 +119,8 @@ class DirectoryListTest extends TestCase
     public function getGeneratedCodeDataProvider(): array
     {
         return [
-            [$this->get21DirectoryList(), __DIR__ . '/var/generation'],
-            [$this->get22DirectoryList(), __DIR__ . '/generated/code'],
+            [$this->get21DirectoryListWithIsGreator(), __DIR__ . '/var/generation'],
+            [$this->get22DirectoryListWithIsGreator(), __DIR__ . '/generated/code'],
         ];
     }
 
@@ -137,8 +137,8 @@ class DirectoryListTest extends TestCase
     public function getGeneratedMetadataDataProvider(): array
     {
         return [
-            [$this->get21DirectoryList(), __DIR__ . '/var/di'],
-            [$this->get22DirectoryList(), __DIR__ . '/generated/metadata'],
+            [$this->get21DirectoryListWithIsGreator(), __DIR__ . '/var/di'],
+            [$this->get22DirectoryListWithIsGreator(), __DIR__ . '/generated/metadata'],
         ];
     }
 
@@ -168,12 +168,12 @@ class DirectoryListTest extends TestCase
         $paths22 = [__DIR__ . '/var', __DIR__ . '/app/etc', __DIR__ . '/pub/media'];
 
         return [
-            [$this->get21DirectoryList(), $paths21],
-            [$this->get22DirectoryList(), $paths22],
+            [$this->get21DirectoryListWithSatisfies(), $paths21],
+            [$this->get22DirectoryListWithSatisfies(), $paths22],
         ];
     }
 
-    private function get21DirectoryList()
+    private function get21DirectoryListWithIsGreator()
     {
         $magentoVersionMock = $this->createMock(MagentoVersion::class);
 
@@ -189,13 +189,49 @@ class DirectoryListTest extends TestCase
         );
     }
 
-    private function get22DirectoryList()
+    private function get21DirectoryListWithSatisfies()
+    {
+        $magentoVersionMock = $this->createMock(MagentoVersion::class);
+
+        $magentoVersionMock->method('satisfies')
+            ->willReturnMap([
+                ['2.1.*', true],
+                ['2.2.*', false],
+            ]);
+
+        return new DirectoryList(
+            __DIR__ . '/_files/bp',
+            __DIR__,
+            $magentoVersionMock,
+            ['empty_path' => [], 'test_var' => [DirectoryList::PATH => '_files/test/var']]
+        );
+    }
+
+    private function get22DirectoryListWithIsGreator()
     {
         $magentoVersionMock = $this->createMock(MagentoVersion::class);
 
         $magentoVersionMock->method('isGreaterOrEqual')
             ->with('2.2')
             ->willReturn(true);
+
+        return new DirectoryList(
+            __DIR__ . '/_files/bp',
+            __DIR__,
+            $magentoVersionMock,
+            ['empty_path' => [], 'test_var' => [DirectoryList::PATH => '_files/test/var']]
+        );
+    }
+
+    private function get22DirectoryListWithSatisfies()
+    {
+        $magentoVersionMock = $this->createMock(MagentoVersion::class);
+
+        $magentoVersionMock->method('satisfies')
+            ->willReturnMap([
+                ['2.1.*', false],
+                ['2.2.*', true],
+            ]);
 
         return new DirectoryList(
             __DIR__ . '/_files/bp',

--- a/src/Test/Unit/Process/Build/BackupDataTest.php
+++ b/src/Test/Unit/Process/Build/BackupDataTest.php
@@ -168,7 +168,8 @@ class BackupDataTest extends TestCase
             );
         $this->directoryListMock->expects($this->once())
             ->method('getWritableDirectories')
-            ->willReturn(['magento_root/some_dir']);
+            ->with(true)
+            ->willReturn(['some_dir']);
         $this->fileMock->expects($this->once())
             ->method('scanDir')
             ->willReturn(['dir1', 'dir2', 'dir3']);
@@ -192,7 +193,8 @@ class BackupDataTest extends TestCase
             );
         $this->directoryListMock->expects($this->once())
             ->method('getWritableDirectories')
-            ->willReturn(['magento_root/some_dir']);
+            ->with(true)
+            ->willReturn(['some_dir']);
         $this->fileMock->expects($this->exactly(3))
             ->method('createDirectory')
             ->withConsecutive(

--- a/src/Test/Unit/Process/Build/BackupDataTest.php
+++ b/src/Test/Unit/Process/Build/BackupDataTest.php
@@ -168,7 +168,7 @@ class BackupDataTest extends TestCase
             );
         $this->directoryListMock->expects($this->once())
             ->method('getWritableDirectories')
-            ->willReturn(['some_dir']);
+            ->willReturn(['magento_root/some_dir']);
         $this->fileMock->expects($this->once())
             ->method('scanDir')
             ->willReturn(['dir1', 'dir2', 'dir3']);
@@ -192,7 +192,7 @@ class BackupDataTest extends TestCase
             );
         $this->directoryListMock->expects($this->once())
             ->method('getWritableDirectories')
-            ->willReturn(['some_dir']);
+            ->willReturn(['magento_root/some_dir']);
         $this->fileMock->expects($this->exactly(3))
             ->method('createDirectory')
             ->withConsecutive(


### PR DESCRIPTION
### Description

1. Clean up some of the logic and redundant method calls in `DirectoryList::getWritableDirectories()`
1. Add some string manipulation to `BackupData::execute()` to remove the Magento root before appending to the init directory
    1. This allows methods in `DirectoryList` to remain consistent: they will **always** include the Magento root.

### Fixed Issues (if relevant)

[MAGECLOUS-1603](https://magento2.atlassian.net/browse/MAGECLOUD-1603)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
