### PR TITLE
MAGECLOUD-2444: scd-dump doesn't remove data from stores if locale not specified

### DIFF
--- a/src/Process/ConfigDump/Generate.php
+++ b/src/Process/ConfigDump/Generate.php
@@ -53,6 +53,11 @@ class Generate implements ProcessInterface
     private $sharedConfig;
 
     /**
+     * @var MagentoVersion
+     */
+    private $magentoVersion;
+
+    /**
      * @param ConnectionInterface $connection
      * @param File $file
      * @param ArrayManager $arrayManager
@@ -70,11 +75,7 @@ class Generate implements ProcessInterface
         $this->file = $file;
         $this->arrayManager = $arrayManager;
         $this->sharedConfig = $sharedConfig;
-
-        if ($magentoVersion->isGreaterOrEqual('2.2')) {
-            $this->configKeys[] = 'modules';
-            $this->configKeys[] = 'system/websites';
-        }
+        $this->magentoVersion = $magentoVersion;
     }
 
     /**
@@ -82,6 +83,11 @@ class Generate implements ProcessInterface
      */
     public function execute()
     {
+        if ($this->magentoVersion->isGreaterOrEqual('2.2')) {
+            $this->configKeys[] = 'modules';
+            $this->configKeys[] = 'system/websites';
+        }
+
         $configFile = $this->sharedConfig->resolve();
         $oldConfig = require $configFile;
         $newConfig = [];
@@ -108,16 +114,16 @@ class Generate implements ProcessInterface
         /**
          * Only saving general/locale/code.
          */
-        $configLocales = isset($newConfig['system']['stores'])
+        $storeCodes = isset($newConfig['system']['stores'])
             ? array_keys($newConfig['system']['stores'])
             : [];
-        foreach ($configLocales as $configLocale) {
-            if (isset($newConfig['system']['stores'][$configLocale]['general']['locale']['code'])) {
-                $temp = $newConfig['system']['stores'][$configLocale]['general']['locale']['code'];
-                unset($newConfig['system']['stores'][$configLocale]);
-                $newConfig['system']['stores'][$configLocale]['general']['locale']['code'] = $temp;
+        foreach ($storeCodes as $storeCode) {
+            if (isset($newConfig['system']['stores'][$storeCode]['general']['locale']['code'])) {
+                $temp = $newConfig['system']['stores'][$storeCode]['general']['locale']['code'];
+                unset($newConfig['system']['stores'][$storeCode]);
+                $newConfig['system']['stores'][$storeCode]['general']['locale']['code'] = $temp;
             } else {
-                unset($newConfig['system']['stores'][$configLocale]);
+                unset($newConfig['system']['stores'][$storeCode]);
             }
         }
 

--- a/src/Process/ConfigDump/Generate.php
+++ b/src/Process/ConfigDump/Generate.php
@@ -116,6 +116,8 @@ class Generate implements ProcessInterface
                 $temp = $newConfig['system']['stores'][$configLocale]['general']['locale']['code'];
                 unset($newConfig['system']['stores'][$configLocale]);
                 $newConfig['system']['stores'][$configLocale]['general']['locale']['code'] = $temp;
+            } else {
+                unset($newConfig['system']['stores'][$configLocale]);
             }
         }
 

--- a/src/Test/Unit/Process/ConfigDump/_files/app/etc/config.php
+++ b/src/Test/Unit/Process/ConfigDump/_files/app/etc/config.php
@@ -439,6 +439,36 @@ return [
                     ],
                 ],
             ],
+            'store1' => [
+                'general' => [
+                    'locale' => [
+                        'code' => 'fr_FR'
+                    ],
+                ],
+                'design' => [
+                    'package' => [
+                        'name' => 'default',
+                    ],
+                    'theme' => [
+                        'default' => 'default',
+                    ],
+                ],
+            ],
+            'store2' => [
+                'general' => [
+                    'locale' => [
+                        'code' => 'kz_KZ'
+                    ],
+                ],
+                'design' => [
+                    'package' => [
+                        'name' => 'default',
+                    ],
+                    'theme' => [
+                        'default' => 'default',
+                    ],
+                ],
+            ],
         ],
         'websites' => [
             'admin' => [

--- a/src/Test/Unit/Process/ConfigDump/_files/app/etc/generated_config.php
+++ b/src/Test/Unit/Process/ConfigDump/_files/app/etc/generated_config.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+return [
+    'scopes' => [
+        'websites' => [
+            'admin' => [
+                'website_id' => '0',
+                'code' => 'admin',
+                'name' => 'Admin',
+                'sort_order' => '0',
+                'default_group_id' => '0',
+                'is_default' => '0',
+            ],
+        ],
+        'groups' => [
+            0 => [
+                'group_id' => '0',
+                'website_id' => '0',
+                'code' => 'default',
+                'name' => 'Default',
+                'root_category_id' => '0',
+                'default_store_id' => '0',
+            ],
+        ],
+        'stores' => [
+            'admin' => [
+                'store_id' => '0',
+                'code' => 'admin',
+                'website_id' => '0',
+                'group_id' => '0',
+                'name' => 'Admin',
+                'sort_order' => '0',
+                'is_active' => '1',
+            ],
+        ],
+    ],
+    'system' => [
+        'default' => [
+            'general' => [
+                'locale' => [
+                    'code' => 'en_US',
+                ],
+            ],
+            'dev' => [
+                'static' => [
+                    'sign' => '1',
+                ],
+                'front_end_development_workflow' => [
+                    'type' => 'server_side_compilation',
+                ],
+                'template' => [
+                    'minify_html' => '0',
+                ],
+                'js' => [
+                    'merge_files' => '0',
+                    'minify_files' => '0',
+                    'minify_exclude' => '
+                      /tiny_mce/
+                  ',
+                    'session_storage_logging' => '0',
+                    'translate_strategy' => 'dictionary',
+                ],
+                'css' => [
+                    'minify_files' => '0',
+                    'minify_exclude' => '
+                      /tiny_mce/
+                  ',
+                ],
+            ],
+        ],
+        'stores' => [
+            'store1' => [
+                'general' => [
+                    'locale' => [
+                        'code' => 'fr_FR'
+                    ],
+                ],
+            ],
+            'store2' => [
+                'general' => [
+                    'locale' => [
+                        'code' => 'kz_KZ'
+                    ],
+                ],
+            ],
+        ],
+        'websites' => [
+            'admin' => [
+                'web' => [
+                    'routers' => [
+                        'frontend' => [
+                            'disabled' => 'true',
+                        ],
+                    ],
+                    'default' => [
+                        'no_route' => 'admin/noroute/index',
+                    ],
+                ],
+            ],
+        ],
+    ],
+    'modules' => [
+        'Magento_Store' => 1,
+        'Magento_Directory' => 1,
+    ],
+    'admin_user' => [
+        'locale' => [
+            'code' => [
+                'fr_FR',
+                'ua_UA',
+            ],
+        ],
+    ],
+];

--- a/src/Test/Unit/Process/ConfigDump/_files/app/etc/generated_config_2.1.php
+++ b/src/Test/Unit/Process/ConfigDump/_files/app/etc/generated_config_2.1.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+return [
+    'scopes' => [
+        'websites' => [
+            'admin' => [
+                'website_id' => '0',
+                'code' => 'admin',
+                'name' => 'Admin',
+                'sort_order' => '0',
+                'default_group_id' => '0',
+                'is_default' => '0',
+            ],
+        ],
+        'groups' => [
+            0 => [
+                'group_id' => '0',
+                'website_id' => '0',
+                'code' => 'default',
+                'name' => 'Default',
+                'root_category_id' => '0',
+                'default_store_id' => '0',
+            ],
+        ],
+        'stores' => [
+            'admin' => [
+                'store_id' => '0',
+                'code' => 'admin',
+                'website_id' => '0',
+                'group_id' => '0',
+                'name' => 'Admin',
+                'sort_order' => '0',
+                'is_active' => '1',
+            ],
+        ],
+    ],
+    'system' => [
+        'default' => [
+            'general' => [
+                'locale' => [
+                    'code' => 'en_US',
+                ],
+            ],
+            'dev' => [
+                'static' => [
+                    'sign' => '1',
+                ],
+                'front_end_development_workflow' => [
+                    'type' => 'server_side_compilation',
+                ],
+                'template' => [
+                    'minify_html' => '0',
+                ],
+                'js' => [
+                    'merge_files' => '0',
+                    'minify_files' => '0',
+                    'minify_exclude' => '
+                      /tiny_mce/
+                  ',
+                    'session_storage_logging' => '0',
+                    'translate_strategy' => 'dictionary',
+                ],
+                'css' => [
+                    'minify_files' => '0',
+                    'minify_exclude' => '
+                      /tiny_mce/
+                  ',
+                ],
+            ],
+        ],
+        'stores' => [
+            'store1' => [
+                'general' => [
+                    'locale' => [
+                        'code' => 'fr_FR'
+                    ],
+                ],
+            ],
+            'store2' => [
+                'general' => [
+                    'locale' => [
+                        'code' => 'kz_KZ'
+                    ],
+                ],
+            ],
+        ],
+    ],
+    'admin_user' => [
+        'locale' => [
+            'code' => [
+                'fr_FR',
+                'ua_UA',
+            ],
+        ],
+    ],
+];

--- a/src/Test/Unit/Util/ArrayManagerTest.php
+++ b/src/Test/Unit/Util/ArrayManagerTest.php
@@ -70,6 +70,21 @@ class ArrayManagerTest extends TestCase
                     'test/test2' => 'value2',
                 ],
             ],
+            [
+                [
+                    'test' => [
+                        'test2' => 'value2',
+                    ],
+                    'test-empty' => [
+                        'test2' => [],
+                    ]
+                ],
+                '#',
+                [
+                    '#test/test2' => 'value2',
+                    '#test-empty/test2' => []
+                ],
+            ],
         ];
     }
 

--- a/src/Util/ArrayManager.php
+++ b/src/Util/ArrayManager.php
@@ -20,7 +20,11 @@ class ArrayManager
         $result = [];
         foreach ($array as $key => $value) {
             if (is_array($value)) {
-                $result = $result + $this->flatten($value, $prefix . $key . '/');
+                if (empty($value)) {
+                    $result[$prefix . $key] = [];
+                } else {
+                    $result = $result + $this->flatten($value, $prefix . $key . '/');
+                }
             } else {
                 $result[$prefix . $key] = $value;
             }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Scd dump should remove everything except locales from store section. And this mechanism works correct if locales exist. But if locale doesn't exist than scd-dump doesn't remove anything and leave all data in store section.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-2444

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGETWO-72296

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
