### PR TITLE
MAGECLOUD-2097: [Backport] Recursive checking of permissions]

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -110,6 +110,9 @@
     },
     "Resolve Issues with Cron Schedule": {
       "2.1.10 - 2.1.14 || 2.2.2 - 2.2.5": "MAGECLOUD-2427__resolve_issues_with_cron_schedule.patch"
+    },
+    "Change the depth of a recursive check of directory write permissions": {
+      "2.1.4 - 2.1.14": "MAGETWO-93265__fix_depth_of_recursive_check_of_directory_permissions__2.1.4.patch"
     }
   }
 }

--- a/patches/MAGETWO-93265__fix_depth_of_recursive_check_of_directory_permissions__2.1.4.patch
+++ b/patches/MAGETWO-93265__fix_depth_of_recursive_check_of_directory_permissions__2.1.4.patch
@@ -1,5 +1,4 @@
-diff --git a/vendor/magento/framework/Setup/FilePermissions.php b/vendor/magento/framework/Setup/FilePermissions.php
-index 36194b853..e257a6c15 100644
+diff -Nuar a/vendor/magento/framework/Setup/FilePermissions.php b/vendor/magento/framework/Setup/FilePermissions.php
 --- a/vendor/magento/framework/Setup/FilePermissions.php
 +++ b/vendor/magento/framework/Setup/FilePermissions.php
 @@ -137,6 +137,7 @@ class FilePermissions

--- a/patches/MAGETWO-93265__fix_depth_of_recursive_check_of_directory_permissions__2.1.4.patch
+++ b/patches/MAGETWO-93265__fix_depth_of_recursive_check_of_directory_permissions__2.1.4.patch
@@ -1,0 +1,21 @@
+diff --git a/vendor/magento/framework/Setup/FilePermissions.php b/vendor/magento/framework/Setup/FilePermissions.php
+index 36194b853..e257a6c15 100644
+--- a/vendor/magento/framework/Setup/FilePermissions.php
++++ b/vendor/magento/framework/Setup/FilePermissions.php
+@@ -137,6 +137,7 @@ class FilePermissions
+      */
+     private function checkRecursiveDirectories($directory)
+     {
++        /** @var $directoryIterator \RecursiveIteratorIterator   */
+         $directoryIterator = new \RecursiveIteratorIterator(
+             new \RecursiveDirectoryIterator($directory, \RecursiveDirectoryIterator::SKIP_DOTS),
+             \RecursiveIteratorIterator::CHILD_FIRST
+@@ -155,6 +156,8 @@ class FilePermissions
+             ]
+         );
+ 
++        $directoryIterator->setMaxDepth(1);
++
+         $foundNonWritable = false;
+ 
+         try {


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-2097

### Description
Changes the depth of the recursive check of the write permission in the catalog for Magento 2 versions 2.1.4 - 2.1.15

### Fixed Issues (if relevant)
1. magento/ece-tools#MAGECLOUD-2097: Create patches in ece-tools

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
