### PR TITLE
MAGECLOUD-2486: CLEAN_STATIC_FILES - Fix .magento.env.yaml Reference

### DIFF
--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -126,7 +126,7 @@
 # Magento Version: 2.1.4 and later                                                                                    #
 # Default value: true                                                                                                 #
 # Possible values: true or false                                                                                      #
-# Stage: build or deploy                                                                                                   #
+# Stage: global or deploy                                                                                                   #
 # Example:                                                                                                            #
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #

--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -121,12 +121,12 @@
 #            deploy:                                                                                                  #
 #              SCD_COMPRESSION_LEVEL: 4                                                                               #
 #######################################################################################################################
-# CLEAN_STATIC_FILES - cleans generated static view files when you perform an action like enabling                    #
-#                      or disabling a component. We recommend the default value in development.                       #
+# CLEAN_STATIC_FILES - cleans generated static files. By specifying the value of this configuration to 'false',       #
+#                      you can leave the statics that were generated in the previous deployment.                      #
 # Magento Version: 2.1.4 and later                                                                                    #
 # Default value: true                                                                                                 #
 # Possible values: true or false                                                                                      #
-# Stage: global or deploy                                                                                                   #
+# Stage: deploy                                                                                                       #
 # Example:                                                                                                            #
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #

--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -126,7 +126,7 @@
 # Magento Version: 2.1.4 and later                                                                                    #
 # Default value: true                                                                                                 #
 # Possible values: true or false                                                                                      #
-# Stage: deploy                                                                                                       #
+# Stage: build or deploy                                                                                                   #
 # Example:                                                                                                            #
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #

--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -122,7 +122,7 @@
 #              SCD_COMPRESSION_LEVEL: 4                                                                               #
 #######################################################################################################################
 # CLEAN_STATIC_FILES - cleans generated static files. By specifying the value of this configuration to 'false',       #
-#                      you can leave the statics that were generated in the previous deployment.                      #
+#                      you can leave the static files which were generated during the previous deployment.            #
 # Magento Version: 2.1.4 and later                                                                                    #
 # Default value: true                                                                                                 #
 # Possible values: true or false                                                                                      #


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-2486
### Fixed Issues
1. magento/ece-tools#MAGECLOUD-2486: CLEAN_STATIC_FILES - Fix .magento.env.yaml Reference

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
