### PR TITLE
MAGECLOUD-1735: Bundling javascript files does not work with gzip com…

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -96,5 +96,13 @@
     "Fix cannot upgrade 2.0 => 2.1 with auto_increment > 1": {
       "101.0.3 - 101.0.5": "2.1/MAGETWO-57799.patch"
     }
+  },
+  "magento/module-require-js": {
+    "Fixing bundling javascript files with gzip compression (Magento 2.1.*)": {
+      "100.1.*": "2.1/MAGETWO-88336.patch"
+    },
+    "Fixing bundling javascript files with gzip compression (Magento 2.2.*)": {
+      "100.2.*": "2.2/MAGETWO-84507.patch"
+    }
   }
 }

--- a/patches/2.1/MAGETWO-88336.patch
+++ b/patches/2.1/MAGETWO-88336.patch
@@ -1,0 +1,12 @@
+--- a/vendor/magento/module-require-js/Model/FileManager.php
++++ b/vendor/magento/module-require-js/Model/FileManager.php
+@@ -164,6 +164,9 @@
+             }
+ 
+             foreach ($libDir->read($bundleDir) as $bundleFile) {
++                if (pathinfo($bundleFile, PATHINFO_EXTENSION) !== 'js') {
++                    continue;
++                }
+                 $relPath = $libDir->getRelativePath($bundleFile);
+                 $bundles[] = $this->assetRepo->createArbitrary($relPath, '');
+             }

--- a/patches/2.2/MAGETWO-84507.patch
+++ b/patches/2.2/MAGETWO-84507.patch
@@ -1,0 +1,12 @@
+--- a/vendor/magento/module-require-js/Model/FileManager.php
++++ b/vendor/magento/module-require-js/Model/FileManager.php
+@@ -183,6 +183,9 @@
+             }
+ 
+             foreach ($libDir->read($bundleDir) as $bundleFile) {
++                if (pathinfo($bundleFile, PATHINFO_EXTENSION) !== 'js') {
++                    continue;
++                }
+                 $relPath = $libDir->getRelativePath($bundleFile);
+                 $bundles[] = $this->assetRepo->createArbitrary($relPath, '');
+             }

--- a/src/Test/Integration/UpgradeTest.php
+++ b/src/Test/Integration/UpgradeTest.php
@@ -41,6 +41,11 @@ class UpgradeTest extends AbstractTest
         $executeAndAssert(Prestart::NAME);
         $this->assertContentPresence();
 
+        $this->bootstrap->execute(sprintf(
+            'rm -rf %s/vendor/*',
+            $this->bootstrap->getSandboxDir()
+        ));
+
         $this->updateToVersion($toVersion);
 
         $executeAndAssert(Build::NAME);


### PR DESCRIPTION
Fixes work javascript bundling with gzip compression in the package magento/ece-tools

### Description
Patches for Magento2 of version 2.1.* and 2.2.* for correctly work JS Bundling and GZIP compression 
### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1735

### Zephyr Tests
https://jira.corp.magento.com/browse/MAGETWO-88341

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
