### PR TITLE
MAGECLOUD-2711: Cron kill during redeploy doesn't work

### DIFF
--- a/src/Process/Deploy/CronProcessKill.php
+++ b/src/Process/Deploy/CronProcessKill.php
@@ -46,7 +46,7 @@ class CronProcessKill implements ProcessInterface
         try {
             $this->logger->info('Trying to kill running cron jobs');
 
-            $cronPids = $this->shell->execute('exec pgrep -U "$USER" -f "bin/magento cron:run"');
+            $cronPids = $this->shell->execute('exec pgrep -U "$(id -u)" -f "bin/magento cron:run"');
             foreach ($cronPids as $pid) {
                 $this->killProcess($pid);
             }

--- a/src/Process/Deploy/CronProcessKill.php
+++ b/src/Process/Deploy/CronProcessKill.php
@@ -46,7 +46,7 @@ class CronProcessKill implements ProcessInterface
         try {
             $this->logger->info('Trying to kill running cron jobs');
 
-            $cronPids = $this->shell->execute('exec pgrep -U "$UID" -f "bin/magento cron:run"');
+            $cronPids = $this->shell->execute('exec pgrep -U "$USER" -f "bin/magento cron:run"');
             foreach ($cronPids as $pid) {
                 $this->killProcess($pid);
             }

--- a/src/Test/Unit/Process/Deploy/CronProcessKillTest.php
+++ b/src/Test/Unit/Process/Deploy/CronProcessKillTest.php
@@ -54,7 +54,7 @@ class CronProcessKillTest extends TestCase
             ->method('execute')
             ->willReturnMap(
                 [
-                    ['exec pgrep -U "$UID" -f "bin/magento cron:run"', [], [111, 222]],
+                    ['exec pgrep -U "$USER" -f "bin/magento cron:run"', [], [111, 222]],
                     ["kill 111", [], []],
                     ["kill 222", [], []],
                 ]
@@ -75,7 +75,7 @@ class CronProcessKillTest extends TestCase
             );
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('exec pgrep -U "$UID" -f "bin/magento cron:run"')
+            ->with('exec pgrep -U "$USER" -f "bin/magento cron:run"')
             ->willThrowException(new \RuntimeException('return code 1', 1));
         $this->process->execute();
     }
@@ -90,7 +90,7 @@ class CronProcessKillTest extends TestCase
             ->with('Trying to kill running cron jobs');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('exec pgrep -U "$UID" -f "bin/magento cron:run"')
+            ->with('exec pgrep -U "$USER" -f "bin/magento cron:run"')
             ->willThrowException(new \RuntimeException('return code 2', 2));
         $this->loggerMock->expects($this->once())
             ->method('warning')
@@ -114,7 +114,7 @@ class CronProcessKillTest extends TestCase
             );
         $this->shellMock->expects($this->at(0))
             ->method('execute')
-            ->with('exec pgrep -U "$UID" -f "bin/magento cron:run"')
+            ->with('exec pgrep -U "$USER" -f "bin/magento cron:run"')
             ->willReturn([111, 222]);
         $this->shellMock->expects($this->at(1))
             ->method('execute')

--- a/src/Test/Unit/Process/Deploy/CronProcessKillTest.php
+++ b/src/Test/Unit/Process/Deploy/CronProcessKillTest.php
@@ -54,7 +54,7 @@ class CronProcessKillTest extends TestCase
             ->method('execute')
             ->willReturnMap(
                 [
-                    ['exec pgrep -U "$USER" -f "bin/magento cron:run"', [], [111, 222]],
+                    ['exec pgrep -U "$(id -u)" -f "bin/magento cron:run"', [], [111, 222]],
                     ["kill 111", [], []],
                     ["kill 222", [], []],
                 ]
@@ -75,7 +75,7 @@ class CronProcessKillTest extends TestCase
             );
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('exec pgrep -U "$USER" -f "bin/magento cron:run"')
+            ->with('exec pgrep -U "$(id -u)" -f "bin/magento cron:run"')
             ->willThrowException(new \RuntimeException('return code 1', 1));
         $this->process->execute();
     }
@@ -90,7 +90,7 @@ class CronProcessKillTest extends TestCase
             ->with('Trying to kill running cron jobs');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('exec pgrep -U "$USER" -f "bin/magento cron:run"')
+            ->with('exec pgrep -U "$(id -u)" -f "bin/magento cron:run"')
             ->willThrowException(new \RuntimeException('return code 2', 2));
         $this->loggerMock->expects($this->once())
             ->method('warning')
@@ -114,7 +114,7 @@ class CronProcessKillTest extends TestCase
             );
         $this->shellMock->expects($this->at(0))
             ->method('execute')
-            ->with('exec pgrep -U "$USER" -f "bin/magento cron:run"')
+            ->with('exec pgrep -U "$(id -u)" -f "bin/magento cron:run"')
             ->willReturn([111, 222]);
         $this->shellMock->expects($this->at(1))
             ->method('execute')


### PR DESCRIPTION

### Description
$UID is not defined during deploy phase. Was changed to $USER

### Fixed Issues (if relevant)
1. https://magento2.atlassian.net/browse/MAGECLOUD-2711

### Manual testing scenarios
https://jira.corp.magento.com/browse/MAGETWO-93796

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
