### PR TITLE
MAGECLOUD-1473: Exception code number in Cloud classes

### DIFF
--- a/src/Config/State.php
+++ b/src/Config/State.php
@@ -74,7 +74,7 @@ class State
         }
 
         if (!in_array('core_config_data', $output) || !in_array('setup_module', $output)) {
-            throw new \Exception('Missing either core_config_data or setup_module table', 5);
+            throw new \Exception('Missing either core_config_data or setup_module table');
         }
 
         $data = $this->reader->read();

--- a/src/Process/Build/DeployStaticContent/Generate.php
+++ b/src/Process/Build/DeployStaticContent/Generate.php
@@ -70,33 +70,29 @@ class Generate implements ProcessInterface
      */
     public function execute()
     {
-        try {
-            $locales = $this->buildOption->getLocales();
-            $excludeThemes = $this->buildOption->getExcludedThemes();
-            $threadCount = $this->buildOption->getThreadCount();
+        $locales = $this->buildOption->getLocales();
+        $excludeThemes = $this->buildOption->getExcludedThemes();
+        $threadCount = $this->buildOption->getThreadCount();
 
-            $logMessage = 'Generating static content for locales: ' . implode(' ', $locales);
+        $logMessage = 'Generating static content for locales: ' . implode(' ', $locales);
 
-            if (count($excludeThemes)) {
-                $logMessage .= PHP_EOL . 'Excluding Themes: ' . implode(' ', $excludeThemes);
-            }
+        if (count($excludeThemes)) {
+            $logMessage .= PHP_EOL . 'Excluding Themes: ' . implode(' ', $excludeThemes);
+        }
 
-            if ($threadCount) {
-                $logMessage .= PHP_EOL . 'Using ' . $threadCount . ' Threads';
-            }
+        if ($threadCount) {
+            $logMessage .= PHP_EOL . 'Using ' . $threadCount . ' Threads';
+        }
 
-            $this->logger->info($logMessage);
+        $this->logger->info($logMessage);
 
-            $commands = $this->commandFactory->matrix(
-                $this->buildOption,
-                $this->buildConfig->get(BuildInterface::VAR_SCD_MATRIX)
-            );
+        $commands = $this->commandFactory->matrix(
+            $this->buildOption,
+            $this->buildConfig->get(BuildInterface::VAR_SCD_MATRIX)
+        );
 
-            foreach ($commands as $command) {
-                $this->shell->execute($command);
-            }
-        } catch (\Exception $e) {
-            throw new \RuntimeException($e->getMessage(), 5);
+        foreach ($commands as $command) {
+            $this->shell->execute($command);
         }
     }
 }

--- a/src/Test/Unit/Config/StateTest.php
+++ b/src/Test/Unit/Config/StateTest.php
@@ -93,7 +93,6 @@ class StateTest extends TestCase
 
     /**
      * @param array $tables
-     * @expectedExceptionCode 5
      * @expectedException \Exception
      * @dataProvider tablesWithExceptionDataProvider
      */


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
We have a few classes where exceptions throw with code 5.
These codes are never used, so they were removed for avoiding confusion.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1473

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Redeploy Magento on cloud. Deploy successful, cloud.log doesn't contain errors.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
