### PR TITLE
MAGECLOUD:1966: Add symfony/console ^4.0 compatibility 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "require": {
     "php": "^7.0",
     "monolog/monolog": "^1.16",
-    "symfony/console": "~4.0.0",
+    "symfony/console": "^2.6||~4.0.0",
     "illuminate/contracts": "^5.5",
     "illuminate/container": "^5.5",
     "illuminate/config": "^5.5",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "require": {
     "php": "^7.0",
     "monolog/monolog": "^1.16",
-    "symfony/console": "^2.6",
+    "symfony/console": "~4.0.0",
     "illuminate/contracts": "^5.5",
     "illuminate/container": "^5.5",
     "illuminate/config": "^5.5",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "require": {
     "php": "^7.0",
     "monolog/monolog": "^1.16",
-    "symfony/console": "^2.6||~4.0.0",
+    "symfony/console": "^2.6||^4.0",
     "illuminate/contracts": "^5.5",
     "illuminate/container": "^5.5",
     "illuminate/config": "^5.5",


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
https://magento2.atlassian.net/browse/MAGECLOUD-1966
### Description
MAGECLOUD-1966: For Magento 2.3 compatibility, switching requirement to "symfony/console": "^2.6||^4.0"

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
1. Fixing Compatibility with Magento 2.3
2. Keeping compatibility with Magento 2.1 & 2.2.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
