### PR TITLE
MAGECLOUD-2402: Pass Ansi & No-Interaction Flags

### DIFF
--- a/src/Command/Dev/UpdateComposer.php
+++ b/src/Command/Dev/UpdateComposer.php
@@ -118,7 +118,7 @@ class UpdateComposer extends Command
         );
 
         $output->writeln('Run composer update');
-        $this->shell->execute('composer update');
+        $this->shell->execute('composer update --ansi --no-interaction');
 
         $output->writeln('Composer update finished.');
         $output->writeln('Please commit and push changed files.');

--- a/src/Config/Module.php
+++ b/src/Config/Module.php
@@ -43,13 +43,13 @@ class Module
         $moduleConfig = (array)$this->sharedConfig->get('modules');
 
         if (!$moduleConfig) {
-            $this->shell->execute('php ./bin/magento module:enable --all');
+            $this->shell->execute('php ./bin/magento module:enable --all --ansi --no-interaction');
             $this->sharedConfig->reset();
 
             return;
         }
 
-        $this->shell->execute('php ./bin/magento module:enable --all');
+        $this->shell->execute('php ./bin/magento module:enable --all --ansi --no-interaction');
         $this->sharedConfig->update(['modules' => $moduleConfig]);
     }
 }

--- a/src/Process/Build/CompileDi.php
+++ b/src/Process/Build/CompileDi.php
@@ -54,6 +54,6 @@ class CompileDi implements ProcessInterface
         $verbosityLevel = $this->stageConfig->get(BuildInterface::VAR_VERBOSE_COMMANDS);
 
         $this->logger->info('Running DI compilation');
-        $this->shell->execute("php ./bin/magento setup:di:compile {$verbosityLevel}");
+        $this->shell->execute("php ./bin/magento setup:di:compile {$verbosityLevel} --ansi --no-interaction");
     }
 }

--- a/src/Process/Build/ComposerDumpAutoload.php
+++ b/src/Process/Build/ComposerDumpAutoload.php
@@ -31,6 +31,6 @@ class ComposerDumpAutoload implements ProcessInterface
      */
     public function execute()
     {
-        $this->shell->execute('composer dump-autoload -o');
+        $this->shell->execute('composer dump-autoload -o --ansi --no-interaction');
     }
 }

--- a/src/Process/ConfigDump/Export.php
+++ b/src/Process/ConfigDump/Export.php
@@ -63,7 +63,7 @@ class Export implements ProcessInterface
         $envConfig = $this->reader->read();
 
         try {
-            $this->shell->execute('php ./bin/magento app:config:dump');
+            $this->shell->execute('php ./bin/magento app:config:dump --ansi --no-interaction');
         } finally {
             $this->writer->create($envConfig);
         }

--- a/src/Process/ConfigDump/Import.php
+++ b/src/Process/ConfigDump/Import.php
@@ -52,6 +52,6 @@ class Import implements ProcessInterface
             return;
         }
 
-        $this->shell->execute('php ./bin/magento app:config:import -n');
+        $this->shell->execute('php ./bin/magento app:config:import --ansi --no-interaction');
     }
 }

--- a/src/Process/Deploy/DeployStaticContent/Generate.php
+++ b/src/Process/Deploy/DeployStaticContent/Generate.php
@@ -88,9 +88,10 @@ class Generate implements ProcessInterface
     {
         $this->file->touch($this->directoryList->getMagentoRoot() . '/pub/static/deployed_version.txt');
         $this->logger->info('Enabling Maintenance mode');
-        $this->shell->execute(
-            "php ./bin/magento maintenance:enable {$this->stageConfig->get(DeployInterface::VAR_VERBOSE_COMMANDS)}"
-        );
+        $this->shell->execute(sprintf(
+            'php ./bin/magento maintenance:enable --ansi --no-interaction %s',
+            $this->stageConfig->get(DeployInterface::VAR_VERBOSE_COMMANDS)
+        ));
         $this->logger->info('Extracting locales');
 
         $logMessage = count($this->deployOption->getLocales()) ?
@@ -108,9 +109,10 @@ class Generate implements ProcessInterface
             $this->shell->execute($command);
         }
 
-        $this->shell->execute(
-            "php ./bin/magento maintenance:disable {$this->stageConfig->get(DeployInterface::VAR_VERBOSE_COMMANDS)}"
-        );
+        $this->shell->execute(sprintf(
+            'php ./bin/magento maintenance:disable --ansi --no-interaction %s',
+            $this->stageConfig->get(DeployInterface::VAR_VERBOSE_COMMANDS)
+        ));
 
         $this->logger->info('Maintenance mode is disabled.');
     }

--- a/src/Process/Deploy/InstallUpdate/Install/ConfigImport.php
+++ b/src/Process/Deploy/InstallUpdate/Install/ConfigImport.php
@@ -58,6 +58,6 @@ class ConfigImport implements ProcessInterface
         }
 
         $this->logger->info('Run app:config:import command');
-        $this->shell->execute('php ./bin/magento app:config:import -n');
+        $this->shell->execute('php ./bin/magento app:config:import --ansi --no-interaction');
     }
 }

--- a/src/Process/Deploy/InstallUpdate/Install/Setup.php
+++ b/src/Process/Deploy/InstallUpdate/Install/Setup.php
@@ -113,7 +113,7 @@ class Setup implements ProcessInterface
             . ' --admin-email=' . escapeshellarg($this->environment->getAdminEmail())
             . ' --admin-password=' . escapeshellarg($this->environment->getAdminPassword()
                 ? $this->environment->getAdminPassword() : $this->passwordGenerator->generateRandomPassword())
-            . ' --use-secure-admin=1';
+            . ' --use-secure-admin=1 --ansi --no-interaction';
 
         $dbPassword = $this->environment->getDbPassword();
         if (strlen($dbPassword)) {

--- a/src/Process/Deploy/InstallUpdate/Update/Setup.php
+++ b/src/Process/Deploy/InstallUpdate/Update/Setup.php
@@ -96,16 +96,16 @@ class Setup implements ProcessInterface
             $verbosityLevel = $this->stageConfig->get(DeployInterface::VAR_VERBOSE_COMMANDS);
 
             $this->logger->notice('Enabling Maintenance mode.');
-            $this->shell->execute('php ./bin/magento maintenance:enable ' . $verbosityLevel);
+            $this->shell->execute('php ./bin/magento maintenance:enable --ansi --no-interaction ' . $verbosityLevel);
             $this->logger->info('Running setup upgrade.');
 
             $this->shell->execute(sprintf(
                 '/bin/bash -c "set -o pipefail; %s | tee -a %s"',
-                'php ./bin/magento setup:upgrade --keep-generated -n ' . $verbosityLevel,
+                'php ./bin/magento setup:upgrade --keep-generated --ansi --no-interaction ' . $verbosityLevel,
                 $this->fileList->getInstallUpgradeLog()
             ));
 
-            $this->shell->execute('php ./bin/magento maintenance:disable ' . $verbosityLevel);
+            $this->shell->execute('php ./bin/magento maintenance:disable --ansi --no-interaction ' . $verbosityLevel);
             $this->logger->notice('Maintenance mode is disabled.');
         } catch (\RuntimeException $e) {
             //Rollback required by database

--- a/src/Process/PostDeploy/CleanCache.php
+++ b/src/Process/PostDeploy/CleanCache.php
@@ -42,8 +42,9 @@ class CleanCache implements ProcessInterface
      */
     public function execute()
     {
-        $this->shell->execute(
-            'php ./bin/magento cache:flush ' . $this->stageConfig->get(PostDeployInterface::VAR_VERBOSE_COMMANDS)
-        );
+        $this->shell->execute(sprintf(
+            'php ./bin/magento cache:flush --ansi --no-interaction %s',
+            $this->stageConfig->get(PostDeployInterface::VAR_VERBOSE_COMMANDS)
+        ));
     }
 }

--- a/src/StaticContent/CommandFactory.php
+++ b/src/StaticContent/CommandFactory.php
@@ -100,7 +100,7 @@ class CommandFactory
      */
     private function build(OptionInterface $option): string
     {
-        $command = 'php ./bin/magento setup:static-content:deploy';
+        $command = 'php ./bin/magento setup:static-content:deploy --ansi --no-interaction';
 
         if ($option->isForce()) {
             $command .= ' -f';

--- a/src/Test/Unit/Command/Dev/UpdateComposerTest.php
+++ b/src/Test/Unit/Command/Dev/UpdateComposerTest.php
@@ -111,7 +111,7 @@ class UpdateComposerTest extends TestCase
             ->withConsecutive(
                 ['script2'],
                 ['script3'],
-                ['composer update']
+                ['composer update --ansi --no-interaction']
             );
         $this->fileListMock->expects($this->once())
             ->method('getMagentoComposer')

--- a/src/Test/Unit/Config/ModuleTest.php
+++ b/src/Test/Unit/Config/ModuleTest.php
@@ -55,7 +55,7 @@ class ModuleTest extends TestCase
             ->method('reset');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('php ./bin/magento module:enable --all');
+            ->with('php ./bin/magento module:enable --all --ansi --no-interaction');
         $this->sharedConfigMock->expects($this->never())
             ->method('update');
 
@@ -70,7 +70,7 @@ class ModuleTest extends TestCase
             ->willReturn(['Some_OtherModule' => 1]);
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('php ./bin/magento module:enable --all');
+            ->with('php ./bin/magento module:enable --all --ansi --no-interaction');
         $this->sharedConfigMock->expects($this->never())
             ->method('reset');
         $this->sharedConfigMock->expects($this->once())

--- a/src/Test/Unit/Process/Build/CompileDiTest.php
+++ b/src/Test/Unit/Process/Build/CompileDiTest.php
@@ -66,7 +66,7 @@ class CompileDiTest extends TestCase
             ->with('Running DI compilation');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('php ./bin/magento setup:di:compile -vvv');
+            ->with('php ./bin/magento setup:di:compile -vvv --ansi --no-interaction');
 
         $this->process->execute();
     }

--- a/src/Test/Unit/Process/Build/ComposerDumpAutoloadTest.php
+++ b/src/Test/Unit/Process/Build/ComposerDumpAutoloadTest.php
@@ -41,7 +41,7 @@ class ComposerDumpAutoloadTest extends TestCase
     {
         $this->shell->expects($this->once())
             ->method('execute')
-            ->with('composer dump-autoload -o');
+            ->with('composer dump-autoload -o --ansi --no-interaction');
 
         $this->process->execute();
     }

--- a/src/Test/Unit/Process/ConfigDump/ExportTest.php
+++ b/src/Test/Unit/Process/ConfigDump/ExportTest.php
@@ -66,7 +66,7 @@ class ExportTest extends TestCase
         $this->shellMock->expects($this->once())
             ->method('execute')
             ->withConsecutive(
-                ['php ./bin/magento app:config:dump']
+                ['php ./bin/magento app:config:dump --ansi --no-interaction']
             );
         $this->readerMock->expects($this->once())
             ->method('read')

--- a/src/Test/Unit/Process/ConfigDump/ImportTest.php
+++ b/src/Test/Unit/Process/ConfigDump/ImportTest.php
@@ -58,7 +58,7 @@ class ImportTest extends TestCase
             ->willReturn(true);
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('php ./bin/magento app:config:import -n');
+            ->with('php ./bin/magento app:config:import --ansi --no-interaction');
         $this->magentoVersionMock->expects($this->once())
         ->method('isGreaterOrEqual')
         ->willReturn(true);

--- a/src/Test/Unit/Process/Deploy/DeployStaticContent/GenerateTest.php
+++ b/src/Test/Unit/Process/Deploy/DeployStaticContent/GenerateTest.php
@@ -102,14 +102,14 @@ class GenerateTest extends TestCase
         $this->commandFactoryMock->expects($this->once())
             ->method('matrix')
             ->willReturn([
-                'php ./bin/magento static:content:deploy:command',
+                'php ./bin/magento static:content:deploy:command --ansi --no-interaction',
             ]);
         $this->shellMock->expects($this->exactly(3))
             ->method('execute')
             ->withConsecutive(
-                ['php ./bin/magento maintenance:enable -vvv'],
-                ['php ./bin/magento static:content:deploy:command'],
-                ['php ./bin/magento maintenance:disable -vvv']
+                ['php ./bin/magento maintenance:enable --ansi --no-interaction -vvv'],
+                ['php ./bin/magento static:content:deploy:command --ansi --no-interaction'],
+                ['php ./bin/magento maintenance:disable --ansi --no-interaction -vvv']
             );
         $this->stageConfigMock->method('get')
             ->willReturnMap([

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Install/ConfigImportTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Install/ConfigImportTest.php
@@ -62,7 +62,7 @@ class ConfigImportTest extends TestCase
             ->with('Run app:config:import command');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('php ./bin/magento app:config:import -n');
+            ->with('php ./bin/magento app:config:import --ansi --no-interaction');
 
         $this->process->execute();
     }

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Install/SetupTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Install/SetupTest.php
@@ -174,7 +174,7 @@ class SetupTest extends TestCase
                 . ' --backend-frontname=\'' . $adminUrlExpected . '\' --admin-user=\'' . $adminNameExpected . '\''
                 . ' --admin-firstname=\'' . $adminFirstnameExpected . '\' --admin-lastname=\'' . $adminLastnameExpected
                 . '\' --admin-email=\'admin@example.com\' --admin-password=\'' . $adminPasswordExpected . '\''
-                . ' --use-secure-admin=1'
+                . ' --use-secure-admin=1 --ansi --no-interaction'
                 . ' --db-password=\'password\' -v'
                 . ' | tee -a ' . $installUpgradeLog . '"'
             );

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Update/SetupTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Update/SetupTest.php
@@ -104,12 +104,13 @@ class SetupTest extends TestCase
         $this->shellMock->expects($this->exactly(3))
             ->method('execute')
             ->withConsecutive(
-                ['php ./bin/magento maintenance:enable -v'],
+                ['php ./bin/magento maintenance:enable --ansi --no-interaction -v'],
                 [
-                    '/bin/bash -c "set -o pipefail; php ./bin/magento setup:upgrade --keep-generated -n -v | tee -a '
+                    '/bin/bash -c "set -o pipefail; php ./bin/magento setup:upgrade '
+                    . '--keep-generated --ansi --no-interaction -v | tee -a '
                     . $installUpgradeLog . '"',
                 ],
-                ['php ./bin/magento maintenance:disable -v']
+                ['php ./bin/magento maintenance:disable --ansi --no-interaction -v']
             );
         $this->loggerMock->expects($this->once())
             ->method('info')

--- a/src/Test/Unit/Process/PostDeploy/CleanCacheTest.php
+++ b/src/Test/Unit/Process/PostDeploy/CleanCacheTest.php
@@ -53,7 +53,7 @@ class CleanCacheTest extends TestCase
             ->willReturn('-vvv');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('php ./bin/magento cache:flush -vvv');
+            ->with('php ./bin/magento cache:flush --ansi --no-interaction -vvv');
 
         $this->process->execute();
     }
@@ -66,7 +66,7 @@ class CleanCacheTest extends TestCase
             ->willReturn('-vvv');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('php ./bin/magento cache:flush -vvv');
+            ->with('php ./bin/magento cache:flush --ansi --no-interaction -vvv');
 
         $this->process->execute();
     }
@@ -78,7 +78,7 @@ class CleanCacheTest extends TestCase
             ->willReturn('');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('php ./bin/magento cache:flush ');
+            ->with('php ./bin/magento cache:flush --ansi --no-interaction ');
 
         $this->process->execute();
     }

--- a/src/Test/Unit/StaticContent/CommandFactoryTest.php
+++ b/src/Test/Unit/StaticContent/CommandFactoryTest.php
@@ -81,8 +81,8 @@ class CommandFactoryTest extends TestCase
                     'verbosity_level' => '-v',
                 ],
                 true,
-                'php ./bin/magento setup:static-content:deploy -f -s quick -v --jobs 3 --exclude-theme theme1 '
-                . '--exclude-theme theme2 en_US',
+                'php ./bin/magento setup:static-content:deploy --ansi --no-interaction -f -s quick '
+                . '-v --jobs 3 --exclude-theme theme1 --exclude-theme theme2 en_US',
             ],
             [
                 [
@@ -94,7 +94,8 @@ class CommandFactoryTest extends TestCase
                     'verbosity_level' => '-v',
                 ],
                 true,
-                'php ./bin/magento setup:static-content:deploy -s quick -v --jobs 1 --exclude-theme theme1 en_US de_DE',
+                'php ./bin/magento setup:static-content:deploy --ansi --no-interaction -s quick '
+                . '-v --jobs 1 --exclude-theme theme1 en_US de_DE',
             ],
             [
                 [
@@ -106,8 +107,8 @@ class CommandFactoryTest extends TestCase
                     'verbosity_level' => '-v',
                 ],
                 false,
-                'php ./bin/magento setup:static-content:deploy -f -v --jobs 3 --exclude-theme theme1 --exclude-theme'
-                . ' theme2 en_US',
+                'php ./bin/magento setup:static-content:deploy --ansi --no-interaction -f -v --jobs 3 '
+                . '--exclude-theme theme1 --exclude-theme theme2 en_US',
             ],
             [
                 [
@@ -119,7 +120,8 @@ class CommandFactoryTest extends TestCase
                     'verbosity_level' => '-v',
                 ],
                 false,
-                'php ./bin/magento setup:static-content:deploy -v --jobs 1 --exclude-theme theme1 en_US de_DE',
+                'php ./bin/magento setup:static-content:deploy --ansi --no-interaction -v --jobs 1 '
+                . '--exclude-theme theme1 en_US de_DE',
             ],
         ];
     }
@@ -207,8 +209,8 @@ class CommandFactoryTest extends TestCase
                 ],
                 [],
                 [
-                    'php ./bin/magento setup:static-content:deploy -f -s quick -v --exclude-theme theme1'
-                    . ' --exclude-theme theme2 en_US',
+                    'php ./bin/magento setup:static-content:deploy --ansi --no-interaction -f -s quick '
+                    . '-v --exclude-theme theme1 --exclude-theme theme2 en_US',
                 ],
             ],
             [
@@ -226,8 +228,8 @@ class CommandFactoryTest extends TestCase
                     ],
                 ],
                 [
-                    'php ./bin/magento setup:static-content:deploy -s quick -v --exclude-theme theme1'
-                    . ' --exclude-theme Magento/backend en_US de_DE',
+                    'php ./bin/magento setup:static-content:deploy --ansi --no-interaction -s quick '
+                    . '-v --exclude-theme theme1 --exclude-theme Magento/backend en_US de_DE',
                 ],
             ],
             [
@@ -243,8 +245,8 @@ class CommandFactoryTest extends TestCase
                     'Magento/backend' => null,
                 ],
                 [
-                    'php ./bin/magento setup:static-content:deploy -s quick -v --exclude-theme theme1'
-                    . ' --exclude-theme Magento/backend en_US de_DE',
+                    'php ./bin/magento setup:static-content:deploy --ansi --no-interaction -s quick '
+                    . '-v --exclude-theme theme1 --exclude-theme Magento/backend en_US de_DE',
                 ],
             ],
             [
@@ -262,10 +264,10 @@ class CommandFactoryTest extends TestCase
                     ],
                 ],
                 [
-                    'php ./bin/magento setup:static-content:deploy -s quick -v --exclude-theme theme1'
-                    . ' --exclude-theme Magento/backend en_US de_DE',
-                    'php ./bin/magento setup:static-content:deploy -s quick -v --theme Magento/backend en_US'
-                    . ' fr_FR af_ZA',
+                    'php ./bin/magento setup:static-content:deploy --ansi --no-interaction -s quick '
+                    . '-v --exclude-theme theme1 --exclude-theme Magento/backend en_US de_DE',
+                    'php ./bin/magento setup:static-content:deploy --ansi --no-interaction -s quick '
+                    . '-v --theme Magento/backend en_US fr_FR af_ZA',
                 ],
             ],
         ];


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

For every command we send through `ShellInterface` I made sure we add `--ansi- and `--no-interaction` to those commands that support them.

### Fixed Issues (if relevant)

[MAGECLOUD-2402](https://magento2.atlassian.net/browse/MAGECLOUD-2402)

### Manual testing scenarios

The log out put has changed slightly, but there really isn't much to actively test.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
