### PR TITLE
MAGECLOUD-1805: Redis - Read from Secondary

### DIFF
--- a/src/Config/Stage/Deploy.php
+++ b/src/Config/Stage/Deploy.php
@@ -207,6 +207,7 @@ class Deploy implements DeployInterface
             self::VAR_SCD_THREADS => 1,
             self::VAR_GENERATED_CODE_SYMLINK => true,
             self::VAR_SCD_EXCLUDE_THEMES => '',
+            self::VAR_REDIS_USE_READ_CONNECTION => false,
         ];
     }
 }

--- a/src/Config/Stage/Deploy.php
+++ b/src/Config/Stage/Deploy.php
@@ -207,7 +207,7 @@ class Deploy implements DeployInterface
             self::VAR_SCD_THREADS => 1,
             self::VAR_GENERATED_CODE_SYMLINK => true,
             self::VAR_SCD_EXCLUDE_THEMES => '',
-            self::VAR_REDIS_USE_READ_CONNECTION => false,
+            self::VAR_REDIS_USE_SLAVE_CONNECTION => false,
         ];
     }
 }

--- a/src/Config/Stage/DeployInterface.php
+++ b/src/Config/Stage/DeployInterface.php
@@ -23,6 +23,11 @@ interface DeployInterface extends StageConfigInterface
     const VAR_STATIC_CONTENT_EXCLUDE_THEMES = 'STATIC_CONTENT_EXCLUDE_THEMES';
 
     /**
+     * The variable responsible to set Redis slave connection when it has true value.
+     */
+    const VAR_REDIS_USE_READ_CONNECTION = 'REDIS_USE_READ_CONNECTION';
+
+    /**
      * @deprecated 2.1 specific variable.
      */
     const VAR_GENERATED_CODE_SYMLINK = 'GENERATED_CODE_SYMLINK';

--- a/src/Config/Stage/DeployInterface.php
+++ b/src/Config/Stage/DeployInterface.php
@@ -25,7 +25,7 @@ interface DeployInterface extends StageConfigInterface
     /**
      * The variable responsible to set Redis slave connection when it has true value.
      */
-    const VAR_REDIS_USE_READ_CONNECTION = 'REDIS_USE_READ_CONNECTION';
+    const VAR_REDIS_USE_SLAVE_CONNECTION = 'REDIS_USE_SLAVE_CONNECTION';
 
     /**
      * @deprecated 2.1 specific variable.

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Cache/Config.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Cache/Config.php
@@ -58,11 +58,11 @@ class Config
         $envCacheConfiguration = (array)$this->stageConfig->get(DeployInterface::VAR_CACHE_CONFIGURATION);
 
         if ($this->isCacheConfigurationValid($envCacheConfiguration)) {
-            if ($this->stageConfig->get(DeployInterface::VAR_REDIS_USE_READ_CONNECTION)) {
+            if ($this->stageConfig->get(DeployInterface::VAR_REDIS_USE_SLAVE_CONNECTION)) {
                 $this->logger->notice(
                     sprintf(
                         'The variable \'%s\' is ignored as you set your own cache connection in \'%s\'',
-                        DeployInterface::VAR_REDIS_USE_READ_CONNECTION,
+                        DeployInterface::VAR_REDIS_USE_SLAVE_CONNECTION,
                         DeployInterface::VAR_CACHE_CONFIGURATION
                     )
                 );
@@ -110,7 +110,7 @@ class Config
     }
 
     /**
-     * Retrieves Redis read connection data if it exists and variable REDIS_USE_READ_CONNECTION was set as true.
+     * Retrieves Redis read connection data if it exists and variable REDIS_USE_SLAVE_CONNECTION was set as true.
      * Otherwise retrieves an empty array.
      *
      * @return array
@@ -121,7 +121,7 @@ class Config
         $redisSlaveConfig = $this->environment->getRelationship('redis-slave');
         $slaveHost = $redisSlaveConfig[0]['host'] ?? null;
 
-        if ($this->stageConfig->get(DeployInterface::VAR_REDIS_USE_READ_CONNECTION) && $slaveHost) {
+        if ($this->stageConfig->get(DeployInterface::VAR_REDIS_USE_SLAVE_CONNECTION) && $slaveHost) {
             $this->logger->info('Set Redis slave connection');
             $connectionData = [
                 'server' => $slaveHost,

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Cache/Config.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Cache/Config.php
@@ -118,11 +118,11 @@ class Config
     private function getSlaveConnection(): array
     {
         $connectionData = [];
+        $redisSlaveConfig = $this->environment->getRelationship('redis-slave');
         $slaveHost = $redisSlaveConfig[0]['host'] ?? null;
 
         if ($this->stageConfig->get(DeployInterface::VAR_REDIS_USE_READ_CONNECTION) && $slaveHost) {
             $this->logger->info('Set Redis slave connection');
-            $redisSlaveConfig = $this->environment->getRelationship('redis-slave');
             $connectionData = [
                 'server' => $slaveHost,
                 'port' => $redisSlaveConfig[0]['port'] ?? '',

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Cache/Config.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Cache/Config.php
@@ -7,6 +7,7 @@ namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate\Cache;
 
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\Stage\DeployInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Returns cache configuration.
@@ -24,15 +25,23 @@ class Config
     private $stageConfig;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param Environment $environment
      * @param DeployInterface $stageConfig
+     * @param LoggerInterface $logger
      */
     public function __construct(
         Environment $environment,
-        DeployInterface $stageConfig
+        DeployInterface $stageConfig,
+        LoggerInterface $logger
     ) {
         $this->environment = $environment;
         $this->stageConfig = $stageConfig;
+        $this->logger = $logger;
     }
 
     /**
@@ -49,6 +58,15 @@ class Config
         $envCacheConfiguration = (array)$this->stageConfig->get(DeployInterface::VAR_CACHE_CONFIGURATION);
 
         if ($this->isCacheConfigurationValid($envCacheConfiguration)) {
+            if ($this->stageConfig->get(DeployInterface::VAR_REDIS_USE_READ_CONNECTION)) {
+                $this->logger->notice(
+                    sprintf(
+                        'The variable \'%s\' is ignored as you set your own cache connection in \'%s\'',
+                        DeployInterface::VAR_REDIS_USE_READ_CONNECTION,
+                        DeployInterface::VAR_CACHE_CONFIGURATION
+                    )
+                );
+            }
             return $envCacheConfiguration;
         }
 
@@ -67,6 +85,11 @@ class Config
             ],
         ];
 
+        $slaveConnectionData = $this->getSlaveConnection();
+        if ($slaveConnectionData) {
+            $redisCache['backend_options']['load_from_slave'] = $slaveConnectionData;
+        }
+
         return [
             'frontend' => [
                 'default' => $redisCache,
@@ -84,5 +107,28 @@ class Config
     private function isCacheConfigurationValid(array $cacheConfiguration): bool
     {
         return !empty($cacheConfiguration) && isset($cacheConfiguration['frontend']);
+    }
+
+    /**
+     * Retrieves Redis read connection data if it exists and variable REDIS_USE_READ_CONNECTION was set as true.
+     * Otherwise retrieves an empty array.
+     *
+     * @return array
+     */
+    private function getSlaveConnection(): array
+    {
+        $connectionData = [];
+        $slaveHost = $redisSlaveConfig[0]['host'] ?? null;
+
+        if ($this->stageConfig->get(DeployInterface::VAR_REDIS_USE_READ_CONNECTION) && $slaveHost) {
+            $this->logger->info('Set Redis slave connection');
+            $redisSlaveConfig = $this->environment->getRelationship('redis-slave');
+            $connectionData = [
+                'server' => $slaveHost,
+                'port' => $redisSlaveConfig[0]['port'] ?? '',
+            ];
+        }
+
+        return $connectionData;
     }
 }

--- a/src/Test/Unit/Config/Stage/DeployTest.php
+++ b/src/Test/Unit/Config/Stage/DeployTest.php
@@ -215,16 +215,16 @@ class DeployTest extends TestCase
                 'some theme 2',
             ],
             'redis_use_slave_default' => [
-                Deploy::VAR_REDIS_USE_READ_CONNECTION,
+                Deploy::VAR_REDIS_USE_SLAVE_CONNECTION,
                 [],
                 [],
                 false,
             ],
             'redis_use_slave_true' => [
-                Deploy::VAR_REDIS_USE_READ_CONNECTION,
+                Deploy::VAR_REDIS_USE_SLAVE_CONNECTION,
                 [],
                 [
-                    Deploy::VAR_REDIS_USE_READ_CONNECTION => true
+                    Deploy::VAR_REDIS_USE_SLAVE_CONNECTION => true
                 ],
                 true,
             ],

--- a/src/Test/Unit/Config/Stage/DeployTest.php
+++ b/src/Test/Unit/Config/Stage/DeployTest.php
@@ -214,6 +214,20 @@ class DeployTest extends TestCase
                 ],
                 'some theme 2',
             ],
+            'redis_use_slave_default' => [
+                Deploy::VAR_REDIS_USE_READ_CONNECTION,
+                [],
+                [],
+                false,
+            ],
+            'redis_use_slave_true' => [
+                Deploy::VAR_REDIS_USE_READ_CONNECTION,
+                [],
+                [
+                    Deploy::VAR_REDIS_USE_READ_CONNECTION => true
+                ],
+                true,
+            ],
         ];
     }
 

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/Cache/ConfigTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/Cache/ConfigTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate\Cache\Config;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
+use Psr\Log\LoggerInterface;
 
 /**
  * @inheritdoc
@@ -27,6 +28,11 @@ class ConfigTest extends TestCase
     private $stageConfigMock;
 
     /**
+     * @var LoggerInterface|Mock
+     */
+    private $loggerMock;
+
+    /**
      * @var Config
      */
     private $config;
@@ -35,22 +41,65 @@ class ConfigTest extends TestCase
     {
         $this->environmentMock = $this->createMock(Environment::class);
         $this->stageConfigMock = $this->getMockForAbstractClass(DeployInterface::class);
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->getMockForAbstractClass();
 
         $this->config = new Config(
             $this->environmentMock,
-            $this->stageConfigMock
+            $this->stageConfigMock,
+            $this->loggerMock
         );
     }
 
     public function testGetWithValidEnvConfig()
     {
-        $this->stageConfigMock->expects($this->once())
+        $this->stageConfigMock->expects($this->exactly(2))
             ->method('get')
-            ->with(DeployInterface::VAR_CACHE_CONFIGURATION)
-            ->willReturn(['frontend' => ['cache_option' => 'value']]);
+            ->willReturnMap([
+                [
+                    DeployInterface::VAR_CACHE_CONFIGURATION,
+                    ['frontend' => ['cache_option' => 'value']]
+                ],
+                [
+                    DeployInterface::VAR_REDIS_USE_READ_CONNECTION,
+                    false
+                ]
+            ]);
         $this->environmentMock->expects($this->never())
             ->method('getRelationship')
             ->with('redis');
+
+        $this->loggerMock->expects($this->never())
+            ->method('notice');
+
+        $this->assertEquals(
+            ['frontend' => ['cache_option' => 'value']],
+            $this->config->get()
+        );
+    }
+
+    public function testGetWithValidEnvConfigWithEnabledRedisSlave()
+    {
+        $this->stageConfigMock->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                [
+                    DeployInterface::VAR_CACHE_CONFIGURATION,
+                    ['frontend' => ['cache_option' => 'value']]
+                ],
+                [
+                    DeployInterface::VAR_REDIS_USE_READ_CONNECTION,
+                    true
+                ]
+            ]);
+        $this->environmentMock->expects($this->never())
+            ->method('getRelationship')
+            ->with('redis');
+
+        $this->loggerMock->expects($this->once())
+            ->method('notice')
+            ->with('The variable \'' . DeployInterface::VAR_REDIS_USE_READ_CONNECTION . '\' is ignored'
+                    . ' as you set your own cache connection in \'' . DeployInterface::VAR_CACHE_CONFIGURATION . '\'');
 
         $this->assertEquals(
             ['frontend' => ['cache_option' => 'value']],
@@ -72,44 +121,125 @@ class ConfigTest extends TestCase
         $this->assertEmpty($this->config->get());
     }
 
-    public function testGetWithRedisAndNotValidEnvConfig()
+    /**
+     * @param $masterConnection array
+     * @param $slaveConnection array
+     * @param $useSlave boolean
+     * @param $expectedResult array
+     *
+     * @dataProvider getFromRelationshipsDataProvider
+     */
+    public function testGetFromRelationships($masterConnection, $slaveConnection, $useSlave, $expectedResult)
     {
-        $this->stageConfigMock->expects($this->once())
+        $this->stageConfigMock->expects($this->exactly(2))
             ->method('get')
-            ->with(DeployInterface::VAR_CACHE_CONFIGURATION)
-            ->willReturn([]);
-        $this->environmentMock->expects($this->once())
-            ->method('getRelationship')
-            ->with('redis')
-            ->willReturn([
+            ->willReturnMap([
                 [
-                    'host' => 'redis_host',
-                    'port' => '1234'
+                    DeployInterface::VAR_CACHE_CONFIGURATION,
+                    []
+                ],
+                [
+                    DeployInterface::VAR_REDIS_USE_READ_CONNECTION,
+                    $useSlave
                 ]
+            ]);
+        $this->environmentMock->expects($this->exactly(2))
+            ->method('getRelationship')
+            ->willReturnMap([
+                ['redis', $masterConnection],
+                ['redis-slave', $slaveConnection],
+
             ]);
 
         $this->assertEquals(
-            [
-                'frontend' => [
-                    'default' => [
-                        'backend' => 'Cm_Cache_Backend_Redis',
-                        'backend_options' => [
-                            'server' => 'redis_host',
-                            'port' => '1234',
-                            'database' => 1
-                        ],
-                    ],
-                    'page_cache' => [
-                        'backend' => 'Cm_Cache_Backend_Redis',
-                        'backend_options' => [
-                            'server' => 'redis_host',
-                            'port' => '1234',
-                            'database' => 1
-                        ],
-                    ],
-                ]
-            ],
+            $expectedResult,
             $this->config->get()
         );
+    }
+
+    /**
+     * Data provider for testGetFromRelationships.
+     *
+     * Results value for next data:
+     * 1 - data for 'redis' relationships
+     * 2 - data for 'redis-slave' relationships
+     * 3 - value for REDIS_USE_READ_CONNECTION variable
+     * 4 - expected result
+     *
+     * @return array
+     */
+    public function getFromRelationshipsDataProvider()
+    {
+        $relationshipsRedis = [
+            [
+                'host' => 'master.host',
+                'port' => 'master.port',
+                'scheme' => 'redis',
+            ]
+        ];
+        $relationshipsRedisSlave = [
+            [
+                'host' => 'slave.host',
+                'port' => 'slave.port',
+                'scheme' => 'redis',
+            ]
+        ];
+
+        $resultMasterOnlyConnection = [
+            'frontend' => [
+                'default' => [
+                    'backend' => 'Cm_Cache_Backend_Redis',
+                    'backend_options' => [
+                        'server' => 'master.host',
+                        'port' => 'master.port',
+                        'database' => 1
+                    ],
+                ],
+                'page_cache' => [
+                    'backend' => 'Cm_Cache_Backend_Redis',
+                    'backend_options' => [
+                        'server' => 'master.host',
+                        'port' => 'master.port',
+                        'database' => 1
+                    ],
+                ],
+            ]
+        ];
+        $resultMasterSlaveConnection = $resultMasterOnlyConnection;
+        $resultMasterSlaveConnection['frontend']['default']['backend_options']['load_from_slave'] = [
+            'server' => 'slave.host',
+            'port' => 'slave.port',
+        ];
+        $resultMasterSlaveConnection['frontend']['page_cache']['backend_options']['load_from_slave'] = [
+            'server' => 'slave.host',
+            'port' => 'slave.port',
+        ];
+
+        return [
+            [
+                $relationshipsRedis,
+                [],
+                false,
+                $resultMasterOnlyConnection
+            ],
+            [
+                $relationshipsRedis,
+                $relationshipsRedisSlave,
+                false,
+                $resultMasterOnlyConnection
+            ],
+            [
+                $relationshipsRedis,
+                [],
+                true,
+                $resultMasterOnlyConnection
+            ],
+            [
+                $relationshipsRedis,
+                $relationshipsRedisSlave,
+                true,
+                $resultMasterSlaveConnection
+            ],
+        ];
     }
 }

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/Cache/ConfigTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/Cache/ConfigTest.php
@@ -61,7 +61,7 @@ class ConfigTest extends TestCase
                     ['frontend' => ['cache_option' => 'value']]
                 ],
                 [
-                    DeployInterface::VAR_REDIS_USE_READ_CONNECTION,
+                    DeployInterface::VAR_REDIS_USE_SLAVE_CONNECTION,
                     false
                 ]
             ]);
@@ -88,7 +88,7 @@ class ConfigTest extends TestCase
                     ['frontend' => ['cache_option' => 'value']]
                 ],
                 [
-                    DeployInterface::VAR_REDIS_USE_READ_CONNECTION,
+                    DeployInterface::VAR_REDIS_USE_SLAVE_CONNECTION,
                     true
                 ]
             ]);
@@ -98,7 +98,7 @@ class ConfigTest extends TestCase
 
         $this->loggerMock->expects($this->once())
             ->method('notice')
-            ->with('The variable \'' . DeployInterface::VAR_REDIS_USE_READ_CONNECTION . '\' is ignored'
+            ->with('The variable \'' . DeployInterface::VAR_REDIS_USE_SLAVE_CONNECTION . '\' is ignored'
                     . ' as you set your own cache connection in \'' . DeployInterface::VAR_CACHE_CONFIGURATION . '\'');
 
         $this->assertEquals(
@@ -139,7 +139,7 @@ class ConfigTest extends TestCase
                     []
                 ],
                 [
-                    DeployInterface::VAR_REDIS_USE_READ_CONNECTION,
+                    DeployInterface::VAR_REDIS_USE_SLAVE_CONNECTION,
                     $useSlave
                 ]
             ]);
@@ -163,7 +163,7 @@ class ConfigTest extends TestCase
      * Results value for next data:
      * 1 - data for 'redis' relationships
      * 2 - data for 'redis-slave' relationships
-     * 3 - value for REDIS_USE_READ_CONNECTION variable
+     * 3 - value for REDIS_USE_SLAVE_CONNECTION variable
      * 4 - expected result
      *
      * @return array


### PR DESCRIPTION
[MAGECLOUD-1805](https://magento2.atlassian.net/browse/MAGECLOUD-1805) Redis - Read from Secondary

### Description
 - ECE-Tools is enabled to automatically configure master-slave connection to Redis
-- New config variable is available to enable this flow.
-- By default it is *disabled* to avoid unexpected behavior on first package update
- Correct connections to master and slaves are established during the deployment process automatically.


### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. [MAGETWO-89254](https://jira.corp.magento.com/browse/MAGETWO-89254) [Cloud] Set Redis Slave Connection

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
