### PR TITLE
MAGECLOUD-1894: Deployment failed on 2.3

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -15,13 +15,18 @@ if (!defined('BP')) {
     define('BP', realpath($magentoRoot));
 }
 
-if (!file_exists($magentoRoot . '/app/etc/NonComposerComponentRegistration.php') &&
-    file_exists($magentoRoot . '/init/app/etc/NonComposerComponentRegistration.php')
-) {
-    copy(
-        $magentoRoot . '/init/app/etc/NonComposerComponentRegistration.php',
-        $magentoRoot . '/app/etc/NonComposerComponentRegistration.php'
-    );
+$files = [
+    '/app/etc/registration_globlist.php',
+    '/app/etc/NonComposerComponentRegistration.php',
+];
+
+foreach ($files as $file) {
+    if (!file_exists($magentoRoot . $file) && file_exists($magentoRoot . '/init' . $file)) {
+        copy(
+            $magentoRoot . '/init' . $file,
+            $magentoRoot . $file
+        );
+    }
 }
 
 foreach ([__DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php'] as $file) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Deployment of Magento 2.3 on Cloud cannot be performed because of new file app/etc/registration_globlist.php

This file must be present before running deployment.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1894

### Manual test steps
1. Uninstall Magento
2. Install Magento 2.3
3. Installation finishes without errors, site works as expected

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
