### PR TITLE
MAGECLOUD-2489: Change Output Log Level if Exit Status !=0

### DIFF
--- a/src/Shell/Shell.php
+++ b/src/Shell/Shell.php
@@ -7,6 +7,7 @@ namespace Magento\MagentoCloud\Shell;
 
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Psr\Log\LoggerInterface;
+use Monolog\Logger;
 
 /**
  * @inheritdoc
@@ -63,7 +64,10 @@ class Shell implements ShellInterface
         }, $output);
 
         if ($output) {
-            $this->logger->debug(PHP_EOL . implode(PHP_EOL, $output));
+            $this->logger->log(
+                $status != 0 ? Logger::CRITICAL : Logger::DEBUG,
+                PHP_EOL . implode(PHP_EOL, $output)
+            );
         }
 
         if ($status != 0) {

--- a/src/Test/Integration/ShellLoggingTest.php
+++ b/src/Test/Integration/ShellLoggingTest.php
@@ -60,7 +60,7 @@ class ShellLoggingTest extends AbstractTest
         $this->shell->execute('non-exist-command');
         $logContent = $this->getLogContent();
         $this->assertContains('Command: non-exist-command ', $logContent);
-        $this->assertContains('Command: non-exist-command ', $logContent);
+        $this->assertRegExp('/CRITICAL:\n.*non-exist-command: command not found/', $logContent);
     }
 
     private function getLogContent()


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If exit code of command !=0, show output in logs regardless which minimum log level was configured

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-2489

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. This task is covered with the integration test `Magento\MagentoCloud\Test\Integration\ShellLoggingTest`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
