### PR TITLE
MAGECLOUD-2491: 3-p Extensions Conflicting with Sitemap Patches in 2.1.x

### DIFF
--- a/patches/MAGECLOUD-1998__unify_sitemapxml_and_robotstxt_generation__2.1.4.patch
+++ b/patches/MAGECLOUD-1998__unify_sitemapxml_and_robotstxt_generation__2.1.4.patch
@@ -139,8 +139,9 @@ diff -Naur a/vendor/magento/module-sitemap/Model/Sitemap.php b/vendor/magento/mo
          \Magento\Framework\Stdlib\DateTime $dateTime,
          \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
          \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-+        DocumentRoot $documentRoot = null,
-         array $data = []
+-        array $data = []
++        array $data = [],
++        DocumentRoot $documentRoot = null
      ) {
          $this->_escaper = $escaper;
          $this->_sitemapData = $sitemapData;


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-2491

### Description
Fixed backward incompatible changes in patch './patches/MAGECLOUD-1998__unify_sitemapxml_and_robotstxt_generation__2.1.4.patch'

### Fixed Issues:
1. magento/ece-tools#MAGECLOUD-2491: 3-p Extensions Conflicting with Sitemap Patches in 2.1.x

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
