### PR TITLE
MAGECLOUD-2515: By Default Redis Setting 'disable_locking' Should be Enabled

### DIFF
--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Session/Config.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Session/Config.php
@@ -121,9 +121,9 @@ class Config
         }
 
         if ($this->comparator::greaterThanOrEqualTo($package->getVersion(), '1.3.4')) {
-            return 0;
+            return 1;
         }
 
-        return 1;
+        return 0;
     }
 }

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/Session/ConfigTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/Session/ConfigTest.php
@@ -5,13 +5,16 @@
  */
 namespace Magento\MagentoCloud\Test\Unit\Process\Deploy\InstallUpdate\ConfigUpdate\Session;
 
+use Composer\Package\PackageInterface;
+use Composer\Semver\Comparator;
 use Magento\MagentoCloud\Config\ConfigMerger;
 use Magento\MagentoCloud\Config\Stage\DeployInterface;
 use Magento\MagentoCloud\Config\StageConfigInterface;
+use Magento\MagentoCloud\Package\Manager;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate\Session\Config;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
 
 /**
  * @inheritdoc
@@ -19,14 +22,29 @@ use PHPUnit_Framework_MockObject_MockObject as Mock;
 class ConfigTest extends TestCase
 {
     /**
-     * @var Environment|Mock
+     * @var Environment|MockObject
      */
     private $environmentMock;
 
     /**
-     * @var DeployInterface|Mock
+     * @var DeployInterface|MockObject
      */
     private $stageConfigMock;
+
+    /**
+     * @var ConfigMerger|MockObject
+     */
+    private $configMergerMock;
+
+    /**
+     * @var Manager|MockObject
+     */
+    private $managerMock;
+
+    /**
+     * @var Comparator|MockObject
+     */
+    private $comparatorMock;
 
     /**
      * @var Config
@@ -37,11 +55,16 @@ class ConfigTest extends TestCase
     {
         $this->environmentMock = $this->createMock(Environment::class);
         $this->stageConfigMock = $this->getMockForAbstractClass(DeployInterface::class);
+        $this->configMergerMock = $this->createTestProxy(ConfigMerger::class);
+        $this->managerMock = $this->createMock(Manager::class);
+        $this->comparatorMock = new Comparator();
 
         $this->config = new Config(
             $this->environmentMock,
             $this->stageConfigMock,
-            new ConfigMerger()
+            $this->configMergerMock,
+            $this->managerMock,
+            $this->comparatorMock
         );
     }
 
@@ -80,6 +103,14 @@ class ConfigTest extends TestCase
             ->method('getRelationship')
             ->with('redis')
             ->willReturn($relationships);
+        $package = $this->getMockForAbstractClass(PackageInterface::class);
+        $this->managerMock->expects($this->once())
+            ->method('get')
+            ->with('colinmollenhour/php-redis-session-abstract')
+            ->willReturn($package);
+        $package->expects($this->once())
+            ->method('getVersion')
+            ->willReturn('1.3.4');
 
         $this->assertEquals(
             $expected,
@@ -106,6 +137,104 @@ class ConfigTest extends TestCase
                 'host' => 'host',
                 'port' => 'port',
                 'database' => 0,
+                'disable_locking' => 0
+            ],
+        ];
+
+        $resultWithMergedKey = $result;
+        $resultWithMergedKey['key'] = 'value';
+
+        $resultWithMergedHostAndPort = $result;
+        $resultWithMergedHostAndPort['redis']['host'] = 'new_host';
+        $resultWithMergedHostAndPort['redis']['port'] = 'new_port';
+
+        return [
+            [
+                [],
+                $relationships,
+                $result,
+            ],
+            [
+                [StageConfigInterface::OPTION_MERGE => true],
+                $relationships,
+                $result,
+            ],
+            [
+                [
+                    StageConfigInterface::OPTION_MERGE => true,
+                    'key' => 'value',
+                ],
+                $relationships,
+                $resultWithMergedKey,
+            ],
+            [
+                [
+                    StageConfigInterface::OPTION_MERGE => true,
+                    'redis' => [
+                        'host' => 'new_host',
+                        'port' => 'new_port',
+                    ],
+                ],
+                $relationships,
+                $resultWithMergedHostAndPort,
+            ],
+        ];
+    }
+
+    /**
+     * @param array $envSessionConfiguration
+     * @param array $relationships
+     * @param array $expected
+     * @dataProvider envConfigurationMergingWithPrevVersionDataProvider
+     */
+    public function testEnvConfigurationMergingWithPrevVersion(
+        array $envSessionConfiguration,
+        array $relationships,
+        array $expected
+    ) {
+        $this->stageConfigMock->expects($this->once())
+            ->method('get')
+            ->with(DeployInterface::VAR_SESSION_CONFIGURATION)
+            ->willReturn($envSessionConfiguration);
+        $this->environmentMock->expects($this->once())
+            ->method('getRelationship')
+            ->with('redis')
+            ->willReturn($relationships);
+        $package = $this->getMockForAbstractClass(PackageInterface::class);
+        $this->managerMock->expects($this->once())
+            ->method('get')
+            ->with('colinmollenhour/php-redis-session-abstract')
+            ->willReturn($package);
+        $package->expects($this->once())
+            ->method('getVersion')
+            ->willReturn('1.3.3');
+
+        $this->assertEquals(
+            $expected,
+            $this->config->get()
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function envConfigurationMergingWithPrevVersionDataProvider(): array
+    {
+        $relationships = [
+            [
+                'host' => 'host',
+                'port' => 'port',
+                'scheme' => 'redis',
+            ],
+        ];
+
+        $result = [
+            'save' => 'redis',
+            'redis' => [
+                'host' => 'host',
+                'port' => 'port',
+                'database' => 0,
+                'disable_locking' => 1
             ],
         ];
 

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/Session/ConfigTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/Session/ConfigTest.php
@@ -8,13 +8,13 @@ namespace Magento\MagentoCloud\Test\Unit\Process\Deploy\InstallUpdate\ConfigUpda
 use Composer\Package\PackageInterface;
 use Composer\Semver\Comparator;
 use Magento\MagentoCloud\Config\ConfigMerger;
+use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\Stage\DeployInterface;
 use Magento\MagentoCloud\Config\StageConfigInterface;
 use Magento\MagentoCloud\Package\Manager;
+use Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate\Session\Config;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Magento\MagentoCloud\Config\Environment;
-use Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate\Session\Config;
 
 /**
  * @inheritdoc
@@ -137,7 +137,7 @@ class ConfigTest extends TestCase
                 'host' => 'host',
                 'port' => 'port',
                 'database' => 0,
-                'disable_locking' => 0
+                'disable_locking' => 1
             ],
         ];
 
@@ -234,7 +234,7 @@ class ConfigTest extends TestCase
                 'host' => 'host',
                 'port' => 'port',
                 'database' => 0,
-                'disable_locking' => 1
+                'disable_locking' => 0
             ],
         ];
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-2515

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. https://jira.corp.magento.com/browse/MAGETWO-93944

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
