### PR TITLE
MAGECLOUD-1678: Don't always overwrite thread setting

### DIFF
--- a/src/Config/Stage/Deploy.php
+++ b/src/Config/Stage/Deploy.php
@@ -152,7 +152,7 @@ class Deploy implements DeployInterface
     private function getScdThreads(): int
     {
         $variables = $this->environmentConfig->getVariables();
-        $staticDeployThreads = 1;
+        $staticDeployThreads = 0;
 
         if (isset($variables['STATIC_CONTENT_THREADS'])) {
             $staticDeployThreads = (int)$variables['STATIC_CONTENT_THREADS'];
@@ -171,7 +171,7 @@ class Deploy implements DeployInterface
      */
     private function getEnvScdThreads(): int
     {
-        $staticDeployThreads = 1;
+        $staticDeployThreads = 0;
 
         if (isset($_ENV['STATIC_CONTENT_THREADS'])) {
             $staticDeployThreads = (int)$_ENV['STATIC_CONTENT_THREADS'];


### PR DESCRIPTION
Don't always overwrite the STATIC_CONTENT_THREADS setting.

### Description
Previously, the deploy stage config would ignore the STATIC_CONTENT_THREADS setting in .magento.env.yaml. There was a value that was returning 1 by default, then that return value was always being used since it couldn't evaluate to false. This pull request fixes that.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1678

### Zephyr Tests
1. https://jira.corp.magento.com/browse/MAGETWO-69221

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
