### PR TITLE
MAGECLOUD-1853: The "disable_locking" parameter breaks latest 2.1.x versions

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -14,6 +14,9 @@
     "Fix redis session locking for 2.2.0 and 2.2.1": {
       "101.0.0||101.0.1": "2.2/fix-redis-session-manager-locking.patch"
     },
+    "Fix redis session locking for 2.1.11 and 2.1.13": {
+      "100.1.11 - 100.1.13": "2.1/fix-redis-session-manager-locking.patch"
+    },
     "Fix locker process (Magento 2.1)": {
       "100.1.*": "2.1/locker-process.magento-2.1.patch"
     },

--- a/patches/2.1/fix-redis-session-manager-locking.patch
+++ b/patches/2.1/fix-redis-session-manager-locking.patch
@@ -1,0 +1,24 @@
+diff -Nuar a/vendor/magento/framework/Session/SessionManager.php b/vendor/magento/framework/Session/SessionManager.php
+--- a/vendor/magento/framework/Session/SessionManager.php
++++ b/vendor/magento/framework/Session/SessionManager.php
+@@ -470,18 +470,9 @@ class SessionManager implements SessionManagerInterface
+         if (headers_sent()) {
+             return $this;
+         }
+-        //@see http://php.net/manual/en/function.session-regenerate-id.php#53480 workaround
++
+         if ($this->isSessionExists()) {
+-            $oldSessionId = session_id();
+-            session_regenerate_id();
+-            $newSessionId = session_id();
+-            session_id($oldSessionId);
+-            session_destroy();
+-
+-            $oldSession = $_SESSION;
+-            session_id($newSessionId);
+-            session_start();
+-            $_SESSION = $oldSession;
++            session_regenerate_id(true);
+         } else {
+             session_start();
+         }


### PR DESCRIPTION
### Description
The "disable_locking" parameter breaks since Magento 2.1.11

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1853

### Zephyr Tests
https://jira.corp.magento.com/browse/MAGETWO-89253

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
