### PR TITLE
MAGECLOUD-2488: SKIP_HTML_MINIFICATION - Fix .magento.env.yaml Reference

### DIFF
--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -85,7 +85,7 @@
 #                          to reduce downtime when deploying to the Staging and Production environments               #
 #                          and generates minified HTML when requested.                                                #
 # Magento Version: 2.1.4 and later                                                                                    #
-# Default value: true (prior to 2002.0.13 the default value was false)                                           #
+# Default value: true (prior to 2002.0.13 the default value was false)                                                #
 # Possible values:                                                                                                    #
 #                  false — copies the view_preprocessed directory to the <magento_root>/init/ directory at the end    #
 #                          of the build stage, and restores the directory in the <magento_root>/var directory         #

--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -85,7 +85,7 @@
 #                          to reduce downtime when deploying to the Staging and Production environments               #
 #                          and generates minified HTML when requested.                                                #
 # Magento Version: 2.1.4 and later                                                                                    #
-# Default value: true                                                                                              #
+# Default value: true (up to version 2002.0.13 the default value was false)                                           #
 # Possible values:                                                                                                    #
 #                  false — copies the view_preprocessed directory to the <magento_root>/init/ directory at the end    #
 #                          of the build stage, and restores the directory in the <magento_root>/var directory         #
@@ -346,7 +346,7 @@
 # Example:                                                                                                            #
 #          stage:                                                                                                     #
 #            global:                                                                                                  #
-#              MIN_LOGGING_LEVEL: debug                                                                               #                                                           #
+#              MIN_LOGGING_LEVEL: debug                                                                               #
 #######################################################################################################################
 # Set up notifications.                                                                                               #
 # Optionally, you can send logs to a messaging system, such as Slack and email, to receive real-time notifications.   #

--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -85,7 +85,7 @@
 #                          to reduce downtime when deploying to the Staging and Production environments               #
 #                          and generates minified HTML when requested.                                                #
 # Magento Version: 2.1.4 and later                                                                                    #
-# Default value: true (up to version 2002.0.13 the default value was false)                                           #
+# Default value: true (prior to 2002.0.13 the default value was false)                                           #
 # Possible values:                                                                                                    #
 #                  false — copies the view_preprocessed directory to the <magento_root>/init/ directory at the end    #
 #                          of the build stage, and restores the directory in the <magento_root>/var directory         #


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-2488

### Fixed Issues
1. magento/ece-tools#MAGECLOUD-2488: SKIP_HTML_MINIFICATION - Fix .magento.env.yaml

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
