### PR TITLE
MAGECLOUD-2516: SCD_ON_DEMAND Environment Variable

### DIFF
--- a/src/Command/Wizard/ScdOnDemand.php
+++ b/src/Command/Wizard/ScdOnDemand.php
@@ -5,11 +5,12 @@
  */
 namespace Magento\MagentoCloud\Command\Wizard;
 
+use Magento\MagentoCloud\Command\Wizard\Util\OutputFormatter;
+use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\GlobalSection;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Magento\MagentoCloud\Command\Wizard\Util\OutputFormatter;
 
 /**
  * Verifies configuration to be properly set and ready to use SCD on demand.
@@ -29,13 +30,20 @@ class ScdOnDemand extends Command
     private $globalStage;
 
     /**
+     * @var Environment
+     */
+    private $environment;
+
+    /**
      * @param OutputFormatter $outputFormatter
      * @param GlobalSection $globalStage
+     * @param Environment $environment
      */
-    public function __construct(OutputFormatter $outputFormatter, GlobalSection $globalStage)
+    public function __construct(OutputFormatter $outputFormatter, GlobalSection $globalStage, Environment $environment)
     {
         $this->outputFormatter = $outputFormatter;
         $this->globalStage = $globalStage;
+        $this->environment = $environment;
 
         parent::__construct();
     }
@@ -56,8 +64,14 @@ class ScdOnDemand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $scdOnDemandEnabled = $this->globalStage->get(GlobalSection::VAR_SCD_ON_DEMAND);
-        $scdOnDemandStatus = $scdOnDemandEnabled ? 'enabled' : 'disabled';
+        $globalScdOnDemandEnabled = $this->globalStage->get(GlobalSection::VAR_SCD_ON_DEMAND);
+        $globalScdOnDemandStatus = $globalScdOnDemandEnabled ? Environment::VAL_ENABLED : Environment::VAL_DISABLED;
+
+        $scdOnDemandStatus = $this->environment->getVariable(
+            GlobalSection::VAR_SCD_ON_DEMAND,
+            $globalScdOnDemandStatus
+        );
+        $scdOnDemandEnabled = $scdOnDemandStatus == Environment::VAL_ENABLED;
 
         $this->outputFormatter->writeResult($output, $scdOnDemandEnabled, 'SCD on demand is ' . $scdOnDemandStatus);
 

--- a/src/Config/Validator/GlobalStage/ScdOnBuild.php
+++ b/src/Config/Validator/GlobalStage/ScdOnBuild.php
@@ -5,11 +5,12 @@
  */
 namespace Magento\MagentoCloud\Config\Validator\GlobalStage;
 
+use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\GlobalSection;
+use Magento\MagentoCloud\Config\Stage\Build as BuildConfig;
 use Magento\MagentoCloud\Config\Stage\BuildInterface;
 use Magento\MagentoCloud\Config\Validator;
 use Magento\MagentoCloud\Config\Validator\CompositeValidator;
-use Magento\MagentoCloud\Config\Stage\Build as BuildConfig;
 
 /**
  * @inheritdoc
@@ -37,19 +38,27 @@ class ScdOnBuild implements CompositeValidator
     private $configFileStructure;
 
     /**
+     * @var Environment
+     */
+    private $environment;
+
+    /**
      * @param Validator\ResultFactory $resultFactory
      * @param GlobalSection $globalStage
+     * @param Environment $environment
      * @param BuildConfig $buildConfig
      * @param Validator\Build\ConfigFileStructure $configFileStructure
      */
     public function __construct(
         Validator\ResultFactory $resultFactory,
         GlobalSection $globalStage,
+        Environment $environment,
         BuildConfig $buildConfig,
         Validator\Build\ConfigFileStructure $configFileStructure
     ) {
         $this->resultFactory = $resultFactory;
         $this->globalConfig = $globalStage;
+        $this->environment = $environment;
         $this->buildConfig = $buildConfig;
         $this->configFileStructure = $configFileStructure;
     }
@@ -73,7 +82,9 @@ class ScdOnBuild implements CompositeValidator
     {
         $errors = [];
 
-        if ($this->globalConfig->get(BuildInterface::VAR_SCD_ON_DEMAND)) {
+        if ($this->globalConfig->get(BuildInterface::VAR_SCD_ON_DEMAND) ||
+            $this->environment->getVariable(BuildInterface::VAR_SCD_ON_DEMAND) == Environment::VAL_ENABLED
+        ) {
             $errors[] = $this->resultFactory->error('SCD_ON_DEMAND variable is enabled');
         }
 

--- a/src/Config/Validator/GlobalStage/ScdOnDeploy.php
+++ b/src/Config/Validator/GlobalStage/ScdOnDeploy.php
@@ -45,17 +45,20 @@ class ScdOnDeploy implements CompositeValidator
     /**
      * @param Validator\ResultFactory $resultFactory
      * @param GlobalSection $globalSection
+     * @param Environment $environment
      * @param DeployInterface $deployConfig
      * @param ScdOnBuild $scdOnBuild
      */
     public function __construct(
         Validator\ResultFactory $resultFactory,
         GlobalSection $globalSection,
+        Environment $environment,
         DeployInterface $deployConfig,
         ScdOnBuild $scdOnBuild
     ) {
         $this->resultFactory = $resultFactory;
         $this->globalConfig = $globalSection;
+        $this->environment = $environment;
         $this->deployConfig = $deployConfig;
         $this->scdOnBuild = $scdOnBuild;
     }

--- a/src/Config/Validator/GlobalStage/ScdOnDeploy.php
+++ b/src/Config/Validator/GlobalStage/ScdOnDeploy.php
@@ -5,9 +5,10 @@
  */
 namespace Magento\MagentoCloud\Config\Validator\GlobalStage;
 
+use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\GlobalSection;
-use Magento\MagentoCloud\Config\Stage\DeployInterface;
 use Magento\MagentoCloud\Config\StageConfigInterface;
+use Magento\MagentoCloud\Config\Stage\DeployInterface;
 use Magento\MagentoCloud\Config\Validator;
 use Magento\MagentoCloud\Config\Validator\CompositeValidator;
 
@@ -35,6 +36,11 @@ class ScdOnDeploy implements CompositeValidator
      * @var ScdOnBuild
      */
     private $scdOnBuild;
+
+    /**
+     * @var Environment
+     */
+    private $environment;
 
     /**
      * @param Validator\ResultFactory $resultFactory
@@ -73,7 +79,9 @@ class ScdOnDeploy implements CompositeValidator
     {
         $errors = [];
 
-        if ($this->globalConfig->get(StageConfigInterface::VAR_SCD_ON_DEMAND)) {
+        if ($this->globalConfig->get(StageConfigInterface::VAR_SCD_ON_DEMAND) ||
+            $this->environment->getVariable(StageConfigInterface::VAR_SCD_ON_DEMAND) == Environment::VAL_ENABLED
+        ) {
             $errors[] = $this->resultFactory->error('SCD_ON_DEMAND variable is enabled');
         }
 

--- a/src/Process/Deploy/CompressStaticContent.php
+++ b/src/Process/Deploy/CompressStaticContent.php
@@ -5,12 +5,13 @@
  */
 namespace Magento\MagentoCloud\Process\Deploy;
 
+use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Config\GlobalSection as GlobalConfig;
 use Magento\MagentoCloud\Config\Stage\DeployInterface;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Process\ProcessInterface;
-use Psr\Log\LoggerInterface;
 use Magento\MagentoCloud\Util\StaticContentCompressor;
-use Magento\MagentoCloud\Config\GlobalSection as GlobalConfig;
+use Psr\Log\LoggerInterface;
 
 /**
  * Compress static content at deploy time.
@@ -43,24 +44,32 @@ class CompressStaticContent implements ProcessInterface
     private $globalConfig;
 
     /**
+     * @var Environment
+     */
+    private $environment;
+
+    /**
      * @param LoggerInterface $logger
      * @param StaticContentCompressor $staticContentCompressor
      * @param FlagManager $flagManager
      * @param DeployInterface $stageConfig
      * @param GlobalConfig $globalConfig
+     * @param Environment $environment
      */
     public function __construct(
         LoggerInterface $logger,
         StaticContentCompressor $staticContentCompressor,
         FlagManager $flagManager,
         DeployInterface $stageConfig,
-        GlobalConfig $globalConfig
+        GlobalConfig $globalConfig,
+        Environment $environment
     ) {
         $this->logger = $logger;
         $this->staticContentCompressor = $staticContentCompressor;
         $this->flagManager = $flagManager;
         $this->stageConfig = $stageConfig;
         $this->globalConfig = $globalConfig;
+        $this->environment = $environment;
     }
 
     /**
@@ -70,7 +79,9 @@ class CompressStaticContent implements ProcessInterface
      */
     public function execute()
     {
-        if ($this->globalConfig->get(DeployInterface::VAR_SCD_ON_DEMAND)) {
+        if ($this->globalConfig->get(DeployInterface::VAR_SCD_ON_DEMAND) ||
+            $this->environment->getVariable(DeployInterface::VAR_SCD_ON_DEMAND) == Environment::VAL_ENABLED
+        ) {
             $this->logger->notice('Skipping static content compression. SCD on demand is enabled.');
 
             return;

--- a/src/Process/Deploy/DeployStaticContent.php
+++ b/src/Process/Deploy/DeployStaticContent.php
@@ -5,12 +5,13 @@
  */
 namespace Magento\MagentoCloud\Process\Deploy;
 
+use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\GlobalSection as GlobalConfig;
 use Magento\MagentoCloud\Config\Stage\DeployInterface;
 use Magento\MagentoCloud\Filesystem\Flag\Manager as FlagManager;
 use Magento\MagentoCloud\Process\ProcessInterface;
-use Psr\Log\LoggerInterface;
 use Magento\MagentoCloud\Util\StaticContentCleaner;
+use Psr\Log\LoggerInterface;
 
 /**
  * @inheritdoc
@@ -43,6 +44,11 @@ class DeployStaticContent implements ProcessInterface
     private $globalConfig;
 
     /**
+     * @var Environment
+     */
+    private $environment;
+
+    /**
      * @var StaticContentCleaner
      */
     private $staticContentCleaner;
@@ -53,6 +59,7 @@ class DeployStaticContent implements ProcessInterface
      * @param LoggerInterface $logger
      * @param DeployInterface $stageConfig
      * @param GlobalConfig $globalConfig
+     * @param Environment $environment
      * @param StaticContentCleaner $staticContentCleaner
      */
     public function __construct(
@@ -61,6 +68,7 @@ class DeployStaticContent implements ProcessInterface
         LoggerInterface $logger,
         DeployInterface $stageConfig,
         GlobalConfig $globalConfig,
+        Environment $environment,
         StaticContentCleaner $staticContentCleaner
     ) {
         $this->process = $process;
@@ -68,6 +76,7 @@ class DeployStaticContent implements ProcessInterface
         $this->logger = $logger;
         $this->stageConfig = $stageConfig;
         $this->globalConfig = $globalConfig;
+        $this->environment = $environment;
         $this->staticContentCleaner = $staticContentCleaner;
     }
 
@@ -80,7 +89,9 @@ class DeployStaticContent implements ProcessInterface
      */
     public function execute()
     {
-        if ($this->globalConfig->get(DeployInterface::VAR_SCD_ON_DEMAND)) {
+        if ($this->globalConfig->get(DeployInterface::VAR_SCD_ON_DEMAND) ||
+            $this->environment->getVariable(DeployInterface::VAR_SCD_ON_DEMAND) == Environment::VAL_ENABLED
+        ) {
             $this->logger->notice('Skipping static content deploy. SCD on demand is enabled.');
             $this->staticContentCleaner->clean();
 

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/PrepareConfig.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/PrepareConfig.php
@@ -5,9 +5,10 @@
  */
 namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate;
 
-use Magento\MagentoCloud\Process\ProcessInterface;
-use Magento\MagentoCloud\Config\GlobalSection as GlobalConfig;
 use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
+use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Config\GlobalSection as GlobalConfig;
+use Magento\MagentoCloud\Process\ProcessInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -31,18 +32,26 @@ class PrepareConfig implements ProcessInterface
     private $globalConfig;
 
     /**
+     * @var Environment
+     */
+    private $environment;
+
+    /**
      * @param LoggerInterface $logger
      * @param ConfigWriter $configWriter
      * @param GlobalConfig $globalConfig
+     * @param Environment $environment
      */
     public function __construct(
         LoggerInterface $logger,
         ConfigWriter $configWriter,
-        GlobalConfig $globalConfig
+        GlobalConfig $globalConfig,
+        Environment $environment
     ) {
         $this->logger = $logger;
         $this->configWriter = $configWriter;
         $this->globalConfig = $globalConfig;
+        $this->environment = $environment;
     }
 
     /**
@@ -52,10 +61,11 @@ class PrepareConfig implements ProcessInterface
     {
         $this->logger->info('Updating env.php.');
 
-        $config = [
-            'static_content_on_demand_in_production' => (int)$this->globalConfig->get(GlobalConfig::VAR_SCD_ON_DEMAND),
-            'force_html_minification' => (int)$this->globalConfig->get(GlobalConfig::VAR_SKIP_HTML_MINIFICATION),
-        ];
+        $config['static_content_on_demand_in_production'] = (int)(
+            $this->globalConfig->get(GlobalConfig::VAR_SCD_ON_DEMAND) ||
+            $this->environment->getVariable(GlobalConfig::VAR_SCD_ON_DEMAND) == Environment::VAL_ENABLED
+        );
+        $config['force_html_minification'] = (int)$this->globalConfig->get(GlobalConfig::VAR_SKIP_HTML_MINIFICATION);
 
         $this->configWriter->update($config);
     }

--- a/src/Test/Unit/Command/Wizard/ScdOnDemandTest.php
+++ b/src/Test/Unit/Command/Wizard/ScdOnDemandTest.php
@@ -6,10 +6,11 @@
 namespace Magento\MagentoCloud\Test\Unit\Command\Wizard;
 
 use Magento\MagentoCloud\Command\Wizard\ScdOnDemand;
-use Magento\MagentoCloud\Config\GlobalSection;
 use Magento\MagentoCloud\Command\Wizard\Util\OutputFormatter;
-use PHPUnit\Framework\TestCase;
+use Magento\MagentoCloud\Config\Environment;
+use Magento\MagentoCloud\Config\GlobalSection;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Output\Output;
 
@@ -34,20 +35,27 @@ class ScdOnDemandTest extends TestCase
     private $globalStageMock;
 
     /**
+     * @var Environment|MockObject
+     */
+    private $environmentMock;
+
+    /**
      * @inheritdoc
      */
     protected function setUp()
     {
         $this->outputFormatterMock = $this->createMock(OutputFormatter::class);
         $this->globalStageMock = $this->createMock(GlobalSection::class);
+        $this->environmentMock = $this->createMock(Environment::class);
 
         $this->command = new ScdOnDemand(
             $this->outputFormatterMock,
-            $this->globalStageMock
+            $this->globalStageMock,
+            $this->environmentMock
         );
     }
 
-    public function testExecute()
+    public function testExecuteConfigEnabled()
     {
         $inputMock = $this->getMockForAbstractClass(Input::class);
         $outputMock = $this->getMockForAbstractClass(Output::class);
@@ -56,11 +64,35 @@ class ScdOnDemandTest extends TestCase
             ->method('get')
             ->with(GlobalSection::VAR_SCD_ON_DEMAND)
             ->willReturn(true);
+        $this->environmentMock->expects($this->once())
+            ->method('getVariable')
+            ->with(GlobalSection::VAR_SCD_ON_DEMAND, Environment::VAL_ENABLED)
+            ->willReturn('enabled');
         $this->outputFormatterMock->expects($this->once())
             ->method('writeResult')
             ->with($outputMock, true, 'SCD on demand is enabled');
 
-        $this->command->run($inputMock, $outputMock);
+        $this->assertSame(0, $this->command->run($inputMock, $outputMock));
+    }
+
+    public function testExecuteEnvironmentEnabled()
+    {
+        $inputMock = $this->getMockForAbstractClass(Input::class);
+        $outputMock = $this->getMockForAbstractClass(Output::class);
+
+        $this->globalStageMock->expects($this->once())
+            ->method('get')
+            ->with(GlobalSection::VAR_SCD_ON_DEMAND)
+            ->willReturn(false);
+        $this->environmentMock->expects($this->once())
+            ->method('getVariable')
+            ->with(GlobalSection::VAR_SCD_ON_DEMAND, Environment::VAL_DISABLED)
+            ->willReturn('enabled');
+        $this->outputFormatterMock->expects($this->once())
+            ->method('writeResult')
+            ->with($outputMock, true, 'SCD on demand is enabled');
+
+        $this->assertSame(0, $this->command->run($inputMock, $outputMock));
     }
 
     public function testExecuteToBeDisabled()
@@ -72,10 +104,14 @@ class ScdOnDemandTest extends TestCase
             ->method('get')
             ->with(GlobalSection::VAR_SCD_ON_DEMAND)
             ->willReturn(false);
+        $this->environmentMock->expects($this->once())
+            ->method('getVariable')
+            ->with(GlobalSection::VAR_SCD_ON_DEMAND, Environment::VAL_DISABLED)
+            ->willReturn('disabled');
         $this->outputFormatterMock->expects($this->once())
             ->method('writeResult')
             ->with($outputMock, false, 'SCD on demand is disabled');
 
-        $this->command->run($inputMock, $outputMock);
+        $this->assertSame(1, $this->command->run($inputMock, $outputMock));
     }
 }


### PR DESCRIPTION
### Description

Allows the use of `SCD_ON_DEMAND` as an environment variable.

### Fixed Issues (if relevant)

[MAGECLOUD-2516](https://magento2.atlassian.net/browse/MAGECLOUD-2516)

### Manual testing scenarios

TBA

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
