### PR TITLE
MAGECLOUD-2280: Setting cron_run from .magento.env.yaml does not work

### DIFF
--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunner.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunner.php
@@ -103,7 +103,7 @@ class CronConsumersRunner implements ProcessInterface
         );
 
         $config['cron_consumers_runner'] = [
-            'cron_run' => $runnerConfig->get('cron_run') === 'true',
+            'cron_run' => $runnerConfig->get('cron_run') === true,
             'max_messages' => $runnerConfig->get('max_messages', static::DEFAULT_MAX_MESSAGES),
             'consumers' => $runnerConfig->get('consumers', []),
         ];

--- a/src/Test/Integration/AcceptanceTest.php
+++ b/src/Test/Integration/AcceptanceTest.php
@@ -86,7 +86,7 @@ class AcceptanceTest extends AbstractTest
                     'variables' => [
                         'ADMIN_EMAIL' => 'admin@example.com',
                         'CRON_CONSUMERS_RUNNER' => [
-                            'cron_run' => "true",
+                            'cron_run' => true,
                             'max_messages' => 5000,
                             'consumers' => ['test'],
                         ],
@@ -103,7 +103,47 @@ class AcceptanceTest extends AbstractTest
                     ],
                 ],
             ],
+            'test cron_consumers_runner with wrong array' => [
+                'environment' => [
+                    'variables' => [
+                        'ADMIN_EMAIL' => 'admin@example.com',
+                        'CRON_CONSUMERS_RUNNER' => [
+                            'cron_run' => 'true',
+                            'max_messages' => 5000,
+                            'consumers' => ['test'],
+                        ],
+                    ],
+                ],
+                'expectedConsumersRunnerConfig' => [
+                    'cron_consumers_runner' => [
+                        'cron_run' => false,
+                        'max_messages' => 5000,
+                        'consumers' => ['test'],
+                    ],
+                    'directories' => [
+                        'document_root_is_pub' => true,
+                    ],
+                ],
+            ],
             'test cron_consumers_runner with string' => [
+                'environment' => [
+                    'variables' => [
+                        'ADMIN_EMAIL' => 'admin@example.com',
+                        'CRON_CONSUMERS_RUNNER' => '{"cron_run":true, "max_messages":100, "consumers":["test2"]}',
+                    ],
+                ],
+                'expectedConsumersRunnerConfig' => [
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 100,
+                        'consumers' => ['test2'],
+                    ],
+                    'directories' => [
+                        'document_root_is_pub' => true,
+                    ],
+                ],
+            ],
+            'test cron_consumers_runner with wrong string' => [
                 'environment' => [
                     'variables' => [
                         'ADMIN_EMAIL' => 'admin@example.com',
@@ -112,7 +152,7 @@ class AcceptanceTest extends AbstractTest
                 ],
                 'expectedConsumersRunnerConfig' => [
                     'cron_consumers_runner' => [
-                        'cron_run' => true,
+                        'cron_run' => false,
                         'max_messages' => 100,
                         'consumers' => ['test2'],
                     ],

--- a/src/Test/Integration/AcceptanceTest.php
+++ b/src/Test/Integration/AcceptanceTest.php
@@ -60,6 +60,7 @@ class AcceptanceTest extends AbstractTest
 
     /**
      * @return array
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function defaultDataProvider(): array
     {

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunnerTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/CronConsumersRunnerTest.php
@@ -120,6 +120,7 @@ class CronConsumersRunnerTest extends TestCase
 
     /**
      * @return array
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function executeDataProvider(): array
     {
@@ -182,13 +183,36 @@ class CronConsumersRunnerTest extends TestCase
                         'consumers' => ['test'],
                     ],
                 ],
-                'configFromVariable' => ['cron_run' => 'true'],
+                'configFromVariable' => ['cron_run' => true],
                 'expectedResult' => [
                     'someConfig' => 'someValue',
                     'cron_consumers_runner' => [
                         'cron_run' => true,
                         'max_messages' => 10000,
                         'consumers' => [],
+                    ],
+                ],
+            ],
+            [
+                'config' => [
+                    'someConfig' => 'someValue',
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 6000,
+                        'consumers' => ['test'],
+                    ],
+                ],
+                'configFromVariable' => [
+                    'cron_run' => true,
+                    'max_messages' => 200,
+                    'consumers' => ['test2', 'test3'],
+                ],
+                'expectedResult' => [
+                    'someConfig' => 'someValue',
+                    'cron_consumers_runner' => [
+                        'cron_run' => true,
+                        'max_messages' => 200,
+                        'consumers' => ['test2', 'test3'],
                     ],
                 ],
             ],
@@ -209,7 +233,7 @@ class CronConsumersRunnerTest extends TestCase
                 'expectedResult' => [
                     'someConfig' => 'someValue',
                     'cron_consumers_runner' => [
-                        'cron_run' => true,
+                        'cron_run' => false,
                         'max_messages' => 200,
                         'consumers' => ['test2', 'test3'],
                     ],


### PR DESCRIPTION
### Description
Setting cron_run from .magento.env.yaml does not work

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-2280

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/secure/enav/#/90075
https://jira.corp.magento.com/secure/enav/#/90072

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
