### PR TITLE
MAGECLOUD-2475: Stop moving di.xml during build process

### DIFF
--- a/src/Process/Build/MarshallFiles.php
+++ b/src/Process/Build/MarshallFiles.php
@@ -7,6 +7,7 @@ namespace Magento\MagentoCloud\Process\Build;
 
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\Process\ProcessInterface;
 
 /**
@@ -27,19 +28,32 @@ class MarshallFiles implements ProcessInterface
     private $directoryList;
 
     /**
+     * @var MagentoVersion
+     */
+    private $magentoVersion;
+
+    /**
      * @param File $file
      * @param DirectoryList $directoryList
+     * @param MagentoVersion $magentoVersion
      */
     public function __construct(
         File $file,
-        DirectoryList $directoryList
+        DirectoryList $directoryList,
+        MagentoVersion $magentoVersion
     ) {
         $this->file = $file;
         $this->directoryList = $directoryList;
+        $this->magentoVersion = $magentoVersion;
     }
 
     /**
-     * @inheritdoc
+     * Clears var/cache directory.
+     * Copying di.xml files for Magento version < 2.2.
+     *
+     * Magento version 2.1.x won't install without copying di.xml files.
+     *
+     * {@inheritdoc}
      */
     public function execute()
     {
@@ -49,6 +63,10 @@ class MarshallFiles implements ProcessInterface
 
         if ($this->file->isExists($varCache)) {
             $this->file->deleteDirectory($varCache);
+        }
+
+        if ($this->magentoVersion->isGreaterOrEqual('2.2')) {
+            return;
         }
 
         $this->file->copy(

--- a/src/Test/Unit/Process/Build/MarshallFilesTest.php
+++ b/src/Test/Unit/Process/Build/MarshallFilesTest.php
@@ -62,7 +62,7 @@ class MarshallFilesTest extends TestCase
      * @param int $createDirectory
      * @dataProvider executeDataProvider
      */
-    public function testExecuteForMagento2_1($isExist, $deleteDirectory, $createDirectory)
+    public function testExecuteForMagento21($isExist, $deleteDirectory, $createDirectory)
     {
         $enterpriseFolder = 'magento_root/app/enterprise';
         $varCache = 'magento_root/var/cache/';
@@ -107,7 +107,7 @@ class MarshallFilesTest extends TestCase
         ];
     }
 
-    public function testExecuteFroMagentoGreater2_2()
+    public function testExecuteFroMagentoGreater22()
     {
         $varCache = 'magento_root/var/cache/';
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
It is no longer necessary to copy these files during the build process:

app/etc/di.xml -> app/di.xml
app/etc/enterprise/di.xml -> app/enterprise/di.xml

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-2475

### Manual testing scenarios
1. Uninstall Magento on cloud if installed.
2. Install Magento on cloud from clean template. Check that Magento installed without errors.
3. Redeploy Magento for triggering an update. Check that Magento updated without errors.
4. Repeat step 1 - 3 for version 2.1.x and 2.2.x
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
