### PR TITLE
MAGECLOUD-2021: Add more logging and handle only proper case in BackupData/StaticContent

### DIFF
--- a/src/Process/Build/BackupData/StaticContent.php
+++ b/src/Process/Build/BackupData/StaticContent.php
@@ -78,11 +78,18 @@ class StaticContent implements ProcessInterface
             $this->file->createDirectory($initPubStatic);
         }
 
-        $this->logger->info('Moving static content to init directory');
         try {
+            $this->logger->info('Moving static content to init directory');
             $this->file->rename($originalPubStatic, $initPubStatic);
         } catch (FileSystemException $e) {
+            $this->logger->notice('Can\'t move static content');
+            $this->logger->info('Copying static content to init directory');
             $this->file->copyDirectory($originalPubStatic, $initPubStatic);
+        } finally {
+            if (!$this->file->isExists($originalPubStatic)) {
+                $this->logger->info('Recreating pub/static directory');
+                $this->file->createDirectory($originalPubStatic);
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
https://magento2.atlassian.net/browse/MAGECLOUD-2021

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. Deploy magento with ece-tools 2002.0.10 on production environment and scd on build phase

✖️ CRITICAL: Directory ".../pub/static" cannot be created Warning!mkdir(): Read-only file system
✔️ Deployment finished successfully

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
