### PR TITLE
MAGECLOUD-2500: Add Redis auto-configuration

### DIFF
--- a/dist/docker/config.php
+++ b/dist/docker/config.php
@@ -12,6 +12,12 @@ return [
                     'port' => '3306',
                 ],
             ],
+            'redis' => [
+                [
+                    'host' => 'redis',
+                    'port' => '6379'
+                ]
+            ],
         ]
     )),
     'MAGENTO_CLOUD_ROUTES' => base64_encode(json_encode(

--- a/src/Docker/Builder.php
+++ b/src/Docker/Builder.php
@@ -111,6 +111,7 @@ class Builder
             'version' => '2',
             'services' => [
                 'varnish' => $this->serviceFactory->create(ServiceFactory::SERVICE_VARNISH)->get(),
+                'redis' => $this->serviceFactory->create(ServiceFactory::SERVICE_REDIS)->get(),
                 'fpm' => $this->getFpmService(),
                 /** For backward compatibility. */
                 'cli' => $this->getCliService(false),

--- a/src/Docker/Builder.php
+++ b/src/Docker/Builder.php
@@ -196,6 +196,7 @@ class Builder
             ),
             'links' => [
                 'db',
+                'redis'
             ],
             'volumes' => [
                 '~/.composer/cache:/root/.composer/cache',

--- a/src/Docker/Service/RedisService.php
+++ b/src/Docker/Service/RedisService.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Docker\Service;
+
+/**
+ * @inheritdoc
+ */
+class RedisService implements ServiceInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function get(): array
+    {
+        return [
+            'image' => 'magento/magento-cloud-docker-redis:latest',
+            'volumes' => [
+                '/data',
+            ],
+            'ports' => [
+                6379,
+            ],
+        ];
+    }
+}

--- a/src/Docker/Service/ServiceFactory.php
+++ b/src/Docker/Service/ServiceFactory.php
@@ -13,12 +13,14 @@ use Magento\MagentoCloud\App\ContainerInterface;
 class ServiceFactory
 {
     const SERVICE_VARNISH = 'varnish';
+    const SERVICE_REDIS = 'redis';
 
     /**
      * @var array
      */
     private static $map = [
         self::SERVICE_VARNISH => VarnishService::class,
+        self::SERVICE_REDIS => RedisService::class,
     ];
 
     /**

--- a/src/Test/Unit/Docker/BuilderTest.php
+++ b/src/Test/Unit/Docker/BuilderTest.php
@@ -175,7 +175,7 @@ class BuilderTest extends TestCase
             ->method('get')
             ->willReturn([]);
 
-        $this->serviceFactoryMock->expects($this->once())
+        $this->serviceFactoryMock->expects($this->any())
             ->method('create')
             ->willReturn($serviceMock);
 

--- a/src/Test/Unit/Docker/Service/RedisServiceTest.php
+++ b/src/Test/Unit/Docker/Service/RedisServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Docker\Service;
+
+use Magento\MagentoCloud\Docker\Service\RedisService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @inheritdoc
+ */
+class RedisServiceTest extends TestCase
+{
+    /**
+     * @var RedisService
+     */
+    private $service;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->service = new RedisService();
+    }
+
+    public function testGet()
+    {
+        $this->assertSame([
+            'image' => 'magento/magento-cloud-docker-redis:latest',
+            'volumes' => [
+                '/data',
+            ],
+            'ports' => [
+                6379,
+            ],
+        ], $this->service->get());
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-2500

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Build Docker environemnt
1. Open frontent
1. Run `docker-compose run deploy bash -c 'redis-cli -h redis -p 6379 KEYS "*"'` and see success response
1. Run `docker-compose run deploy bash -c "cat /var/www/magento/app/etc/env.php | grep redis"` and see redis section 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
