### PR TITLE
MAGECLOUD-1221: #79 AdminCredentials class should throw an exception when updating an already used username

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -197,7 +197,9 @@ class Container implements ContainerInterface
                             'validators' => [
                                 ValidatorInterface::LEVEL_CRITICAL => [
                                     $this->container->make(ConfigValidator\Deploy\AdminEmail::class),
+                                    $this->container->make(ConfigValidator\Build\StageConfig::class),
                                     $this->container->make(ConfigValidator\Deploy\Variables::class),
+                                    $this->container->make(ConfigValidator\Deploy\AdminCredentials::class),
                                 ],
                             ],
                         ]),

--- a/src/Config/Validator/Deploy/AdminCredentials.php
+++ b/src/Config/Validator/Deploy/AdminCredentials.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Config\Validator\Deploy;
+
+use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Config\State;
+use Magento\MagentoCloud\Config\Validator;
+use Magento\MagentoCloud\Config\ValidatorInterface;
+use Magento\MagentoCloud\DB\ConnectionInterface;
+
+/**
+ * @inheritdoc
+ */
+class AdminCredentials implements ValidatorInterface
+{
+    /**
+     * @var State
+     */
+    private $state;
+
+    /**
+     * @var ConnectionInterface
+     */
+    private $connection;
+
+    /**
+     * @var Environment
+     */
+    private $environment;
+
+    /**
+     * @var Validator\ResultFactory
+     */
+    private $resultFactory;
+
+    /**
+     * @param Validator\ResultFactory $resultFactory
+     * @param State $state
+     * @param ConnectionInterface $connection
+     * @param Environment $environment
+     */
+    public function __construct(
+        Validator\ResultFactory $resultFactory,
+        State $state,
+        ConnectionInterface $connection,
+        Environment $environment
+    ) {
+        $this->resultFactory = $resultFactory;
+        $this->state = $state;
+        $this->connection = $connection;
+        $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function validate(): Validator\ResultInterface
+    {
+        if (!$this->state->isInstalled()) {
+            return $this->resultFactory->create(Validator\Result\Success::SUCCESS);
+        }
+
+        $adminEmail = $this->environment->getAdminEmail();
+        $adminUsername = $this->environment->getAdminUsername();
+
+        $isEmailUsed = $adminEmail && $this->isEmailUsed($adminEmail);
+        $isUsernameUsed = $adminUsername && $this->isUsernameUsed($adminUsername);
+
+        if (!$isEmailUsed && !$isUsernameUsed) {
+            return $this->resultFactory->create(Validator\Result\Success::SUCCESS);
+        }
+
+        $storedData = $this->getStoredData();
+
+        if ($isEmailUsed && $adminEmail !== $storedData['email']) {
+            return $this->resultFactory->create(
+                Validator\Result\Error::ERROR,
+                [
+                    'error' => 'This email is already used',
+                    'suggestion' => 'Use different email',
+                ]
+            );
+        }
+
+        if ($isUsernameUsed && $adminUsername !== $storedData['username']) {
+            return $this->resultFactory->create(
+                Validator\Result\Error::ERROR,
+                [
+                    'error' => 'This username is already used',
+                    'suggestion' => 'Use different username',
+                ]
+            );
+        }
+
+        return $this->resultFactory->create(Validator\Result\Success::SUCCESS);
+    }
+
+    /**
+     * @param string $email
+     * @return bool
+     */
+    private function isEmailUsed(string $email): bool
+    {
+        return $this->connection->count('SELECT 1 FROM `admin_user` WHERE `email` = ?', [$email]) > 0;
+    }
+
+    /**
+     * @param string $username
+     * @return bool
+     */
+    private function isUsernameUsed(string $username): bool
+    {
+        return $this->connection->count('SELECT 1 FROM `admin_user` WHERE `username` = ?', [$username]) > 0;
+    }
+
+    /**
+     * @return array
+     */
+    private function getStoredData(): array
+    {
+        return $this->connection->selectOne(
+            'SELECT `email`, `username` FROM `admin_user` ORDER BY `user_id` ASC LIMIT 1'
+        );
+    }
+}

--- a/src/Config/Validator/Deploy/AdminCredentials.php
+++ b/src/Config/Validator/Deploy/AdminCredentials.php
@@ -119,6 +119,9 @@ class AdminCredentials implements ValidatorInterface
     }
 
     /**
+     * Retrieves admin data of the first user as the only, which must be created by
+     * this scripts.
+     *
      * @return array
      */
     private function getStoredData(): array

--- a/src/Config/ValidatorInterface.php
+++ b/src/Config/ValidatorInterface.php
@@ -5,13 +5,15 @@
  */
 namespace Magento\MagentoCloud\Config;
 
+use Magento\MagentoCloud\App\Logger;
+
 /**
  * Interface for validators which runs at the very beginning of build or deploy phase
  */
 interface ValidatorInterface
 {
-    const LEVEL_WARNING = 'warning';
-    const LEVEL_CRITICAL = 'critical';
+    const LEVEL_WARNING = Logger::WARNING;
+    const LEVEL_CRITICAL = Logger::CRITICAL;
 
     /**
      * @return Validator\ResultInterface

--- a/src/DB/Connection.php
+++ b/src/DB/Connection.php
@@ -84,6 +84,19 @@ class Connection implements ConnectionInterface
      */
     public function select(string $query, array $bindings = []): array
     {
+        return $this->getFetchStatement($query, $bindings)->fetchAll();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function selectOne(string $query, array $bindings = []): array
+    {
+        return $this->getFetchStatement($query, $bindings)->fetch(\PDO::FETCH_ASSOC);
+    }
+
+    private function getFetchStatement(string $query, array $bindings = []): \PDOStatement
+    {
         return $this->run($query, $bindings, function ($query, $bindings) {
             $statement = $this->getPdo()->prepare($query);
 
@@ -94,7 +107,7 @@ class Connection implements ConnectionInterface
             );
             $statement->execute();
 
-            return $statement->fetchAll();
+            return $statement;
         });
     }
 
@@ -165,7 +178,7 @@ class Connection implements ConnectionInterface
             $environment->getDbUser(),
             $environment->getDbPassword(),
             [
-                \PDO::ATTR_PERSISTENT => true
+                \PDO::ATTR_PERSISTENT => true,
             ]
         );
     }
@@ -185,5 +198,19 @@ class Connection implements ConnectionInterface
         }
 
         return $closure($query, $bindings);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function count(string $query, array $bindings = []): int
+    {
+        return $this->run($query, $bindings, function ($query, $bindings) {
+            $statement = $this->getPdo()->prepare($query);
+            $this->bindValues($statement, $bindings);
+            $statement->execute();
+
+            return $statement->rowCount();
+        });
     }
 }

--- a/src/DB/ConnectionInterface.php
+++ b/src/DB/ConnectionInterface.php
@@ -38,6 +38,20 @@ interface ConnectionInterface
     public function select(string $query, array $bindings = []): array;
 
     /**
+     * @param string $query
+     * @param array $bindings
+     * @return array
+     */
+    public function selectOne(string $query, array $bindings = []): array;
+
+    /**
+     * @param string $query
+     * @param array $bindings
+     * @return int
+     */
+    public function count(string $query, array $bindings = []): int;
+
+    /**
      * @return array
      */
     public function listTables(): array;

--- a/src/Process/Deploy/InstallUpdate/Update/AdminCredentials.php
+++ b/src/Process/Deploy/InstallUpdate/Update/AdminCredentials.php
@@ -88,6 +88,7 @@ class AdminCredentials implements ProcessInterface
 
         if (!$data) {
             $this->logger->info('Updating admin credentials: nothing to update.');
+
             return;
         }
 
@@ -99,7 +100,7 @@ class AdminCredentials implements ProcessInterface
             },
             array_keys($data)
         );
-            $query = 'UPDATE `admin_user` SET ' . implode(', ', $fields) . ' ORDER BY `user_id` ASC LIMIT 1';
+        $query = 'UPDATE `admin_user` SET ' . implode(', ', $fields) . ' ORDER BY `user_id` ASC LIMIT 1';
 
         $this->connection->affectingQuery(
             $query,
@@ -113,13 +114,7 @@ class AdminCredentials implements ProcessInterface
      */
     private function isEmailUsed(string $email): bool
     {
-        $isUsed = count($this->connection->select('SELECT 1 FROM `admin_user` WHERE `email` = ?', [$email])) > 0;
-
-        if ($isUsed) {
-            $this->logger->warning('Some administrator already uses this email ' . $email);
-        }
-
-        return $isUsed;
+        return count($this->connection->select('SELECT 1 FROM `admin_user` WHERE `email` = ?', [$email])) > 0;
     }
 
     /**
@@ -128,12 +123,6 @@ class AdminCredentials implements ProcessInterface
      */
     private function isUsernameUsed(string $username): bool
     {
-        $isUsed = count($this->connection->select('SELECT 1 FROM `admin_user` WHERE `username` = ?', [$username])) > 0;
-
-        if ($isUsed) {
-            $this->logger->warning('Some administrator already uses this username ' . $username);
-        }
-
-        return $isUsed;
+        return count($this->connection->select('SELECT 1 FROM `admin_user` WHERE `username` = ?', [$username])) > 0;
     }
 }

--- a/src/Process/ValidateConfiguration.php
+++ b/src/Process/ValidateConfiguration.php
@@ -65,14 +65,18 @@ class ValidateConfiguration implements ProcessInterface
 
         $this->logger->info('End of validation');
 
-        if ($maxLevel >= ValidatorInterface::LEVEL_CRITICAL && $messages) {
+        if (!$messages && $maxLevel) {
+            return;
+        }
+
+        $error = 'Fix configuration with given suggestions:' . PHP_EOL . implode(PHP_EOL, $messages);
+
+        if ($maxLevel >= ValidatorInterface::LEVEL_CRITICAL) {
             throw new \RuntimeException(
-                'Fix configuration with given suggestions: ' . PHP_EOL . implode(PHP_EOL, $messages)
+                $error
             );
         }
 
-        if ($maxLevel && $messages) {
-            $this->logger->log($maxLevel, implode(PHP_EOL, $messages));
-        }
+        $this->logger->log($maxLevel, $error);
     }
 }

--- a/src/Process/ValidateConfiguration.php
+++ b/src/Process/ValidateConfiguration.php
@@ -51,13 +51,13 @@ class ValidateConfiguration implements ProcessInterface
 
         /* @var $validators ValidatorInterface[] */
         foreach ($this->validators as $level => $validators) {
-            $maxLevel = max($maxLevel, $level);
-
             foreach ($validators as $validator) {
                 $result = $validator->validate();
 
                 if ($result instanceof Error) {
+                    $maxLevel = max($maxLevel, $level);
                     $pattern = $result->getSuggestion() ? '- %s (%s)' : '- %s';
+
                     $messages[] = sprintf($pattern, $result->getError(), $result->getSuggestion());
                 }
             }

--- a/src/Process/ValidateConfiguration.php
+++ b/src/Process/ValidateConfiguration.php
@@ -65,7 +65,7 @@ class ValidateConfiguration implements ProcessInterface
 
         $this->logger->info('End of validation');
 
-        if (!$messages && $maxLevel) {
+        if (!$messages || !$maxLevel) {
             return;
         }
 

--- a/src/Test/Integration/AdminCredentialTest.php
+++ b/src/Test/Integration/AdminCredentialTest.php
@@ -58,7 +58,7 @@ class AdminCredentialTest extends AbstractTest
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage Please fix configuration with given suggestions
+     * @expectedExceptionMessage Fix configuration with given suggestions
      */
     public function testInstallWithoutAdminEmail()
     {

--- a/src/Test/Integration/AdminCredentialTest.php
+++ b/src/Test/Integration/AdminCredentialTest.php
@@ -149,8 +149,6 @@ class AdminCredentialTest extends AbstractTest
         $this->executeAndAssert(Deploy::NAME, $application);
 
         $this->assertContains('Updating admin credentials: nothing to update.', $this->getCloudLog());
-        $this->assertContains('Some administrator already uses this email admin@example.com', $this->getCloudLog());
-        $this->assertContains('Some administrator already uses this username admin', $this->getCloudLog());
     }
 
     private function getCloudLog()

--- a/src/Test/Integration/PostDeployTest.php
+++ b/src/Test/Integration/PostDeployTest.php
@@ -73,7 +73,7 @@ class PostDeployTest extends AbstractTest
         try {
             $this->assertSame(1, $this->execute(Deploy::NAME, $application));
         } catch (\Exception $e) {
-            $this->assertContains('Please fix configuration with given suggestions', $e->getMessage());
+            $this->assertContains('Fix configuration with given suggestions', $e->getMessage());
         }
         $this->assertSame(0, $this->execute(PostDeploy::NAME, $application));
 

--- a/src/Test/Unit/Config/Validator/Deploy/AdminCredentialsTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/AdminCredentialsTest.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Config\Validator\Deploy;
+
+use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Config\State;
+use Magento\MagentoCloud\Config\Validator\Deploy\AdminCredentials;
+use Magento\MagentoCloud\Config\Validator\Result\Error;
+use Magento\MagentoCloud\Config\Validator\Result\Success;
+use Magento\MagentoCloud\Config\Validator\ResultFactory;
+use Magento\MagentoCloud\Config\ValidatorInterface;
+use Magento\MagentoCloud\DB\ConnectionInterface;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+/**
+ * @inheritdoc
+ */
+class AdminCredentialsTest extends TestCase
+{
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    /**
+     * @var ResultFactory|Mock
+     */
+    private $resultFactoryMock;
+
+    /**
+     * @var State|Mock
+     */
+    private $stateMock;
+
+    /**
+     * @var ConnectionInterface|Mock
+     */
+    private $connectionMock;
+
+    /**
+     * @var Environment|Mock
+     */
+    private $environmentMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->resultFactoryMock = $this->createMock(ResultFactory::class);
+        $this->stateMock = $this->createMock(State::class);
+        $this->connectionMock = $this->getMockForAbstractClass(ConnectionInterface::class);
+        $this->environmentMock = $this->createMock(Environment::class);
+
+        $this->validator = new AdminCredentials(
+            $this->resultFactoryMock,
+            $this->stateMock,
+            $this->connectionMock,
+            $this->environmentMock
+        );
+    }
+
+    public function testValidate()
+    {
+        $email = 'test@email.com';
+        $username = 'admin';
+
+        $this->stateMock->expects($this->once())
+            ->method('isInstalled')
+            ->willReturn(true);
+        $this->environmentMock->expects($this->once())
+            ->method('getAdminEmail')
+            ->willReturn($email);
+        $this->environmentMock->expects($this->once())
+            ->method('getAdminUsername')
+            ->willReturn($username);
+        $this->connectionMock->expects($this->exactly(2))
+            ->method('count')
+            ->willReturnMap([
+                [
+                    'SELECT 1 FROM `admin_user` WHERE `email` = ?',
+                    [$email],
+                    0,
+                ],
+                [
+                    'SELECT 1 FROM `admin_user` WHERE `username` = ?',
+                    [$username],
+                    0,
+                ],
+            ]);
+        $this->resultFactoryMock->expects($this->once())
+            ->method('create')
+            ->with(Success::SUCCESS)
+            ->willReturn(new Success());
+
+        $this->validator->validate();
+    }
+
+    public function testValidateDuplicateEmail()
+    {
+        $email = 'test@email.com';
+        $username = 'admin';
+
+        $this->stateMock->expects($this->once())
+            ->method('isInstalled')
+            ->willReturn(true);
+        $this->environmentMock->expects($this->once())
+            ->method('getAdminEmail')
+            ->willReturn($email);
+        $this->environmentMock->expects($this->once())
+            ->method('getAdminUsername')
+            ->willReturn($username);
+        $this->connectionMock->expects($this->exactly(2))
+            ->method('count')
+            ->willReturnMap([
+                [
+                    'SELECT 1 FROM `admin_user` WHERE `email` = ?',
+                    [$email],
+                    1,
+                ],
+                [
+                    'SELECT 1 FROM `admin_user` WHERE `username` = ?',
+                    [$username],
+                    0,
+                ],
+            ]);
+        $this->connectionMock->expects($this->once())
+            ->method('selectOne')
+            ->with('SELECT `email`, `username` FROM `admin_user` ORDER BY `user_id` ASC LIMIT 1')
+            ->willReturn([
+                'email' => 'old_email@email.com',
+                'username' => 'admin',
+            ]);
+        $this->resultFactoryMock->expects($this->once())
+            ->method('create')
+            ->with(Error::ERROR, [
+                'error' => 'This email is already used',
+                'suggestion' => 'Use different email',
+            ])
+            ->willReturn(new Error('some_error'));
+
+        $this->validator->validate();
+    }
+
+    public function testValidateDuplicateUsername()
+    {
+        $email = 'test@email.com';
+        $username = 'admin';
+
+        $this->stateMock->expects($this->once())
+            ->method('isInstalled')
+            ->willReturn(true);
+        $this->environmentMock->expects($this->once())
+            ->method('getAdminEmail')
+            ->willReturn($email);
+        $this->environmentMock->expects($this->once())
+            ->method('getAdminUsername')
+            ->willReturn($username);
+        $this->connectionMock->expects($this->exactly(2))
+            ->method('count')
+            ->willReturnMap([
+                [
+                    'SELECT 1 FROM `admin_user` WHERE `email` = ?',
+                    [$email],
+                    0,
+                ],
+                [
+                    'SELECT 1 FROM `admin_user` WHERE `username` = ?',
+                    [$username],
+                    1,
+                ],
+            ]);
+        $this->connectionMock->expects($this->once())
+            ->method('selectOne')
+            ->with('SELECT `email`, `username` FROM `admin_user` ORDER BY `user_id` ASC LIMIT 1')
+            ->willReturn([
+                'email' => 'email@email.com',
+                'username' => 'old_admin',
+            ]);
+        $this->resultFactoryMock->expects($this->once())
+            ->method('create')
+            ->with(Error::ERROR, [
+                'error' => 'This username is already used',
+                'suggestion' => 'Use different username',
+            ])
+            ->willReturn(new Error('some_error'));
+
+        $this->validator->validate();
+    }
+
+    public function testValidateNotInstalled()
+    {
+        $this->stateMock->expects($this->once())
+            ->method('isInstalled')
+            ->willReturn(false);
+        $this->connectionMock->expects($this->never())
+            ->method('count');
+
+        $this->validator->validate();
+    }
+}

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Update/AdminCredentialsTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Update/AdminCredentialsTest.php
@@ -123,12 +123,6 @@ class AdminCredentialsTest extends TestCase
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Updating admin credentials.');
-        $this->loggerMock->expects($this->exactly(2))
-            ->method('warning')
-            ->withConsecutive(
-                ['Some administrator already uses this email ' . $email],
-                ['Some administrator already uses this username ' . $userName]
-            );
         $this->environmentMock->expects($this->once())
             ->method('getAdminPassword')
             ->willReturn('');

--- a/src/Test/Unit/Process/ValidateConfigurationTest.php
+++ b/src/Test/Unit/Process/ValidateConfigurationTest.php
@@ -115,7 +115,11 @@ class ValidateConfigurationTest extends TestCase
             );
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with(ValidatorInterface::LEVEL_WARNING, '- some warning (some warning suggestion)');
+            ->with(
+                ValidatorInterface::LEVEL_WARNING,
+                'Fix configuration with given suggestions:'
+                . PHP_EOL . '- some warning (some warning suggestion)'
+            );
 
         $process = new ValidateConfiguration(
             $this->loggerMock,
@@ -168,7 +172,8 @@ class ValidateConfigurationTest extends TestCase
             ->method('log')
             ->with(
                 Logger::WARNING,
-                '- some warning (some warning suggestion)'
+                'Fix configuration with given suggestions:'
+                . PHP_EOL . '- some warning (some warning suggestion)'
                 . PHP_EOL . '- some warning 2 (some warning suggestion 2)'
             );
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Description
https://magento2.atlassian.net/browse/MAGECLOUD-1221
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
1. Added validation for duplicate admin `username` and `email`
2. Changed Validator mechanism to not fail on first error

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. https://jira.corp.magento.com/browse/MAGETWO-89772

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
