### PR TITLE
MAGECLOUD-2057: Remove password from log output of mysqldump

### DIFF
--- a/src/App/Logger/Processor/SanitizeProcessor.php
+++ b/src/App/Logger/Processor/SanitizeProcessor.php
@@ -16,7 +16,8 @@ class SanitizeProcessor
      * @var array
      */
     private $replacements = [
-        '/-password=\'.*?\'(\s|$)/i' => '-password=\'******\'$1'
+        '/-password=\'.*?\'(\s|$)/i' => '-password=\'******\'$1',
+        '/mysqldump (.* )-p\'[^\']+\'/i'  => 'mysqldump $1-p\'******\'',
     ];
 
     /**

--- a/src/Test/Unit/App/Logger/Processor/SanitizeProcessorTest.php
+++ b/src/Test/Unit/App/Logger/Processor/SanitizeProcessorTest.php
@@ -57,6 +57,23 @@ class SanitizeProcessorTest extends TestCase
                 ['message' => 'some text --admin-password=\'' . escapeshellarg("Ks81b'USl'13Osd") . '\''],
                 ['message' => 'some text --admin-password=\'******\''],
             ],
+            [
+                ['message' => 'Command: bash -c "set -o pipefail; timeout 3600 mysqldump -h \'127.0.0.1\' -P \'3304\''
+                    . ' -u \'abcdefghijklm_stg\' -p\'OmgSuperSecretPasswordDoNotLeak\' \'abcdefghijklm_stg\''
+                    . ' --single-transaction --no-autocommit --quick | gzip > /tmp/dump-1525977618.sql.gz'],
+                ['message' => 'Command: bash -c "set -o pipefail; timeout 3600 mysqldump -h \'127.0.0.1\' -P \'3304\''
+                    . ' -u \'abcdefghijklm_stg\' -p\'******\' \'abcdefghijklm_stg\''
+                    . ' --single-transaction --no-autocommit --quick | gzip > /tmp/dump-1525977618.sql.gz'],
+            ],
+            [
+                ['message' => 'Command: bash -c "set -o pipefail; timeout 3600 mysqldump -h \'127.0.0.1\' -P \'3304\''
+                    . ' -u \'abcdefghijklm_stg\' \'abcdefghijklm_stg\' --single-transaction --no-autocommit'
+                    . ' --quick | gzip > /tmp/dump-1525977618.sql.gz'],
+                ['message' => 'Command: bash -c "set -o pipefail; timeout 3600 mysqldump -h \'127.0.0.1\' -P \'3304\''
+                    . ' -u \'abcdefghijklm_stg\' \'abcdefghijklm_stg\' --single-transaction --no-autocommit'
+                    . ' --quick | gzip > /tmp/dump-1525977618.sql.gz'],
+            ],
+
         ];
     }
 }


### PR DESCRIPTION
MAGECLOUD-2057
Update Sanitize Processor to handle MysqlDump password usage
https://magento2.atlassian.net/browse/MAGECLOUD-2057

### Description
Add regular expression replace to hide passwords from mysqldump command.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues, if relevant  -->
1.  `ece-tools db-dump` was logging the database password in the mysqldump -p argument.

### Zephyr Tests
1. Push branch to a staging or production environment.  (integration (and maybe starter?) environments don't use database passwords.)
2. Ssh to that environment.
3. `vendor/bin/ece-tools db-dump`
4. Look at output from that command, and also check ~/var/log/cloud.log for the mysqldump command with the correct timestamp.
5. Should not show password.  Should look like this:
[2018-05-10 18:40:18] INFO: Command: bash -c "set -o pipefail; timeout 3600 mysqldump -h '127.0.0.1' -P '3304' -u 'qxmtlseakof6y_stg' -p'******' 'qxmtlseakof6y_stg' --single-transaction --no-autocommit --quick | gzip > /tmp/dump-1525977618.sql.gz"


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

