### PR TITLE
MAGECLOUD-1630: Fixing Static Assets deployment throws errors when redis is used for cache

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -40,6 +40,12 @@
     },
     "Fixed: When SCD is in build, js resources do not load in admin": {
       "100.1.4 - 100.1.7": "patches/2.1/secure-static-resource.patch"
+    },
+    "Fixed Static Assets deployment throws errors when redis is used for cache (2.1)": {
+      "100.1.*": "patches/2.1/MAGETWO-69847-2.1.x.patch"
+    },
+    "Fixed Static Assets deployment throws errors when redis is used for cache (2.2)": {
+      "100.2.*": "patches/MAGETWO-69847-2.2.x.patch"
     }
   },
   "magento/module-customer-import-export": {

--- a/patches.json
+++ b/patches.json
@@ -45,7 +45,7 @@
       "100.1.*": "2.1/MAGETWO-69847-2.1.x.patch"
     },
     "Fixed Static Assets deployment throws errors when redis is used for cache (2.2)": {
-      ">=100.2.*": "MAGETWO-69847-2.2.x.patch"
+      ">=100.2.0": "MAGETWO-69847-2.2.x.patch"
     }
   },
   "magento/module-customer-import-export": {

--- a/patches.json
+++ b/patches.json
@@ -45,7 +45,7 @@
       "100.1.*": "2.1/MAGETWO-69847-2.1.x.patch"
     },
     "Fixed Static Assets deployment throws errors when redis is used for cache (2.2)": {
-      "100.2.*": "MAGETWO-69847-2.2.x.patch"
+      ">=100.2.*": "MAGETWO-69847-2.2.x.patch"
     }
   },
   "magento/module-customer-import-export": {

--- a/patches/2.1/MAGETWO-69847-2.1.x.patch
+++ b/patches/2.1/MAGETWO-69847-2.1.x.patch
@@ -1,0 +1,166 @@
+diff --git a/vendor/magento/framework/App/Cache/Frontend/Factory.php b/vendor/magento/framework/App/Cache/Frontend/Factory.php
+index a71ff27b07..e1c65ef572 100644
+--- a/vendor/magento/framework/App/Cache/Frontend/Factory.php
++++ b/vendor/magento/framework/App/Cache/Frontend/Factory.php
+@@ -1,6 +1,6 @@
+ <?php
+ /**
+- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
++ * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+ 
+@@ -145,15 +145,17 @@ class Factory
+         $result = $this->_objectManager->create(
+             'Magento\Framework\Cache\Frontend\Adapter\Zend',
+             [
+-                'frontend' => \Zend_Cache::factory(
+-                    $frontend['type'],
+-                    $backend['type'],
+-                    $frontend,
+-                    $backend['options'],
+-                    true,
+-                    true,
+-                    true
+-                )
++                'frontendFactory' => function () use ($frontend, $backend) {
++                    return \Zend_Cache::factory(
++                        $frontend['type'],
++                        $backend['type'],
++                        $frontend,
++                        $backend['options'],
++                        true,
++                        true,
++                        true
++                    );
++                }
+             ]
+         );
+         $result = $this->_applyDecorators($result);
+diff --git a/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php b/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
+index 5d72ee6a1e..f99468b20a 100644
+--- a/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
++++ b/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
+@@ -1,6 +1,6 @@
+ <?php
+ /**
+- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
++ * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+ namespace Magento\Framework\Cache\Frontend\Adapter;
+@@ -16,11 +16,27 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+     protected $_frontend;
+ 
+     /**
+-     * @param \Zend_Cache_Core $frontend
++     * Factory that creates the \Zend_Cache_Cores
++     *
++     * @var \Closure
++     */
++    protected $_frontendFactory;
++
++    /**
++     * The pid that owns the $_frontend object
++     *
++     * @var int
+      */
+-    public function __construct(\Zend_Cache_Core $frontend)
++    protected $_pid;
++
++    /**
++     * @param \Closure $frontendFactory
++     */
++    public function __construct(\Closure $frontendFactory)
+     {
+-        $this->_frontend = $frontend;
++        $this->_frontendFactory = $frontendFactory;
++        $this->_frontend = $frontendFactory();
++        $this->_pid = getmypid();
+     }
+ 
+     /**
+@@ -28,7 +44,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function test($identifier)
+     {
+-        return $this->_frontend->test($this->_unifyId($identifier));
++        return $this->_getFrontEnd()->test($this->_unifyId($identifier));
+     }
+ 
+     /**
+@@ -36,7 +52,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function load($identifier)
+     {
+-        return $this->_frontend->load($this->_unifyId($identifier));
++        return $this->_getFrontEnd()->load($this->_unifyId($identifier));
+     }
+ 
+     /**
+@@ -44,7 +60,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function save($data, $identifier, array $tags = [], $lifeTime = null)
+     {
+-        return $this->_frontend->save($data, $this->_unifyId($identifier), $this->_unifyIds($tags), $lifeTime);
++        return $this->_getFrontEnd()->save($data, $this->_unifyId($identifier), $this->_unifyIds($tags), $lifeTime);
+     }
+ 
+     /**
+@@ -52,7 +68,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function remove($identifier)
+     {
+-        return $this->_frontend->remove($this->_unifyId($identifier));
++        return $this->_getFrontEnd()->remove($this->_unifyId($identifier));
+     }
+ 
+     /**
+@@ -76,7 +92,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+                 "Magento cache frontend does not support the cleaning mode '{$mode}'."
+             );
+         }
+-        return $this->_frontend->clean($mode, $this->_unifyIds($tags));
++        return $this->_getFrontEnd()->clean($mode, $this->_unifyIds($tags));
+     }
+ 
+     /**
+@@ -84,7 +100,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function getBackend()
+     {
+-        return $this->_frontend->getBackend();
++        return $this->_getFrontEnd()->getBackend();
+     }
+ 
+     /**
+@@ -92,7 +108,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function getLowLevelFrontend()
+     {
+-        return $this->_frontend;
++        return $this->_getFrontEnd();
+     }
+ 
+     /**
+@@ -119,4 +135,20 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+         }
+         return $ids;
+     }
++
++    /**
++     * getter for _frontend so that we can support fork()s
++     *
++     * @return \Zend_Cache_Core
++     */
++    protected function _getFrontEnd()
++    {
++        if (getmypid() === $this->_pid) {
++            return $this->_frontend;
++        }
++        $frontendFactory = $this->_frontendFactory;
++        $this->_frontend = $frontendFactory();
++        $this->_pid = getmypid();
++        return $this->_frontend;
++    }
+ }

--- a/patches/2.1/MAGETWO-69847-2.1.x.patch
+++ b/patches/2.1/MAGETWO-69847-2.1.x.patch
@@ -2,14 +2,6 @@ diff --git a/vendor/magento/framework/App/Cache/Frontend/Factory.php b/vendor/ma
 index a71ff27b07..e1c65ef572 100644
 --- a/vendor/magento/framework/App/Cache/Frontend/Factory.php
 +++ b/vendor/magento/framework/App/Cache/Frontend/Factory.php
-@@ -1,6 +1,6 @@
- <?php
- /**
-- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
-+ * Copyright © Magento, Inc. All rights reserved.
-  * See COPYING.txt for license details.
-  */
- 
 @@ -145,15 +145,17 @@ class Factory
          $result = $this->_objectManager->create(
              'Magento\Framework\Cache\Frontend\Adapter\Zend',
@@ -38,18 +30,10 @@ index a71ff27b07..e1c65ef572 100644
          );
          $result = $this->_applyDecorators($result);
 diff --git a/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php b/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
-index 5d72ee6a1e..f99468b20a 100644
+index 5d72ee6a1e..fe9dc2f453 100644
 --- a/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
 +++ b/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
-@@ -1,6 +1,6 @@
- <?php
- /**
-- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
-+ * Copyright © Magento, Inc. All rights reserved.
-  * See COPYING.txt for license details.
-  */
- namespace Magento\Framework\Cache\Frontend\Adapter;
-@@ -16,11 +16,27 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -16,11 +16,32 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
      protected $_frontend;
  
      /**
@@ -64,13 +48,18 @@ index 5d72ee6a1e..f99468b20a 100644
 +     * The pid that owns the $_frontend object
 +     *
 +     * @var int
-      */
--    public function __construct(\Zend_Cache_Core $frontend)
++     */
 +    protected $_pid;
 +
 +    /**
-+     * @param \Closure $frontendFactory
++     * @var \Zend_Cache_Core[]
 +     */
++    static protected $_parentFrontends = [];
++
++    /**
++     * @param \Closure $frontendFactory
+      */
+-    public function __construct(\Zend_Cache_Core $frontend)
 +    public function __construct(\Closure $frontendFactory)
      {
 -        $this->_frontend = $frontend;
@@ -80,7 +69,7 @@ index 5d72ee6a1e..f99468b20a 100644
      }
  
      /**
-@@ -28,7 +44,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -28,7 +49,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function test($identifier)
      {
@@ -89,7 +78,7 @@ index 5d72ee6a1e..f99468b20a 100644
      }
  
      /**
-@@ -36,7 +52,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -36,7 +57,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function load($identifier)
      {
@@ -98,7 +87,7 @@ index 5d72ee6a1e..f99468b20a 100644
      }
  
      /**
-@@ -44,7 +60,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -44,7 +65,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function save($data, $identifier, array $tags = [], $lifeTime = null)
      {
@@ -107,7 +96,7 @@ index 5d72ee6a1e..f99468b20a 100644
      }
  
      /**
-@@ -52,7 +68,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -52,7 +73,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function remove($identifier)
      {
@@ -116,7 +105,7 @@ index 5d72ee6a1e..f99468b20a 100644
      }
  
      /**
-@@ -76,7 +92,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -76,7 +97,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
                  "Magento cache frontend does not support the cleaning mode '{$mode}'."
              );
          }
@@ -125,7 +114,7 @@ index 5d72ee6a1e..f99468b20a 100644
      }
  
      /**
-@@ -84,7 +100,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -84,7 +105,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function getBackend()
      {
@@ -134,7 +123,7 @@ index 5d72ee6a1e..f99468b20a 100644
      }
  
      /**
-@@ -92,7 +108,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -92,7 +113,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function getLowLevelFrontend()
      {
@@ -143,7 +132,7 @@ index 5d72ee6a1e..f99468b20a 100644
      }
  
      /**
-@@ -119,4 +135,20 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -119,4 +140,34 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
          }
          return $ids;
      }
@@ -158,9 +147,23 @@ index 5d72ee6a1e..f99468b20a 100644
 +        if (getmypid() === $this->_pid) {
 +            return $this->_frontend;
 +        }
++        static::$_parentFrontends[] = $this->_frontend;
 +        $frontendFactory = $this->_frontendFactory;
 +        $this->_frontend = $frontendFactory();
 +        $this->_pid = getmypid();
 +        return $this->_frontend;
++    }
++
++    /**
++     * If the current _frontend is owned by a different pid, add it to $_parentFrontends so that the
++     * destructor isn't called on it.
++     *
++     * @return void
++     */
++    public function __destruct()
++    {
++        if (getmypid() !== $this->_pid) {
++            static::$_parentFrontends[] = $this->_frontend;
++        }
 +    }
  }

--- a/patches/MAGETWO-69847-2.2.x.patch
+++ b/patches/MAGETWO-69847-2.2.x.patch
@@ -30,10 +30,10 @@ index 4c539da096..8477d94f28 100644
          );
          $result = $this->_applyDecorators($result);
 diff --git a/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php b/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
-index c8917a0996..f99468b20a 100644
+index c8917a0996..fe9dc2f453 100644
 --- a/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
 +++ b/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
-@@ -16,11 +16,27 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -16,11 +16,32 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
      protected $_frontend;
  
      /**
@@ -48,13 +48,18 @@ index c8917a0996..f99468b20a 100644
 +     * The pid that owns the $_frontend object
 +     *
 +     * @var int
-      */
--    public function __construct(\Zend_Cache_Core $frontend)
++     */
 +    protected $_pid;
 +
 +    /**
-+     * @param \Closure $frontendFactory
++     * @var \Zend_Cache_Core[]
 +     */
++    static protected $_parentFrontends = [];
++
++    /**
++     * @param \Closure $frontendFactory
+      */
+-    public function __construct(\Zend_Cache_Core $frontend)
 +    public function __construct(\Closure $frontendFactory)
      {
 -        $this->_frontend = $frontend;
@@ -64,7 +69,7 @@ index c8917a0996..f99468b20a 100644
      }
  
      /**
-@@ -28,7 +44,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -28,7 +49,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function test($identifier)
      {
@@ -73,7 +78,7 @@ index c8917a0996..f99468b20a 100644
      }
  
      /**
-@@ -36,7 +52,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -36,7 +57,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function load($identifier)
      {
@@ -82,7 +87,7 @@ index c8917a0996..f99468b20a 100644
      }
  
      /**
-@@ -44,7 +60,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -44,7 +65,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function save($data, $identifier, array $tags = [], $lifeTime = null)
      {
@@ -91,7 +96,7 @@ index c8917a0996..f99468b20a 100644
      }
  
      /**
-@@ -52,7 +68,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -52,7 +73,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function remove($identifier)
      {
@@ -100,7 +105,7 @@ index c8917a0996..f99468b20a 100644
      }
  
      /**
-@@ -76,7 +92,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -76,7 +97,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
                  "Magento cache frontend does not support the cleaning mode '{$mode}'."
              );
          }
@@ -109,7 +114,7 @@ index c8917a0996..f99468b20a 100644
      }
  
      /**
-@@ -84,7 +100,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -84,7 +105,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function getBackend()
      {
@@ -118,7 +123,7 @@ index c8917a0996..f99468b20a 100644
      }
  
      /**
-@@ -92,7 +108,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -92,7 +113,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
       */
      public function getLowLevelFrontend()
      {
@@ -127,7 +132,7 @@ index c8917a0996..f99468b20a 100644
      }
  
      /**
-@@ -119,4 +135,20 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+@@ -119,4 +140,34 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
          }
          return $ids;
      }
@@ -142,9 +147,23 @@ index c8917a0996..f99468b20a 100644
 +        if (getmypid() === $this->_pid) {
 +            return $this->_frontend;
 +        }
++        static::$_parentFrontends[] = $this->_frontend;
 +        $frontendFactory = $this->_frontendFactory;
 +        $this->_frontend = $frontendFactory();
 +        $this->_pid = getmypid();
 +        return $this->_frontend;
++    }
++
++    /**
++     * If the current _frontend is owned by a different pid, add it to $_parentFrontends so that the
++     * destructor isn't called on it.
++     *
++     * @return void
++     */
++    public function __destruct()
++    {
++        if (getmypid() !== $this->_pid) {
++            static::$_parentFrontends[] = $this->_frontend;
++        }
 +    }
  }

--- a/patches/MAGETWO-69847-2.2.x.patch
+++ b/patches/MAGETWO-69847-2.2.x.patch
@@ -1,0 +1,150 @@
+diff --git a/vendor/magento/framework/App/Cache/Frontend/Factory.php b/vendor/magento/framework/App/Cache/Frontend/Factory.php
+index 4c539da096..8477d94f28 100644
+--- a/vendor/magento/framework/App/Cache/Frontend/Factory.php
++++ b/vendor/magento/framework/App/Cache/Frontend/Factory.php
+@@ -148,15 +148,17 @@ class Factory
+         $result = $this->_objectManager->create(
+             \Magento\Framework\Cache\Frontend\Adapter\Zend::class,
+             [
+-                'frontend' => \Zend_Cache::factory(
+-                    $frontend['type'],
+-                    $backend['type'],
+-                    $frontend,
+-                    $backend['options'],
+-                    true,
+-                    true,
+-                    true
+-                )
++                'frontendFactory' => function () use ($frontend, $backend) {
++                    return \Zend_Cache::factory(
++                        $frontend['type'],
++                        $backend['type'],
++                        $frontend,
++                        $backend['options'],
++                        true,
++                        true,
++                        true
++                    );
++                }
+             ]
+         );
+         $result = $this->_applyDecorators($result);
+diff --git a/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php b/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
+index c8917a0996..f99468b20a 100644
+--- a/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
++++ b/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php
+@@ -16,11 +16,27 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+     protected $_frontend;
+ 
+     /**
+-     * @param \Zend_Cache_Core $frontend
++     * Factory that creates the \Zend_Cache_Cores
++     *
++     * @var \Closure
++     */
++    protected $_frontendFactory;
++
++    /**
++     * The pid that owns the $_frontend object
++     *
++     * @var int
+      */
+-    public function __construct(\Zend_Cache_Core $frontend)
++    protected $_pid;
++
++    /**
++     * @param \Closure $frontendFactory
++     */
++    public function __construct(\Closure $frontendFactory)
+     {
+-        $this->_frontend = $frontend;
++        $this->_frontendFactory = $frontendFactory;
++        $this->_frontend = $frontendFactory();
++        $this->_pid = getmypid();
+     }
+ 
+     /**
+@@ -28,7 +44,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function test($identifier)
+     {
+-        return $this->_frontend->test($this->_unifyId($identifier));
++        return $this->_getFrontEnd()->test($this->_unifyId($identifier));
+     }
+ 
+     /**
+@@ -36,7 +52,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function load($identifier)
+     {
+-        return $this->_frontend->load($this->_unifyId($identifier));
++        return $this->_getFrontEnd()->load($this->_unifyId($identifier));
+     }
+ 
+     /**
+@@ -44,7 +60,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function save($data, $identifier, array $tags = [], $lifeTime = null)
+     {
+-        return $this->_frontend->save($data, $this->_unifyId($identifier), $this->_unifyIds($tags), $lifeTime);
++        return $this->_getFrontEnd()->save($data, $this->_unifyId($identifier), $this->_unifyIds($tags), $lifeTime);
+     }
+ 
+     /**
+@@ -52,7 +68,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function remove($identifier)
+     {
+-        return $this->_frontend->remove($this->_unifyId($identifier));
++        return $this->_getFrontEnd()->remove($this->_unifyId($identifier));
+     }
+ 
+     /**
+@@ -76,7 +92,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+                 "Magento cache frontend does not support the cleaning mode '{$mode}'."
+             );
+         }
+-        return $this->_frontend->clean($mode, $this->_unifyIds($tags));
++        return $this->_getFrontEnd()->clean($mode, $this->_unifyIds($tags));
+     }
+ 
+     /**
+@@ -84,7 +100,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function getBackend()
+     {
+-        return $this->_frontend->getBackend();
++        return $this->_getFrontEnd()->getBackend();
+     }
+ 
+     /**
+@@ -92,7 +108,7 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+      */
+     public function getLowLevelFrontend()
+     {
+-        return $this->_frontend;
++        return $this->_getFrontEnd();
+     }
+ 
+     /**
+@@ -119,4 +135,20 @@ class Zend implements \Magento\Framework\Cache\FrontendInterface
+         }
+         return $ids;
+     }
++
++    /**
++     * getter for _frontend so that we can support fork()s
++     *
++     * @return \Zend_Cache_Core
++     */
++    protected function _getFrontEnd()
++    {
++        if (getmypid() === $this->_pid) {
++            return $this->_frontend;
++        }
++        $frontendFactory = $this->_frontendFactory;
++        $this->_frontend = $frontendFactory();
++        $this->_pid = getmypid();
++        return $this->_frontend;
++    }
+ }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
https://magento2.atlassian.net/browse/MAGECLOUD-1630

When static content deploy is run with jobs > 1, then there can exist a condition where multiple processes are trying to use the same redis connection at the same time, causing an exception to be throw, or sometimes other errors like unserialize errors.

Originally, in MAGECLOUD-1260, I had made a patch that modifies Credis_Client to fix the problem.  Because the maintainer of that third part project decided not to accept the changes to make it safe across fork() calls, it was decided that the issue needed to be fixed in Magento core.

In this patch, I am modifying the Zend adapter in Magento core, which is the closest we can get to the cache system in our code base.  Other classes have been looked at, but because of the way that some objects that are copied across the fork call holding references to objects that have already gotten their CacheInterface objects, I had to patch the closest thing to the cache system itself in order to avoid these problems.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
1. https://magento2.atlassian.net/browse/MAGECLOUD-1630
2. https://jira.corp.magento.com/browse/MAGETWO-69847
3. https://magento2.atlassian.net/browse/MAGECLOUD-1260

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. https://jira.corp.magento.com/browse/MAGETWO-87469 Precondition
2. https://jira.corp.magento.com/browse/MAGETWO-85715 Different strategies 
3. https://jira.corp.magento.com/browse/MAGETWO-69221 Number of threads
4. https://jira.corp.magento.com/browse/MAGETWO-86842 Redis
5. https://jira.corp.magento.com/browse/MAGETWO-86791 Redis
6. https://jira.corp.magento.com/browse/MAGETWO-71004 Redis

### Test flow
Need to test SCD with different strategies and different number of threads in deploy phase with [test](https://jira.corp.magento.com/browse/MAGETWO-87469) as precondition  ?

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
