### PR TITLE
MAGECLOUD-2218: Can't specify variable DEPLOYED_MAGENTO_VERSION_FROM_GIT

### DIFF
--- a/src/Config/Schema.php
+++ b/src/Config/Schema.php
@@ -174,7 +174,7 @@ class Schema
                 ],
             ],
             StageConfigInterface::VAR_DEPLOYED_MAGENTO_VERSION_FROM_GIT => [
-                self::SCHEMA_TYPE => ['array', 'boolean'],
+                self::SCHEMA_TYPE => ['string'],
                 self::SCHEMA_STAGE => [
                     StageConfigInterface::STAGE_GLOBAL
                 ],

--- a/src/Config/Schema.php
+++ b/src/Config/Schema.php
@@ -179,7 +179,7 @@ class Schema
                     StageConfigInterface::STAGE_GLOBAL
                 ],
                 self::SCHEMA_DEFAULT_VALUE => [
-                    StageConfigInterface::STAGE_GLOBAL => false,
+                    StageConfigInterface::STAGE_GLOBAL => '',
                 ],
             ],
             StageConfigInterface::VAR_DEPLOY_FROM_GIT_OPTIONS => [


### PR DESCRIPTION
MAGECLOUD-2218: Can't specify variable DEPLOYED_MAGENTO_VERSION_FROM_GIT

### Fixed Issues (if relevant)
1. Changed type for DEPLOYED_MAGENTO_VERSION_FROM_GIT to be string

### Zephyr Tests
<!--- Provide links to Zephyr tests -->
1. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request was approved by architect
 - [ ] Pull request was approved by QA member
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

