### PR TITLE
MAGECLOUD-2520: Issue with _merge Option for Environment Variables

### DIFF
--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine/Config.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine/Config.php
@@ -68,19 +68,14 @@ class Config
     public function get(): array
     {
         $envSearchConfig = (array)$this->stageConfig->get(DeployInterface::VAR_SEARCH_CONFIGURATION);
-        $envSearchConfigValidFlag = $this->isSearchConfigValid($envSearchConfig);
 
-        if ($envSearchConfigValidFlag && !$this->configMerger->isMergeRequired($envSearchConfig)) {
+        if ($this->isSearchConfigValid($envSearchConfig)
+            && !$this->configMerger->isMergeRequired($envSearchConfig)
+        ) {
             return $this->configMerger->clear($envSearchConfig);
         }
 
-        $searchConfig = $this->getSearchConfig();
-
-        if ($envSearchConfigValidFlag && $this->configMerger->isMergeRequired($envSearchConfig)) {
-            return $this->configMerger->mergeConfigs($searchConfig, $envSearchConfig);
-        }
-
-        return $searchConfig;
+        return $this->configMerger->mergeConfigs($this->getSearchConfig(), $envSearchConfig);
     }
 
     /**

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine/ConfigTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine/ConfigTest.php
@@ -170,6 +170,39 @@ class ConfigTest extends TestCase
                 ],
             ],
             [
+                'customSearchConfig' => [
+                    'elasticsearch_server_port' => 2345,
+                    'elasticsearch_index_prefix' => 'new_prefix',
+                    '_merge' => true,
+                ],
+                'version' => '2.4',
+                'relationships' => [
+                    'host' => 'localhost',
+                    'port' => 1234,
+                ],
+                'expected' => [
+                    'engine' => 'elasticsearch',
+                    'elasticsearch_server_hostname' => 'localhost',
+                    'elasticsearch_server_port' => 2345,
+                    'elasticsearch_index_prefix' => 'new_prefix',
+                ],
+            ],
+            [
+                'customSearchConfig' => [
+                    '_merge' => true,
+                ],
+                'version' => '2.4',
+                'relationships' => [
+                    'host' => 'localhost',
+                    'port' => 1234,
+                ],
+                'expected' => [
+                    'engine' => 'elasticsearch',
+                    'elasticsearch_server_hostname' => 'localhost',
+                    'elasticsearch_server_port' => 1234,
+                ],
+            ],
+            [
                 'customSearchConfig' => [],
                 'version' => '5',
                 'relationships' => [

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine/ConfigTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine/ConfigTest.php
@@ -131,6 +131,8 @@ class ConfigTest extends TestCase
 
     /**
      * @return array
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function testGetWithElasticSearchDataProvider(): array
     {


### PR DESCRIPTION


### Description
Wrong merge behavior for search engine configuration. Merge doesn't work if configuration to be merged doesn't contain 'engine' option.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-2520

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGETWO-85547

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
