### PR TITLE
MAGECLOUD-1842 Moving static content to init directory instead of copying

### DIFF
--- a/src/Process/Build/BackupData/StaticContent.php
+++ b/src/Process/Build/BackupData/StaticContent.php
@@ -7,6 +7,7 @@ namespace Magento\MagentoCloud\Process\Build\BackupData;
 
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Filesystem\FileSystemException;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Psr\Log\LoggerInterface;
@@ -78,6 +79,10 @@ class StaticContent implements ProcessInterface
         }
 
         $this->logger->info('Moving static content to init directory');
-        $this->file->copyDirectory($originalPubStatic, $initPubStatic);
+        try {
+            $this->file->rename($originalPubStatic, $initPubStatic);
+        } catch (FileSystemException $e) {
+            $this->file->copyDirectory($originalPubStatic, $initPubStatic);
+        }
     }
 }

--- a/src/Test/Unit/Process/Build/BackupData/StaticContentTest.php
+++ b/src/Test/Unit/Process/Build/BackupData/StaticContentTest.php
@@ -86,34 +86,28 @@ class StaticContentTest extends TestCase
             ->method('exists')
             ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
             ->willReturn(true);
-
         $this->directoryListMock->expects($this->exactly(2))
             ->method('getPath')
             ->willReturnMap([
                 [DirectoryList::DIR_STATIC, false, $this->originalPubStaticPath],
                 [DirectoryList::DIR_INIT, false, $this->rootInitDir]
             ]);
-
         $this->fileMock->expects($this->once())
             ->method('isExists')
             ->with($this->initPubStaticPath)
             ->willReturn(true);
-
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
             ->withConsecutive(
                 ['Clear ./init/pub/static'],
                 ['Moving static content to init directory']
             );
-
         $this->fileMock->expects($this->once())
             ->method('backgroundClearDirectory')
             ->with($this->initPubStaticPath);
-
         $this->fileMock->expects($this->never())
             ->method('createDirectory')
             ->with($this->initPubStaticPath);
-
         $this->fileMock->expects($this->once())
             ->method('rename')
             ->with($this->originalPubStaticPath, $this->initPubStaticPath);
@@ -130,38 +124,31 @@ class StaticContentTest extends TestCase
             ->method('exists')
             ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
             ->willReturn(true);
-
         $this->directoryListMock->expects($this->exactly(2))
             ->method('getPath')
             ->willReturnMap([
                 [DirectoryList::DIR_STATIC, false, $this->originalPubStaticPath],
                 [DirectoryList::DIR_INIT, false, $this->rootInitDir]
             ]);
-
         $this->fileMock->expects($this->once())
             ->method('isExists')
             ->with($this->initPubStaticPath)
             ->willReturn(false);
-
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
             ->withConsecutive(
                 ['Create ./init/pub/static'],
                 ['Moving static content to init directory']
             );
-
         $this->fileMock->expects($this->never())
             ->method('backgroundClearDirectory')
             ->with($this->initPubStaticPath);
-
         $this->fileMock->expects($this->once())
             ->method('createDirectory')
             ->with($this->initPubStaticPath);
-
         $this->fileMock->expects($this->once())
             ->method('rename')
             ->with($this->originalPubStaticPath, $this->initPubStaticPath);
-
         $this->fileMock->expects($this->never())
             ->method('copyDirectory');
 
@@ -203,39 +190,32 @@ class StaticContentTest extends TestCase
             ->method('exists')
             ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
             ->willReturn(true);
-
         $this->directoryListMock->expects($this->exactly(2))
             ->method('getPath')
             ->willReturnMap([
                 [DirectoryList::DIR_STATIC, false, $this->originalPubStaticPath],
                 [DirectoryList::DIR_INIT, false, $this->rootInitDir]
             ]);
-
         $this->fileMock->expects($this->once())
             ->method('isExists')
             ->with($this->initPubStaticPath)
             ->willReturn(false);
-
         $this->loggerMock->expects($this->exactly(2))
             ->method('info')
             ->withConsecutive(
                 ['Create ./init/pub/static'],
                 ['Moving static content to init directory']
             );
-
         $this->fileMock->expects($this->never())
             ->method('backgroundClearDirectory')
             ->with($this->initPubStaticPath);
-
         $this->fileMock->expects($this->once())
             ->method('createDirectory')
             ->with($this->initPubStaticPath);
-
         $this->fileMock->expects($this->once())
             ->method('rename')
             ->with($this->originalPubStaticPath, $this->initPubStaticPath)
             ->will($this->throwException(new FileSystemException()));
-
         $this->fileMock->expects($this->once())
             ->method('copyDirectory')
             ->with($this->originalPubStaticPath, $this->initPubStaticPath);

--- a/src/Test/Unit/Process/Build/BackupData/StaticContentTest.php
+++ b/src/Test/Unit/Process/Build/BackupData/StaticContentTest.php
@@ -12,6 +12,7 @@ use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Psr\Log\LoggerInterface;
 use Magento\MagentoCloud\Process\Build\BackupData\StaticContent;
+use Magento\MagentoCloud\Filesystem\FileSystemException;
 
 /**
  * @inheritdoc
@@ -114,8 +115,11 @@ class StaticContentTest extends TestCase
             ->with($this->initPubStaticPath);
 
         $this->fileMock->expects($this->once())
-            ->method('copyDirectory')
+            ->method('rename')
             ->with($this->originalPubStaticPath, $this->initPubStaticPath);
+
+        $this->fileMock->expects($this->never())
+            ->method('copyDirectory');
 
         $this->process->execute();
     }
@@ -155,8 +159,11 @@ class StaticContentTest extends TestCase
             ->with($this->initPubStaticPath);
 
         $this->fileMock->expects($this->once())
-            ->method('copyDirectory')
+            ->method('rename')
             ->with($this->originalPubStaticPath, $this->initPubStaticPath);
+
+        $this->fileMock->expects($this->never())
+            ->method('copyDirectory');
 
         $this->process->execute();
     }
@@ -186,6 +193,52 @@ class StaticContentTest extends TestCase
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('SCD not performed during build');
+
+        $this->process->execute();
+    }
+
+    public function testRenameFails()
+    {
+        $this->flagManagerMock->expects($this->once())
+            ->method('exists')
+            ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
+            ->willReturn(true);
+
+        $this->directoryListMock->expects($this->exactly(2))
+            ->method('getPath')
+            ->willReturnMap([
+                [DirectoryList::DIR_STATIC, false, $this->originalPubStaticPath],
+                [DirectoryList::DIR_INIT, false, $this->rootInitDir]
+            ]);
+
+        $this->fileMock->expects($this->once())
+            ->method('isExists')
+            ->with($this->initPubStaticPath)
+            ->willReturn(false);
+
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('info')
+            ->withConsecutive(
+                ['Create ./init/pub/static'],
+                ['Moving static content to init directory']
+            );
+
+        $this->fileMock->expects($this->never())
+            ->method('backgroundClearDirectory')
+            ->with($this->initPubStaticPath);
+
+        $this->fileMock->expects($this->once())
+            ->method('createDirectory')
+            ->with($this->initPubStaticPath);
+
+        $this->fileMock->expects($this->once())
+            ->method('rename')
+            ->with($this->originalPubStaticPath, $this->initPubStaticPath)
+            ->will($this->throwException(new FileSystemException()));
+
+        $this->fileMock->expects($this->once())
+            ->method('copyDirectory')
+            ->with($this->originalPubStaticPath, $this->initPubStaticPath);
 
         $this->process->execute();
     }


### PR DESCRIPTION
### Description
Moving static content to init directory instead of copying.  Fall back is to copy it as it worked previously.  

### Fixed Issues (if relevant)

### Zephyr Tests
1. https://jira.corp.magento.com/browse/MAGETWO-85715

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
