### PR TITLE
MAGECLOUD-2205: Cannot upgrade magento/ece-tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "composer/composer": "@stable",
     "composer/semver": "^1.4",
     "graylog2/gelf-php": "^1.4.2",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^6.2",
     "illuminate/config": "^5.5",
     "illuminate/container": "^5.5",
     "illuminate/contracts": "^5.5",


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Changing version constraint of guzzle package from ^6.3 to ^6.2 to improve compatibility with other packages using older versions.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. MAGECLOUD-2205

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. https://jira.corp.magento.com/browse/MAGETWO-93022

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
