### PR TITLE
MAGECLOUD-2556: Deploy failed when try to setup redirecting naked domain to www

### DIFF
--- a/src/Test/Unit/Util/UrlManagerTest.php
+++ b/src/Test/Unit/Util/UrlManagerTest.php
@@ -317,6 +317,34 @@ class UrlManagerTest extends TestCase
                     ],
                 ],
             ],
+            'domain with www by default' => [
+                'routes' => [
+                    'http://example.com/' => ['original_url' => 'http://www.{default}/', 'type' => 'upstream'],
+                    'https://example.com/' => ['original_url' => 'https://www.{default}/', 'type' => 'upstream'],
+                    'http://*.example.com/' => ['original_url' => 'http://*.{default}/', 'type' => 'upstream'],
+                    'https://*.example.com/' => ['original_url' => 'https://*.{default}/', 'type' => 'upstream'],
+                    'http://french.example.com/' => [
+                        'original_url' => 'http://french.{default}/',
+                        'type' => 'upstream',
+                    ],
+                    'https://french.example.com/' => [
+                        'original_url' => 'https://french.{default}/',
+                        'type' => 'upstream',
+                    ],
+                ],
+                [
+                    'secure' => [
+                        '' => 'https://example.com/',
+                        '*' => 'https://*.example.com/',
+                        'french' => 'https://french.example.com/',
+                    ],
+                    'unsecure' => [
+                        '' => 'http://example.com/',
+                        '*' => 'http://*.example.com/',
+                        'french' => 'http://french.example.com/',
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -61,7 +61,7 @@ class UrlManager
             }
 
             $host = parse_url($val['original_url'], PHP_URL_HOST);
-            $originalUrlRegEx = sprintf('/\.?%s/', preg_quote(self::MAGIC_ROUTE));
+            $originalUrlRegEx = sprintf('/(www)?\.?%s/', preg_quote(self::MAGIC_ROUTE));
             $originalUrl = preg_replace($originalUrlRegEx, '', $host);
 
             if (strpos($key, self::PREFIX_UNSECURE) === 0) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Ece-tools throws an error during installation if domain by default configured with www and redirects to domain without www.
For example, deploy is failing with next configuration .magento/routes.yaml:
```
"http://www.{default}/":
    type: upstream
    upstream: "mymagento:http"

"http://{default}/":
    type: redirect
    to: "http://www.{default}/"
```

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-2556

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. https://jira.corp.magento.com/browse/MAGETWO-93992

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
