### PR TITLE
MAGECLOUD-2446: Automatically Configure S3

### DIFF
--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -335,6 +335,19 @@
 #                - "index.php"                                                                                        #
 #                - "index.php/customer/account/create"                                                                #
 #######################################################################################################################
+# S3_CONFIGURATION - configure credentials used to upload media for storage in an Amazon S3 bucket.                   #
+# Magento Version: Magento 2.1.4 and later                                                                            #
+# Default value: not set                                                                                              #
+# Stages: post-deploy                                                                                                 #
+# Example:                                                                                                            #
+#          stage:                                                                                                     #
+#            post-deploy:                                                                                             #
+#              S3_CONFIGURATION:                                                                                      #
+#                access_key: AWS_ACCESS_KEY                                                                           #
+#                secret_key: AWS_SECRET_KEY                                                                           #
+#                bucket: my.bucket.name                                                                               #
+#                region: some-region-1                                                                                #
+#######################################################################################################################
 # MIN_LOGGING_LEVEL - use to override the minimum logging level for all output streams without making changes         #
 #                     to the code. This helps to improve troubleshooting problems with deployment. For example, if    #
 #                     your deployment fails, you can use this variable to increase the logging granularity globally.  #

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -247,7 +247,6 @@ class Container implements ContainerInterface
                         $this->container->make(DeployProcess\InstallUpdate::class),
                         $this->container->make(DeployProcess\DeployStaticContent::class),
                         $this->container->make(DeployProcess\CompressStaticContent::class),
-                        $this->container->make(DeployProcess\UploadStaticContent::class),
                         $this->container->make(DeployProcess\DisableGoogleAnalytics::class),
                         $this->container->make(DeployProcess\UnlockCronJobs::class),
                         $this->container->make(\Magento\MagentoCloud\Process\ValidateConfiguration::class, [
@@ -390,6 +389,7 @@ class Container implements ContainerInterface
                 return $this->container->make(ProcessComposite::class, [
                     'processes' => [
                         $this->container->make(PostDeployProcess\Backup::class),
+                        $this->container->make(DeployProcess\UploadStaticContent::class),
                         $this->container->make(PostDeployProcess\CleanCache::class),
                         $this->container->make(PostDeployProcess\WarmUp::class),
                     ],

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -85,6 +85,7 @@ class Container implements ContainerInterface
                     Flag\Manager::FLAG_REGENERATE => 'var/.regenerate',
                     Flag\Manager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD => '.static_content_deploy',
                     Flag\Manager::FLAG_DEPLOY_HOOK_IS_FAILED => 'var/.deploy_is_failed',
+                    Flag\Manager::FLAG_S3_CONFIG_MODIFIED => 'var/.s3_config_modified',
                 ]);
             }
         );
@@ -246,6 +247,7 @@ class Container implements ContainerInterface
                         $this->container->make(DeployProcess\InstallUpdate::class),
                         $this->container->make(DeployProcess\DeployStaticContent::class),
                         $this->container->make(DeployProcess\CompressStaticContent::class),
+                        $this->container->make(DeployProcess\UploadStaticContent::class),
                         $this->container->make(DeployProcess\DisableGoogleAnalytics::class),
                         $this->container->make(DeployProcess\UnlockCronJobs::class),
                         $this->container->make(\Magento\MagentoCloud\Process\ValidateConfiguration::class, [

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -311,6 +311,7 @@ class Container implements ContainerInterface
                         $this->container->make(DeployProcess\InstallUpdate\ConfigUpdate\SearchEngine::class),
                         $this->container->make(DeployProcess\InstallUpdate\ConfigUpdate\Urls::class),
                         $this->container->make(DeployProcess\InstallUpdate\ConfigUpdate\DocumentRoot::class),
+                        $this->container->make(DeployProcess\InstallUpdate\ConfigUpdate\S3Bucket::class),
                     ],
                 ]);
             });

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -14,9 +14,10 @@ interface ConfigInterface
      * Retrieve data by key.
      *
      * @param string $key
+     * @param mixed $default
      * @return string|int|bool|array|null
      */
-    public function get(string $key);
+    public function get(string $key, $default = null);
 
     /**
      * Assert data by key.
@@ -32,6 +33,14 @@ interface ConfigInterface
      * @return array
      */
     public function all(): array;
+
+    /**
+     * Update data by key.
+     *
+     * @param string $key
+     * @param mixed $value
+     */
+    public function set(string $key, $value);
 
     /**
      * Update current data.

--- a/src/Config/Deploy.php
+++ b/src/Config/Deploy.php
@@ -6,13 +6,13 @@
 namespace Magento\MagentoCloud\Config;
 
 use Illuminate\Contracts\Config\Repository;
-use Magento\MagentoCloud\Config\Shared\Reader;
-use Magento\MagentoCloud\Config\Shared\Writer;
+use Magento\MagentoCloud\Config\Deploy\Reader;
+use Magento\MagentoCloud\Config\Deploy\Writer;
 
 /**
- * Class Shared.
+ * Repository for deploy config.
  */
-class Shared implements ConfigInterface
+class Deploy implements ConfigInterface
 {
     /**
      * @var Reader
@@ -32,29 +32,13 @@ class Shared implements ConfigInterface
     /**
      * @var RepositoryFactory
      */
-    private $repositoryFactory;
+    private $factory;
 
-    /**
-     * @param Reader $reader
-     * @param Writer $writer
-     * @param RepositoryFactory $repositoryFactory
-     */
-    public function __construct(
-        Reader $reader,
-        Writer $writer,
-        RepositoryFactory $repositoryFactory
-    ) {
+    public function __construct(Reader $reader, Writer $writer, RepositoryFactory $factory)
+    {
         $this->reader = $reader;
         $this->writer = $writer;
-        $this->repositoryFactory = $repositoryFactory;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function has(string $key): bool
-    {
-        return $this->read()->has($key);
+        $this->factory = $factory;
     }
 
     /**
@@ -63,6 +47,14 @@ class Shared implements ConfigInterface
     public function get(string $key, $default = null)
     {
         return $this->read()->get($key, $default);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function has(string $key): bool
+    {
+        return $this->read()->has($key);
     }
 
     /**
@@ -100,14 +92,14 @@ class Shared implements ConfigInterface
     }
 
     /**
+     * Lod config data from disk (if necessary).
+     *
      * @return Repository
      */
     private function read(): Repository
     {
         if ($this->config === null) {
-            $this->config = $this->repositoryFactory->create(
-                $this->reader->read()
-            );
+            $this->config = $this->factory->create($this->reader->read());
         }
 
         return $this->config;

--- a/src/Config/RepositoryFactory.php
+++ b/src/Config/RepositoryFactory.php
@@ -5,7 +5,8 @@
  */
 namespace Magento\MagentoCloud\Config;
 
-use Illuminate\Contracts\Config\Repository;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository as RepositoryInterface;
 use Magento\MagentoCloud\App\ContainerInterface;
 
 /**
@@ -14,26 +15,13 @@ use Magento\MagentoCloud\App\ContainerInterface;
 class RepositoryFactory
 {
     /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    /**
-     * @param ContainerInterface $container
-     */
-    public function __construct(ContainerInterface $container)
-    {
-        $this->container = $container;
-    }
-
-    /**
      * Creates instances of Repository.
      *
      * @param array $items The config array
-     * @return Repository
+     * @return RepositoryInterface
      */
-    public function create(array $items = []): Repository
+    public function create(array $items = []): RepositoryInterface
     {
-        return $this->container->create(\Illuminate\Config\Repository::class, ['items' => $items]);
+        return new Repository($items);
     }
 }

--- a/src/Config/Schema.php
+++ b/src/Config/Schema.php
@@ -331,6 +331,16 @@ class Schema
                     StageConfigInterface::STAGE_DEPLOY => true,
                 ],
             ],
+            DeployInterface::VAR_S3_CONFIGURATION => [
+                self::SCHEMA_TYPE => ['array'],
+                self::SCHEMA_STAGE => [
+                    StageConfigInterface::STAGE_GLOBAL,
+                    StageConfigInterface::STAGE_DEPLOY
+                ],
+                self::SCHEMA_DEFAULT_VALUE => [
+                    StageConfigInterface::STAGE_DEPLOY => [],
+                ],
+            ],
             PostDeployInterface::VAR_WARM_UP_PAGES => [
                 self::SCHEMA_TYPE => ['array'],
                 self::SCHEMA_STAGE => [

--- a/src/Config/Stage/DeployInterface.php
+++ b/src/Config/Stage/DeployInterface.php
@@ -32,6 +32,8 @@ interface DeployInterface extends StageConfigInterface
      */
     const VAR_MYSQL_USE_SLAVE_CONNECTION = 'MYSQL_USE_SLAVE_CONNECTION';
 
+    const VAR_S3_CONFIGURATION = 'S3_CONFIGURATION';
+
     /**
      * @deprecated 2.1 specific variable.
      */

--- a/src/Filesystem/Flag/Manager.php
+++ b/src/Filesystem/Flag/Manager.php
@@ -31,6 +31,8 @@ class Manager
      */
     const FLAG_DEPLOY_HOOK_IS_FAILED = 'deploy_is_failed';
 
+    const FLAG_S3_CONFIG_MODIFIED = 's3_config_modified';
+
     /**
      * @var LoggerInterface
      */

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
@@ -62,9 +62,7 @@ class S3Bucket implements ProcessInterface
 
         $envConfig = $this->configReader->read();
 
-        $s3EnvConfig = isset($envConfig['system']['default']['thai_s3']['general'])
-            ? isset($envConfig['system']['default']['thai_s3']['general'])
-            : [];
+        $s3EnvConfig = $envConfig['system']['default']['thai_s3']['general'] ?? [];
 
         asort($s3EnvConfig);
         asort($s3StageConfig);

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
@@ -7,6 +7,7 @@ namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate;
 
 use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
 use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
+use Magento\MagentoCloud\Config\Shared as SharedConfig;
 use Magento\MagentoCloud\Config\Stage\DeployInterface as DeployConfig;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Process\ProcessInterface;
@@ -14,10 +15,17 @@ use Psr\Log\LoggerInterface;
 
 class S3Bucket implements ProcessInterface
 {
+    const MEDIA_STORAGE_S3 = 2;
+
     /**
      * @var LoggerInterface
      */
     private $logger;
+
+    /**
+     * @var SharedConfig
+     */
+    private $sharedConfig;
 
     /**
      * @var ConfigReader
@@ -41,12 +49,14 @@ class S3Bucket implements ProcessInterface
 
     public function __construct(
         LoggerInterface $logger,
+        SharedConfig $sharedConfig,
         ConfigReader $configReader,
         ConfigWriter $configWriter,
         DeployConfig $stageConfig,
         FlagManager $flagManager
     ) {
         $this->logger = $logger;
+        $this->sharedConfig = $sharedConfig;
         $this->configReader = $configReader;
         $this->configWriter = $configWriter;
         $this->stageConfig = $stageConfig;
@@ -69,14 +79,23 @@ class S3Bucket implements ProcessInterface
 
         $this->flagManager->delete(FlagManager::FLAG_S3_CONFIG_MODIFIED);
 
-        if ($s3EnvConfig == $s3StageConfig) {
-            return;
+        if ($s3EnvConfig != $s3StageConfig) {
+            $this->logger->info('Updating S3 Configuration');
+
+            $envConfig['system']['default']['thai_s3']['general'] = $s3StageConfig;
+            $this->flagManager->set(FlagManager::FLAG_S3_CONFIG_MODIFIED);
         }
 
-        $this->logger->info('Updating S3 Configuration');
+        $modules = (array)$this->config->get('modules');
+        $mediaStorage = $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] ?? null;
 
-        $envConfig['system']['default']['thai_s3']['general'] = $s3StageConfig;
-        $this->flagManager->set(FlagManager::FLAG_S3_CONFIG_MODIFIED);
+        // Media storage has already been configured to use S3 and nothing in the config has changed.
+        if (!empty($modules['Thai_S3']) && $mediaStorage != self::MEDIA_STORAGE_S3) {
+            $this->logger->info('Updating Media Storage Configuration');
+
+            $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] = self::MEDIA_STORAGE_S3;
+            $this->flagManager->set(FlagManager::FLAG_S3_CONFIG_MODIFIED);
+        }
 
         $this->configWriter->create($envConfig);
     }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
@@ -90,17 +90,18 @@ class S3Bucket implements ProcessInterface
         }
 
         $modules = (array)$this->sharedConfig->get('modules');
-        $mediaStorage = $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] ?? null;
+        $mediaStorage =
+            $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] ?? null;
 
         // Media storage has already been configured to use S3 and nothing in the config has changed.
-        if (
-            !empty($envConfig['system']['default']['thai_s3']['general']) &&
+        if (!empty($envConfig['system']['default']['thai_s3']['general']) &&
             !empty($modules['Thai_S3']) &&
             $mediaStorage != self::MEDIA_STORAGE_S3
         ) {
             $this->logger->info('Updating Media Storage Configuration');
 
-            $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] = self::MEDIA_STORAGE_S3;
+            $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] =
+                self::MEDIA_STORAGE_S3;
             $this->flagManager->set(FlagManager::FLAG_S3_CONFIG_MODIFIED);
         }
 

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
@@ -13,6 +13,9 @@ use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Configure environment to use S3 bucket.
+ */
 class S3Bucket implements ProcessInterface
 {
     const MEDIA_STORAGE_S3 = 2;
@@ -74,8 +77,8 @@ class S3Bucket implements ProcessInterface
 
         $s3EnvConfig = $envConfig['system']['default']['thai_s3']['general'] ?? [];
 
-        asort($s3EnvConfig);
-        asort($s3StageConfig);
+        ksort($s3EnvConfig);
+        ksort($s3StageConfig);
 
         $this->flagManager->delete(FlagManager::FLAG_S3_CONFIG_MODIFIED);
 
@@ -90,7 +93,11 @@ class S3Bucket implements ProcessInterface
         $mediaStorage = $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] ?? null;
 
         // Media storage has already been configured to use S3 and nothing in the config has changed.
-        if (!empty($modules['Thai_S3']) && $mediaStorage != self::MEDIA_STORAGE_S3) {
+        if (
+            !empty($envConfig['system']['default']['thai_s3']['general']) &&
+            !empty($modules['Thai_S3']) &&
+            $mediaStorage != self::MEDIA_STORAGE_S3
+        ) {
             $this->logger->info('Updating Media Storage Configuration');
 
             $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] = self::MEDIA_STORAGE_S3;

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate;
+
+use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
+use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
+use Magento\MagentoCloud\Config\Stage\DeployInterface as DeployConfig;
+use Magento\MagentoCloud\Process\ProcessInterface;
+use Psr\Log\LoggerInterface;
+
+class S3Bucket implements ProcessInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var ConfigReader
+     */
+    private $configReader;
+
+    /**
+     * @var ConfigWriter
+     */
+    private $configWriter;
+
+    /**
+     * @var DeployConfig
+     */
+    private $stageConfig;
+
+    public function __construct(
+        LoggerInterface $logger,
+        ConfigReader $configReader,
+        ConfigWriter $configWriter,
+        DeployConfig $stageConfig
+    ) {
+        $this->logger = $logger;
+        $this->configReader = $configReader;
+        $this->configWriter = $configWriter;
+        $this->stageConfig = $stageConfig;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        $s3StageConfig = $this->stageConfig->get(DeployConfig::VAR_S3_CONFIGURATION);
+
+        $envConfig = $this->configReader->read();
+
+        $s3EnvConfig = isset($envConfig['system']['default']['thai_s3']['general'])
+            ? isset($envConfig['system']['default']['thai_s3']['general'])
+            : [];
+
+        asort($s3EnvConfig);
+        asort($s3StageConfig);
+
+        if ($s3EnvConfig == $s3StageConfig) {
+            return;
+        }
+
+        $this->logger->info('Updating S3 Configuration');
+
+        $envConfig['system']['default']['thai_s3']['general'] = $s3StageConfig;
+
+        $this->configWriter->create($envConfig);
+    }
+}

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/S3Bucket.php
@@ -86,7 +86,7 @@ class S3Bucket implements ProcessInterface
             $this->flagManager->set(FlagManager::FLAG_S3_CONFIG_MODIFIED);
         }
 
-        $modules = (array)$this->config->get('modules');
+        $modules = (array)$this->sharedConfig->get('modules');
         $mediaStorage = $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] ?? null;
 
         // Media storage has already been configured to use S3 and nothing in the config has changed.

--- a/src/Process/Deploy/UploadStaticContent.php
+++ b/src/Process/Deploy/UploadStaticContent.php
@@ -7,7 +7,6 @@ namespace Magento\MagentoCloud\Process\Deploy;
 
 use Magento\MagentoCloud\Config\Shared as SharedConfig;
 use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
-use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Magento\MagentoCloud\Shell\ShellInterface;
@@ -31,11 +30,6 @@ class UploadStaticContent implements ProcessInterface
     private $configReader;
 
     /**
-     * @var ConfigWriter
-     */
-    private $configWriter;
-
-    /**
      * @var FlagManager
      */
     private $flagManager;
@@ -49,14 +43,12 @@ class UploadStaticContent implements ProcessInterface
         LoggerInterface $logger,
         SharedConfig $config,
         ConfigReader $configReader,
-        ConfigWriter $configWriter,
         FlagManager $flagManager,
         ShellInterface $shell
     ) {
         $this->logger = $logger;
         $this->config = $config;
         $this->configReader = $configReader;
-        $this->configWriter = $configWriter;
         $this->flagManager = $flagManager;
         $this->shell = $shell;
     }

--- a/src/Process/Deploy/UploadStaticContent.php
+++ b/src/Process/Deploy/UploadStaticContent.php
@@ -6,7 +6,7 @@
 namespace Magento\MagentoCloud\Process\Deploy;
 
 use Magento\MagentoCloud\Config\Shared as SharedConfig;
-use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
+use Magento\MagentoCloud\Config\Deploy as DeployConfig;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Magento\MagentoCloud\Shell\ShellInterface;
@@ -25,12 +25,12 @@ class UploadStaticContent implements ProcessInterface
     /**
      * @var SharedConfig
      */
-    private $config;
+    private $sharedConfig;
 
     /**
-     * @var ConfigReader
+     * @var DeployConfig
      */
-    private $configReader;
+    private $deployConfig;
 
     /**
      * @var FlagManager
@@ -44,14 +44,14 @@ class UploadStaticContent implements ProcessInterface
 
     public function __construct(
         LoggerInterface $logger,
-        SharedConfig $config,
-        ConfigReader $configReader,
+        SharedConfig $sharedConfig,
+        DeployConfig $deployConfig,
         FlagManager $flagManager,
         ShellInterface $shell
     ) {
         $this->logger = $logger;
-        $this->config = $config;
-        $this->configReader = $configReader;
+        $this->sharedConfig = $sharedConfig;
+        $this->deployConfig = $deployConfig;
         $this->flagManager = $flagManager;
         $this->shell = $shell;
     }
@@ -61,10 +61,10 @@ class UploadStaticContent implements ProcessInterface
      */
     public function execute()
     {
-        $modules = (array)$this->config->get('modules');
-        $envConfig = $this->configReader->read();
+        $moduleEnabled = (bool)$this->sharedConfig->get('modules.Thai_S3');
+        $bucketConfigured = !empty($this->deployConfig->get('system.default.thai_s3.general'));
 
-        if (empty($modules['Thai_S3']) || empty($envConfig['system']['default']['thai_s3']['general'])) {
+        if (!$moduleEnabled || !$bucketConfigured) {
             $this->logger->debug('S3 Module is not enabled or config has not been set.');
             return;
         }

--- a/src/Process/Deploy/UploadStaticContent.php
+++ b/src/Process/Deploy/UploadStaticContent.php
@@ -12,6 +12,9 @@ use Magento\MagentoCloud\Process\ProcessInterface;
 use Magento\MagentoCloud\Shell\ShellInterface;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Upload static content to S3 (if configured)
+ */
 class UploadStaticContent implements ProcessInterface
 {
     /**

--- a/src/Process/Deploy/UploadStaticContent.php
+++ b/src/Process/Deploy/UploadStaticContent.php
@@ -69,12 +69,12 @@ class UploadStaticContent implements ProcessInterface
     public function execute()
     {
         $modules = (array)$this->config->get('modules');
+        $envConfig = $this->configReader->read();
 
-        if (empty($modules['Thai_S3'])) {
+        if (empty($modules['Thai_S3']) || empty($envConfig['system']['default']['thai_s3']['general'])) {
+            $this->logger->debug('S3 Module is not enabled or config has not been set.');
             return;
         }
-
-        $envConfig = $this->configReader->read();
 
         $mediaStorage = $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] ?? null;
 
@@ -83,6 +83,7 @@ class UploadStaticContent implements ProcessInterface
             $mediaStorage == self::MEDIA_STORAGE_S3 &&
             !$this->flagManager->exists(FlagManager::FLAG_S3_CONFIG_MODIFIED)
         ) {
+            $this->logger->debug('Mediat Storage already configured to use S3.');
             return;
         }
 

--- a/src/Process/Deploy/UploadStaticContent.php
+++ b/src/Process/Deploy/UploadStaticContent.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Process\Deploy;
+
+use Magento\MagentoCloud\Config\Shared as SharedConfig;
+use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
+use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
+use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
+use Magento\MagentoCloud\Process\ProcessInterface;
+use Magento\MagentoCloud\Shell\ShellInterface;
+use Psr\Log\LoggerInterface;
+
+class UploadStaticContent implements ProcessInterface
+{
+    const MEDIA_STORAGE_S3 = 2;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var SharedConfig
+     */
+    private $config;
+
+    /**
+     * @var ConfigReader
+     */
+    private $configReader;
+
+    /**
+     * @var ConfigWriter
+     */
+    private $configWriter;
+
+    /**
+     * @var FlagManager
+     */
+    private $flagManager;
+
+    /**
+     * @var ShellInterface
+     */
+    private $shell;
+
+    public function __construct(
+        LoggerInterface $logger,
+        SharedConfig $config,
+        ConfigReader $configReader,
+        ConfigWriter $configWriter,
+        FlagManager $flagManager,
+        ShellInterface $shell
+    ) {
+        $this->logger = $logger;
+        $this->config = $config;
+        $this->configReader = $configReader;
+        $this->configWriter = $configWriter;
+        $this->flagManager = $flagManager;
+        $this->shell = $shell;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        $modules = (array)$this->config->get('modules');
+
+        if (empty($modules['Thai_S3'])) {
+            return;
+        }
+
+        $envConfig = $this->configReader->read();
+
+        $mediaStorage = $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] ?? null;
+
+        // Media storage has already been configured to use S3 and nothing in the config has changed.
+        if (
+            $mediaStorage == self::MEDIA_STORAGE_S3 &&
+            !$this->flagManager->exists(FlagManager::FLAG_S3_CONFIG_MODIFIED)
+        ) {
+            return;
+        }
+
+        $this->logger->notice('Uploading static content to S3 bucket');
+
+        $this->shell->execute('php ./bin/magento s3:storage:export --ansi --no-interaction');
+
+        $envConfig['system']['default']['system']['media_storage_configuration']['media_storage'] = self::MEDIA_STORAGE_S3;
+
+        $this->configWriter->create($envConfig);
+    }
+}

--- a/src/Process/Deploy/UploadStaticContent.php
+++ b/src/Process/Deploy/UploadStaticContent.php
@@ -74,7 +74,7 @@ class UploadStaticContent implements ProcessInterface
             return;
         }
 
-        $this->logger->notice('Uploading static content to S3 bucket');
+        $this->logger->notice('Uploading static content to S3 bucket.');
 
         $this->shell->execute('php ./bin/magento s3:storage:export --ansi --no-interaction');
 

--- a/src/Process/PostDeploy/UploadStaticContent.php
+++ b/src/Process/PostDeploy/UploadStaticContent.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\MagentoCloud\Process\Deploy;
+namespace Magento\MagentoCloud\Process\PostDeploy;
 
 use Magento\MagentoCloud\Config\Shared as SharedConfig;
 use Magento\MagentoCloud\Config\Deploy as DeployConfig;

--- a/src/Test/Unit/Config/DeployTest.php
+++ b/src/Test/Unit/Config/DeployTest.php
@@ -7,45 +7,45 @@ namespace Magento\MagentoCloud\Test\Unit\Config;
 
 use Illuminate\Config\Repository;
 use Magento\MagentoCloud\Config\RepositoryFactory;
-use Magento\MagentoCloud\Config\Shared;
+use Magento\MagentoCloud\Config\Deploy;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @inheritdoc
  */
-class SharedTest extends TestCase
+class DeploydTest extends TestCase
 {
     /**
-     * @var Shared
+     * @var Deploy
      */
-    private $shared;
+    private $deploy;
 
     /**
-     * @var Shared\Reader|\PHPUnit_Framework_MockObject_MockObject
+     * @var Deploy\Reader|MockObject
      */
     private $readerMock;
 
     /**
-     * @var Shared\Writer|\PHPUnit_Framework_MockObject_MockObject
+     * @var Deploy\Writer|MockObject
      */
     private $writerMock;
 
     /**
-     * @var RepositoryFactory|Mock
+     * @var RepositoryFactory|MockObject
      */
-    private $repositoryFactoryMock;
+    private $factoryMock;
 
     /**
      * @inheritdoc
      */
     protected function setUp()
     {
-        $this->readerMock = $this->createMock(Shared\Reader::class);
-        $this->writerMock = $this->createMock(Shared\Writer::class);
-        $this->repositoryFactoryMock = $this->createMock(RepositoryFactory::class);
+        $this->readerMock = $this->createMock(Deploy\Reader::class);
+        $this->writerMock = $this->createMock(Deploy\Writer::class);
+        $this->factoryMock = $this->createMock(RepositoryFactory::class);
 
-        $this->shared = new Shared($this->readerMock, $this->writerMock, $this->repositoryFactoryMock);
+        $this->deploy = new Deploy($this->readerMock, $this->writerMock, $this->factoryMock);
     }
 
     public function testGet()
@@ -58,15 +58,15 @@ class SharedTest extends TestCase
         $this->readerMock->expects($this->once())
             ->method('read')
             ->willReturn($config);
-        $this->repositoryFactoryMock->expects($this->once())
+        $this->factoryMock->expects($this->once())
             ->method('create')
             ->with($config)
             ->willReturn(new Repository($config));
 
-        $this->assertSame('value1', $this->shared->get('key1'));
-        $this->assertSame('value2', $this->shared->get('key2'));
-        $this->assertNull($this->shared->get('undefined'));
-        $this->assertSame('default value', $this->shared->get('missing_key', 'default value'));
+        $this->assertSame('value1', $this->deploy->get('key1'));
+        $this->assertSame('value2', $this->deploy->get('key2'));
+        $this->assertNull($this->deploy->get('undefined'));
+        $this->assertSame('default value', $this->deploy->get('missing_key', 'default value'));
     }
 
     public function testSet()
@@ -87,13 +87,13 @@ class SharedTest extends TestCase
         $this->writerMock->expects($this->once())
             ->method('update')
             ->with($configFinal);
-        $this->repositoryFactoryMock->expects($this->once())
+        $this->factoryMock->expects($this->once())
             ->method('create')
             ->with($configInit)
             ->willReturn(new Repository($configInit));
 
-        $this->shared->set('key3', 'value3');
-        $this->assertSame('value3', $this->shared->get('key3'));
+        $this->deploy->set('key3', 'value3');
+        $this->assertSame('value3', $this->deploy->get('key3'));
     }
 
     public function testAll()
@@ -106,12 +106,12 @@ class SharedTest extends TestCase
         $this->readerMock->expects($this->once())
             ->method('read')
             ->willReturn($config);
-        $this->repositoryFactoryMock->expects($this->once())
+        $this->factoryMock->expects($this->once())
             ->method('create')
             ->with($config)
             ->willReturn(new Repository($config));
 
-        $this->assertSame($config, $this->shared->all());
+        $this->assertSame($config, $this->deploy->all());
     }
 
     public function testHas()
@@ -124,14 +124,14 @@ class SharedTest extends TestCase
         $this->readerMock->expects($this->once())
             ->method('read')
             ->willReturn($config);
-        $this->repositoryFactoryMock->expects($this->once())
+        $this->factoryMock->expects($this->once())
             ->method('create')
             ->with($config)
             ->willReturn(new Repository($config));
 
-        $this->assertTrue($this->shared->has('key1'));
-        $this->assertTrue($this->shared->has('key2'));
-        $this->assertFalse($this->shared->has('key3'));
+        $this->assertTrue($this->deploy->has('key1'));
+        $this->assertTrue($this->deploy->has('key2'));
+        $this->assertFalse($this->deploy->has('key3'));
     }
 
     public function testReset()
@@ -144,14 +144,14 @@ class SharedTest extends TestCase
         $this->readerMock->expects($this->exactly(2))
             ->method('read')
             ->willReturn($config);
-        $this->repositoryFactoryMock->expects($this->exactly(2))
+        $this->factoryMock->expects($this->exactly(2))
             ->method('create')
             ->with($config)
             ->willReturn(new Repository($config));
 
-        $this->shared->all();
-        $this->shared->reset();
-        $this->shared->all();
+        $this->deploy->all();
+        $this->deploy->reset();
+        $this->deploy->all();
     }
 
     public function testUpdate()
@@ -160,6 +160,6 @@ class SharedTest extends TestCase
             ->method('update')
             ->with(['some' => 'config']);
 
-        $this->shared->update(['some' => 'config']);
+        $this->deploy->update(['some' => 'config']);
     }
 }

--- a/src/Test/Unit/Config/RepositoryFactoryTest.php
+++ b/src/Test/Unit/Config/RepositoryFactoryTest.php
@@ -6,10 +6,8 @@
 namespace Magento\MagentoCloud\Test\Unit\Config;
 
 use Illuminate\Config\Repository;
-use Magento\MagentoCloud\App\ContainerInterface;
 use Magento\MagentoCloud\Config\RepositoryFactory;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
 
 /**
  * @inheritdoc
@@ -22,26 +20,11 @@ class RepositoryFactoryTest extends TestCase
     private $factory;
 
     /**
-     * @var ContainerInterface|Mock
-     */
-    private $containerMock;
-
-    /**
-     * @var Repository|Mock
-     */
-    private $repositoryMock;
-
-    /**
      * @inheritdoc
      */
     protected function setUp()
     {
-        $this->containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $this->repositoryMock = $this->createMock(Repository::class);
-
-        $this->factory = new RepositoryFactory(
-            $this->containerMock
-        );
+        $this->factory = new RepositoryFactory();
     }
 
     public function testCreate()
@@ -50,14 +33,9 @@ class RepositoryFactoryTest extends TestCase
             'some_item' => 1,
         ];
 
-        $this->containerMock->expects($this->once())
-            ->method('create')
-            ->with(Repository::class, ['items' => $items])
-            ->willReturn($this->repositoryMock);
+        $repository = $this->factory->create($items);
 
-        $this->assertSame(
-            $this->repositoryMock,
-            $this->factory->create($items)
-        );
+        $this->assertInstanceOf(Repository::class, $repository);
+        $this->assertAttributeSame($items, 'items', $repository);
     }
 }

--- a/src/Test/Unit/Config/SchemaTest.php
+++ b/src/Test/Unit/Config/SchemaTest.php
@@ -69,6 +69,7 @@ class SchemaTest extends TestCase
                 DeployInterface::VAR_REDIS_USE_SLAVE_CONNECTION => false,
                 DeployInterface::VAR_MYSQL_USE_SLAVE_CONNECTION => false,
                 DeployInterface::VAR_SCD_MATRIX => [],
+                DeployInterface::VAR_S3_CONFIGURATION => [],
             ],
             $this->schema->getDefaults(StageConfigInterface::STAGE_DEPLOY)
         );

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/S3BucketTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/S3BucketTest.php
@@ -15,7 +15,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-
+/**
+ * Test S3Bucket config update process.
+ */
 class S3BucketTest extends TestCase
 {
     /**

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/S3BucketTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/S3BucketTest.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Process\Deploy\InstallUpdate\ConfigUpdate;
+
+use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
+use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
+use Magento\MagentoCloud\Config\Shared as SharedConfig;
+use Magento\MagentoCloud\Config\Stage\DeployInterface as DeployConfig;
+use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
+use Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate\S3Bucket;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+
+class S3BucketTest extends TestCase
+{
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $loggerMock;
+
+    /**
+     * @var SharedConfig|MockObject
+     */
+    private $sharedConfigMock;
+
+    /**
+     * @var ConfigReader|MockObject
+     */
+    private $configReaderMock;
+
+    /**
+     * @var ConfigWriter|MockObject
+     */
+    private $configWriterMock;
+
+    /**
+     * @var DeployConfig|MockObject
+     */
+    private $stageConfigMock;
+
+    /**
+     * @var FlagManager|MockObject
+     */
+    private $flagManagerMock;
+
+    /**
+     * @var S3Bucket
+     */
+    private $process;
+
+    protected function setUp()
+    {
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+        $this->sharedConfigMock = $this->createMock(SharedConfig::class);
+        $this->configReaderMock = $this->createMock(ConfigReader::class);
+        $this->configWriterMock = $this->createMock(ConfigWriter::class);
+        $this->stageConfigMock = $this->createMock(DeployConfig::class);
+        $this->flagManagerMock = $this->createMock(FlagManager::class);
+
+        $this->process = new S3Bucket(
+            $this->loggerMock,
+            $this->sharedConfigMock,
+            $this->configReaderMock,
+            $this->configWriterMock,
+            $this->stageConfigMock,
+            $this->flagManagerMock
+        );
+    }
+
+    public function testExecuteSettingsEmpty()
+    {
+        $this->stageConfigMock->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo(DeployConfig::VAR_S3_CONFIGURATION))
+            ->willReturn([]);
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn([]);
+        $this->flagManagerMock->expects($this->once())
+            ->method('delete')
+            ->with($this->equalTo(FlagManager::FLAG_S3_CONFIG_MODIFIED));
+        $this->flagManagerMock->expects($this->never())
+            ->method('set');
+        $this->sharedConfigMock->expects($this->once())
+            ->method('get')
+            ->with('modules')
+            ->willReturn(null);
+        $this->configWriterMock->expects($this->once())
+            ->method('create')
+            ->with([]);
+
+        $this->process->execute();
+    }
+
+    public function testExecuteConfigChanged()
+    {
+        $s3Config = [
+            'access_key' => 'AWS_ACCESS_KEY',
+            'bucket' => 'my.s3.bucket',
+            'region' => 'some-region-1',
+            'secret_key' => 'AWS_SECRET_KEY',
+        ];
+
+        $envConfig = [
+            'system' => [
+                'default' => [
+                    'thai_s3' => [
+                        'general' => $s3Config,
+                    ]
+                ]
+            ]
+        ];
+
+        $this->stageConfigMock->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo(DeployConfig::VAR_S3_CONFIGURATION))
+            ->willReturn($s3Config);
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn([]);
+        $this->flagManagerMock->expects($this->once())
+            ->method('delete')
+            ->with($this->equalTo(FlagManager::FLAG_S3_CONFIG_MODIFIED));
+        $this->flagManagerMock->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo(FlagManager::FLAG_S3_CONFIG_MODIFIED));
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Updating S3 Configuration');
+        $this->sharedConfigMock->expects($this->once())
+            ->method('get')
+            ->with('modules')
+            ->willReturn(null);
+        $this->configWriterMock->expects($this->once())
+            ->method('create')
+            ->with($envConfig);
+
+        $this->process->execute();
+    }
+
+    public function testExecuteModuleDisabled()
+    {
+        $s3Config = [
+            'access_key' => 'AWS_ACCESS_KEY',
+            'bucket' => 'my.s3.bucket',
+            'region' => 'some-region-1',
+            'secret_key' => 'AWS_SECRET_KEY',
+        ];
+
+        $envConfig = [
+            'system' => [
+                'default' => [
+                    'thai_s3' => [
+                        'general' => $s3Config,
+                    ]
+                ]
+            ]
+        ];
+
+        $this->stageConfigMock->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo(DeployConfig::VAR_S3_CONFIGURATION))
+            ->willReturn($s3Config);
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn($envConfig);
+        $this->flagManagerMock->expects($this->once())
+            ->method('delete')
+            ->with($this->equalTo(FlagManager::FLAG_S3_CONFIG_MODIFIED));
+        $this->flagManagerMock->expects($this->never())
+            ->method('set');
+        $this->sharedConfigMock->expects($this->once())
+            ->method('get')
+            ->with('modules')
+            ->willReturn(['Thai_S3' => '0']);
+        $this->configWriterMock->expects($this->once())
+            ->method('create')
+            ->with($envConfig);
+
+        $this->process->execute();
+    }
+
+    public function testConfigurationAllSet()
+    {
+        $s3Config = [
+            'access_key' => 'AWS_ACCESS_KEY',
+            'bucket' => 'my.s3.bucket',
+            'region' => 'some-region-1',
+            'secret_key' => 'AWS_SECRET_KEY',
+        ];
+
+        $envConfig = [
+            'system' => [
+                'default' => [
+                    'system' => [
+                        'media_storage_configuration' => [
+                            'media_storage' => S3Bucket::MEDIA_STORAGE_S3,
+                        ],
+                    ],
+                    'thai_s3' => [
+                        'general' => $s3Config,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->stageConfigMock->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo(DeployConfig::VAR_S3_CONFIGURATION))
+            ->willReturn($s3Config);
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn($envConfig);
+        $this->flagManagerMock->expects($this->once())
+            ->method('delete')
+            ->with($this->equalTo(FlagManager::FLAG_S3_CONFIG_MODIFIED));
+        $this->flagManagerMock->expects($this->never())
+            ->method('set');
+        $this->sharedConfigMock->expects($this->once())
+            ->method('get')
+            ->with('modules')
+            ->willReturn(['Thai_S3' => '1']);
+        $this->configWriterMock->expects($this->once())
+            ->method('create')
+            ->with($envConfig);
+
+        $this->process->execute();
+    }
+
+    public function testConfigurationSetMediaStorage()
+    {
+        $s3Config = [
+            'access_key' => 'AWS_ACCESS_KEY',
+            'bucket' => 'my.s3.bucket',
+            'region' => 'some-region-1',
+            'secret_key' => 'AWS_SECRET_KEY',
+        ];
+        $thaiConfig = ['general' => $s3Config];
+        $storageConfig = [
+            'media_storage_configuration' => [
+                'media_storage' => S3Bucket::MEDIA_STORAGE_S3,
+            ],
+        ];
+        $envConfigFinal = [
+            'system' => [
+                'default' => [
+                    'system' => $storageConfig,
+                    'thai_s3' => $thaiConfig,
+                ],
+            ],
+        ];
+        $envConfigInit = [
+            'system' => [
+                'default' => [
+                    'thai_s3' => $thaiConfig,
+                ],
+            ],
+        ];
+
+        $this->stageConfigMock->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo(DeployConfig::VAR_S3_CONFIGURATION))
+            ->willReturn($s3Config);
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn($envConfigInit);
+        $this->flagManagerMock->expects($this->once())
+            ->method('delete')
+            ->with($this->equalTo(FlagManager::FLAG_S3_CONFIG_MODIFIED));
+        $this->flagManagerMock->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo(FlagManager::FLAG_S3_CONFIG_MODIFIED));
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Updating Media Storage Configuration');
+        $this->sharedConfigMock->expects($this->once())
+            ->method('get')
+            ->with('modules')
+            ->willReturn(['Thai_S3' => '1']);
+        $this->configWriterMock->expects($this->once())
+            ->method('create')
+            ->with($envConfigFinal);
+
+        $this->process->execute();
+    }
+}

--- a/src/Test/Unit/Process/Deploy/UploadStaticContentTest.php
+++ b/src/Test/Unit/Process/Deploy/UploadStaticContentTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Process\Deploy;
+
+use Magento\MagentoCloud\Config\Shared as SharedConfig;
+use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
+use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
+use Magento\MagentoCloud\Process\Deploy\UploadStaticContent;
+use Magento\MagentoCloud\Shell\ShellInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Test UploadStaticContent process.
+ */
+class UploadStaticContentTest extends TestCase
+{
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $loggerMock;
+
+    /**
+     * @var SharedConfig|MockObject
+     */
+    private $configMock;
+
+    /**
+     * @var ConfigReader|MockObject
+     */
+    private $configReaderMock;
+
+    /**
+     * @var FlagManager|MockObject
+     */
+    private $flagManagerMock;
+
+    /**
+     * @var ShellInterface|MockObject
+     */
+    private $shellMock;
+
+    /**
+     * @var UploadStaticContent
+     */
+    private $process;
+
+    protected function setUp()
+    {
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+        $this->configMock = $this->createMock(SharedConfig::class);
+        $this->configReaderMock = $this->createMock(ConfigReader::class);
+        $this->flagManagerMock = $this->createMock(FlagManager::class);
+        $this->shellMock = $this->createMock(ShellInterface::class);
+
+        $this->process = new UploadStaticContent(
+            $this->loggerMock,
+            $this->configMock,
+            $this->configReaderMock,
+            $this->flagManagerMock,
+            $this->shellMock
+        );
+    }
+
+    public function testModuleNotSet()
+    {
+        $envConfig = [
+            'system' => [
+                'default' => [
+                    'thai_s3' => [
+                        'general' => [
+                            'S3 Bucket Configuration',
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->configMock->expects($this->once())
+            ->method('get')
+            ->with('modules')
+            ->willReturn(null);
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn($envConfig);
+        $this->loggerMock->expects($this->once())
+            ->method('debug')
+            ->with('S3 Module is not enabled or config has not been set.');
+        $this->loggerMock->expects($this->never())
+            ->method('notice');
+        $this->shellMock->expects($this->never())
+            ->method('execute');
+        $this->flagManagerMock->expects($this->never())
+            ->method('delete');
+
+        $this->process->execute();
+    }
+
+    public function testConfigNotSet()
+    {
+        $this->configMock->expects($this->once())
+            ->method('get')
+            ->with('modules')
+            ->willReturn(['Thai_S3' => '1']);
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn([]);
+        $this->loggerMock->expects($this->once())
+            ->method('debug')
+            ->with('S3 Module is not enabled or config has not been set.');
+        $this->loggerMock->expects($this->never())
+            ->method('notice');
+        $this->shellMock->expects($this->never())
+            ->method('execute');
+        $this->flagManagerMock->expects($this->never())
+            ->method('delete');
+
+        $this->process->execute();
+    }
+
+    public function testFlagNotSet()
+    {
+        $envConfig = [
+            'system' => [
+                'default' => [
+                    'thai_s3' => [
+                        'general' => [
+                            'S3 Bucket Configuration',
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->configMock->expects($this->once())
+            ->method('get')
+            ->with('modules')
+            ->willReturn(['Thai_S3' => '1']);
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn($envConfig);
+        $this->flagManagerMock->expects($this->once())
+            ->method('exists')
+            ->with(FlagManager::FLAG_S3_CONFIG_MODIFIED)
+            ->willReturn(false);
+        $this->flagManagerMock->expects($this->never())
+            ->method('delete');
+        $this->loggerMock->expects($this->once())
+            ->method('debug')
+            ->with('S3 configuration has not been changed.');
+        $this->loggerMock->expects($this->never())
+            ->method('notice');
+        $this->shellMock->expects($this->never())
+            ->method('execute');
+
+        $this->process->execute();
+    }
+
+    public function testExecute()
+    {
+        $envConfig = [
+            'system' => [
+                'default' => [
+                    'thai_s3' => [
+                        'general' => [
+                            'S3 Bucket Configuration',
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->configMock->expects($this->once())
+            ->method('get')
+            ->with('modules')
+            ->willReturn(['Thai_S3' => '1']);
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn($envConfig);
+        $this->flagManagerMock->expects($this->once())
+            ->method('exists')
+            ->with(FlagManager::FLAG_S3_CONFIG_MODIFIED)
+            ->willReturn(true);
+        $this->flagManagerMock->expects($this->once())
+            ->method('delete')
+            ->with(FlagManager::FLAG_S3_CONFIG_MODIFIED);
+        $this->loggerMock->expects($this->once())
+            ->method('notice')
+            ->with('Uploading static content to S3 bucket.');
+        $this->shellMock->expects($this->once())
+            ->method('execute')
+            ->with('php ./bin/magento s3:storage:export --ansi --no-interaction');
+
+        $this->process->execute();
+    }
+}

--- a/src/Test/Unit/Process/Deploy/UploadStaticContentTest.php
+++ b/src/Test/Unit/Process/Deploy/UploadStaticContentTest.php
@@ -6,7 +6,7 @@
 namespace Magento\MagentoCloud\Test\Unit\Process\Deploy;
 
 use Magento\MagentoCloud\Config\Shared as SharedConfig;
-use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
+use Magento\MagentoCloud\Config\Deploy as DeployConfig;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Process\Deploy\UploadStaticContent;
 use Magento\MagentoCloud\Shell\ShellInterface;
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * Test UploadStaticContent process.
+ * @inheritdoc
  */
 class UploadStaticContentTest extends TestCase
 {
@@ -27,12 +27,12 @@ class UploadStaticContentTest extends TestCase
     /**
      * @var SharedConfig|MockObject
      */
-    private $configMock;
+    private $sharedConfigMock;
 
     /**
-     * @var ConfigReader|MockObject
+     * @var DeployConfig|MockObject
      */
-    private $configReaderMock;
+    private $deployConfigMock;
 
     /**
      * @var FlagManager|MockObject
@@ -49,18 +49,21 @@ class UploadStaticContentTest extends TestCase
      */
     private $process;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp()
     {
         $this->loggerMock = $this->createMock(LoggerInterface::class);
-        $this->configMock = $this->createMock(SharedConfig::class);
-        $this->configReaderMock = $this->createMock(ConfigReader::class);
+        $this->sharedConfigMock = $this->createMock(SharedConfig::class);
+        $this->deployConfigMock = $this->createMock(DeployConfig::class);
         $this->flagManagerMock = $this->createMock(FlagManager::class);
         $this->shellMock = $this->createMock(ShellInterface::class);
 
         $this->process = new UploadStaticContent(
             $this->loggerMock,
-            $this->configMock,
-            $this->configReaderMock,
+            $this->sharedConfigMock,
+            $this->deployConfigMock,
             $this->flagManagerMock,
             $this->shellMock
         );
@@ -68,25 +71,14 @@ class UploadStaticContentTest extends TestCase
 
     public function testModuleNotSet()
     {
-        $envConfig = [
-            'system' => [
-                'default' => [
-                    'thai_s3' => [
-                        'general' => [
-                            'S3 Bucket Configuration',
-                        ]
-                    ]
-                ]
-            ]
-        ];
-
-        $this->configMock->expects($this->once())
+        $this->sharedConfigMock->expects($this->once())
             ->method('get')
-            ->with('modules')
+            ->with('modules.Thai_S3')
             ->willReturn(null);
-        $this->configReaderMock->expects($this->once())
-            ->method('read')
-            ->willReturn($envConfig);
+        $this->deployConfigMock->expects($this->once())
+            ->method('get')
+            ->with('system.default.thai_s3.general')
+            ->willReturn(['S3 Bucket Configuration']);
         $this->loggerMock->expects($this->once())
             ->method('debug')
             ->with('S3 Module is not enabled or config has not been set.');
@@ -102,12 +94,13 @@ class UploadStaticContentTest extends TestCase
 
     public function testConfigNotSet()
     {
-        $this->configMock->expects($this->once())
+        $this->sharedConfigMock->expects($this->once())
             ->method('get')
-            ->with('modules')
-            ->willReturn(['Thai_S3' => '1']);
-        $this->configReaderMock->expects($this->once())
-            ->method('read')
+            ->with('modules.Thai_S3')
+            ->willReturn('1');
+        $this->deployConfigMock->expects($this->once())
+            ->method('get')
+            ->with('system.default.thai_s3.general')
             ->willReturn([]);
         $this->loggerMock->expects($this->once())
             ->method('debug')
@@ -124,25 +117,14 @@ class UploadStaticContentTest extends TestCase
 
     public function testFlagNotSet()
     {
-        $envConfig = [
-            'system' => [
-                'default' => [
-                    'thai_s3' => [
-                        'general' => [
-                            'S3 Bucket Configuration',
-                        ]
-                    ]
-                ]
-            ]
-        ];
-
-        $this->configMock->expects($this->once())
+        $this->sharedConfigMock->expects($this->once())
             ->method('get')
-            ->with('modules')
-            ->willReturn(['Thai_S3' => '1']);
-        $this->configReaderMock->expects($this->once())
-            ->method('read')
-            ->willReturn($envConfig);
+            ->with('modules.Thai_S3')
+            ->willReturn('1');
+        $this->deployConfigMock->expects($this->once())
+            ->method('get')
+            ->with('system.default.thai_s3.general')
+            ->willReturn(['S3 Bucket Configuration']);
         $this->flagManagerMock->expects($this->once())
             ->method('exists')
             ->with(FlagManager::FLAG_S3_CONFIG_MODIFIED)
@@ -162,25 +144,14 @@ class UploadStaticContentTest extends TestCase
 
     public function testExecute()
     {
-        $envConfig = [
-            'system' => [
-                'default' => [
-                    'thai_s3' => [
-                        'general' => [
-                            'S3 Bucket Configuration',
-                        ]
-                    ]
-                ]
-            ]
-        ];
-
-        $this->configMock->expects($this->once())
+        $this->sharedConfigMock->expects($this->once())
             ->method('get')
-            ->with('modules')
-            ->willReturn(['Thai_S3' => '1']);
-        $this->configReaderMock->expects($this->once())
-            ->method('read')
-            ->willReturn($envConfig);
+            ->with('modules.Thai_S3')
+            ->willReturn('1');
+        $this->deployConfigMock->expects($this->once())
+            ->method('get')
+            ->with('system.default.thai_s3.general')
+            ->willReturn(['S3 Bucket Configuration']);
         $this->flagManagerMock->expects($this->once())
             ->method('exists')
             ->with(FlagManager::FLAG_S3_CONFIG_MODIFIED)

--- a/src/Test/Unit/Process/PostDeploy/UploadStaticContentTest.php
+++ b/src/Test/Unit/Process/PostDeploy/UploadStaticContentTest.php
@@ -3,12 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\MagentoCloud\Test\Unit\Process\Deploy;
+namespace Magento\MagentoCloud\Test\Unit\Process\PostDeploy;
 
 use Magento\MagentoCloud\Config\Shared as SharedConfig;
 use Magento\MagentoCloud\Config\Deploy as DeployConfig;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
-use Magento\MagentoCloud\Process\Deploy\UploadStaticContent;
+use Magento\MagentoCloud\Process\PostDeploy\UploadStaticContent;
 use Magento\MagentoCloud\Shell\ShellInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/code-coverage.php
+++ b/tests/unit/code-coverage.php
@@ -3,7 +3,7 @@
  * @author Marco Pivetta
  * @link https://ocramius.github.io/blog/automated-code-coverage-check-for-github-pull-requests-with-travis/
  */
-const MIN_COVERAGE = 92;
+const MIN_COVERAGE = 93;
 
 $inputFile = $argv[1];
 $percentage = min(100, max(0, MIN_COVERAGE));


### PR DESCRIPTION
### Description

Looks up S3 credentials in `.magento.env.yaml` and automatically configure Thaiphan/Magento2-S3 to use them.

### Fixed Issues (if relevant)

1. [MAGECLOUD-2446](https://magento2.atlassian.net/browse/MAGECLOUD-2446)

### Manual testing scenarios

TBA

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
