### PR TITLE
MAGECLOUD-2527: ./vendor/bin/ece-tools config:dump formats config.php incorrectly

### DIFF
--- a/src/Test/Unit/Util/PhpFormatterTest.php
+++ b/src/Test/Unit/Util/PhpFormatterTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Util;
+
+use Magento\MagentoCloud\Package\MagentoVersion;
+use Magento\MagentoCloud\Package\UndefinedPackageException;
+use Magento\MagentoCloud\Util\PhpFormatter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @inheritdoc
+ */
+class PhpFormatterTest extends TestCase
+{
+    /**
+     * @var PhpFormatter
+     */
+    private $formatter;
+
+    /**
+     * @var MagentoVersion|MockObject
+     */
+    private $magentoVersionMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->magentoVersionMock = $this->createMock(MagentoVersion::class);
+
+        $this->formatter = new PhpFormatter(
+            $this->magentoVersionMock
+        );
+    }
+
+    /**
+     * @param string $expected
+     * @param array $data
+     * @throws UndefinedPackageException
+     *
+     * @dataProvider formatDataProvider
+     */
+    public function testFormat(string $expected, array $data)
+    {
+        $this->magentoVersionMock->expects($this->once())
+            ->method('isGreaterOrEqual')
+            ->with('2.2.5')
+            ->willReturn(true);
+
+        $this->assertSame(
+            $expected,
+            $this->formatter->format($data)
+        );
+    }
+
+    public function formatDataProvider(): array
+    {
+        $expected1 = <<<TEXT
+<?php
+return [
+    'some' => 'data'
+];
+
+TEXT;
+        $expected2 = <<<TEXT
+<?php
+return [
+    'some' => [
+        'data' => 'value'
+    ]
+];
+
+TEXT;
+
+        return [
+            [
+                $expected1,
+                ['some' => 'data'],
+            ],
+            [
+                $expected2,
+                ['some' => ['data' => 'value']],
+            ],
+        ];
+    }
+
+    public function testFormatLegacy()
+    {
+        $this->magentoVersionMock->expects($this->once())
+            ->method('isGreaterOrEqual')
+            ->with('2.2.5')
+            ->willReturn(false);
+
+        $expected = <<<TEXT
+<?php
+return array (
+  'some' => 'data',
+);
+
+TEXT;
+
+        $this->assertSame(
+            $expected,
+            $this->formatter->format(['some' => 'data'])
+        );
+    }
+}

--- a/src/Util/PhpFormatter.php
+++ b/src/Util/PhpFormatter.php
@@ -41,7 +41,7 @@ class PhpFormatter
     public function format(array $data): string
     {
         if (!$this->magentoVersion->isGreaterOrEqual('2.2.5')) {
-            return '<?php' . "\n" . 'return ' . var_export($data, true) . ";\n";
+            return "<?php\nreturn " . var_export($data, true) . ";\n";
         }
 
         return "<?php\nreturn " . $this->varExportShort($data) . ";\n";

--- a/src/Util/PhpFormatter.php
+++ b/src/Util/PhpFormatter.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Util;
+
+use Magento\MagentoCloud\Package\MagentoVersion;
+use Magento\MagentoCloud\Package\UndefinedPackageException;
+
+/**
+ * Formats PHP array into exportable string.
+ */
+class PhpFormatter
+{
+    /**
+     * @var MagentoVersion
+     */
+    private $magentoVersion;
+
+    /**
+     * @param MagentoVersion $magentoVersion
+     */
+    public function __construct(MagentoVersion $magentoVersion)
+    {
+        $this->magentoVersion = $magentoVersion;
+    }
+
+    /**
+     * 4 space indentation for array formatting.
+     */
+    const INDENT = '    ';
+
+    /**
+     * Format deployment configuration.
+     *
+     * @param array $data
+     * @return string
+     * @throws UndefinedPackageException
+     */
+    public function format(array $data): string
+    {
+        if (!$this->magentoVersion->isGreaterOrEqual('2.2.5')) {
+            return '<?php' . "\n" . 'return ' . var_export($data, true) . ";\n";
+        }
+
+        return "<?php\nreturn " . $this->varExportShort($data, true) . ";\n";
+    }
+
+    /**
+     * If variable to export is an array, format with the php >= 5.4 short array syntax. Otherwise use
+     * default var_export functionality.
+     *
+     * @param mixed $var
+     * @param int $depth
+     * @return string
+     */
+    private function varExportShort($var, int $depth = 0): string
+    {
+        if (!is_array($var)) {
+            return var_export($var, true);
+        }
+
+        $indexed = array_keys($var) === range(0, count($var) - 1);
+        $expanded = [];
+        foreach ($var as $key => $value) {
+            $expanded[] = str_repeat(self::INDENT, $depth)
+                . ($indexed ? '' : $this->varExportShort($key) . ' => ')
+                . $this->varExportShort($value, $depth + 1);
+        }
+
+        return sprintf("[\n%s\n%s]", implode(",\n", $expanded), str_repeat(self::INDENT, $depth - 1));
+    }
+}

--- a/src/Util/PhpFormatter.php
+++ b/src/Util/PhpFormatter.php
@@ -44,7 +44,7 @@ class PhpFormatter
             return '<?php' . "\n" . 'return ' . var_export($data, true) . ";\n";
         }
 
-        return "<?php\nreturn " . $this->varExportShort($data, true) . ";\n";
+        return "<?php\nreturn " . $this->varExportShort($data) . ";\n";
     }
 
     /**
@@ -55,7 +55,7 @@ class PhpFormatter
      * @param int $depth
      * @return string
      */
-    private function varExportShort($var, int $depth = 0): string
+    private function varExportShort($var, int $depth = 1): string
     {
         if (!is_array($var)) {
             return var_export($var, true);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

https://magento2.atlassian.net/browse/MAGECLOUD-2527

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Update environment to 2.2.5
1. Run `./vendor/bin/m2-ece-scd-dump`
1. Check `app/etc/config.php` to have short array syntax and 4 space identation

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
