### PR TITLE
MAGECLOUD-1744: On earlier PHP versions, ECE-Tools command returns exception

### DIFF
--- a/src/DB/Dump.php
+++ b/src/DB/Dump.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\MagentoCloud\DB;
 
-use Magento\MagentoCloud\DB\Data\ConnectionInterface;
+use Magento\MagentoCloud\DB\Data\ConnectionInterface as DatabaseConnectionInterface;
 
 /**
  * Class Dump generate mysqldump command with read only connection
@@ -15,15 +15,15 @@ class Dump implements DumpInterface
     /**
      * Database connection data for read operations
      *
-     * @var ConnectionInterface
+     * @var DatabaseConnectionInterface
      */
     private $connectionData;
 
     /**
-     * @param ConnectionInterface $connectionData
+     * @param DatabaseConnectionInterface $connectionData
      */
     public function __construct(
-        ConnectionInterface $connectionData
+        DatabaseConnectionInterface $connectionData
     ) {
         $this->connectionData = $connectionData;
     }

--- a/src/Test/Unit/DB/DumpTest.php
+++ b/src/Test/Unit/DB/DumpTest.php
@@ -13,9 +13,8 @@ use PHPUnit_Framework_MockObject_MockObject as Mock;
 /**
  * @inheritdoc
  */
-class DbDumpTest extends TestCase
+class DumpTest extends TestCase
 {
-
     /**
      * @var Dump
      */


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
On PHP 7.0.10 ece-tools throws an exception

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1744

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. Install magento from templete on system with PHP version 7.0.1 - 7.0.10
2. Run command `php vendor/bin/ece-tools`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
