### PR TITLE
MAGECLOUD-2711: Cron kill during redeploy doesn't work

### DIFF
--- a/src/Process/Deploy/CronProcessKill.php
+++ b/src/Process/Deploy/CronProcessKill.php
@@ -46,7 +46,7 @@ class CronProcessKill implements ProcessInterface
         try {
             $this->logger->info('Trying to kill running cron jobs');
 
-            $cronPids = $this->shell->execute('exec pgrep -U "$UID" -f "bin/magento cron:run"');
+            $cronPids = $this->shell->execute('exec pgrep -U "$USER" -f "bin/magento cron:run"');
             foreach ($cronPids as $pid) {
                 $this->killProcess($pid);
             }

--- a/src/Test/Unit/Process/Deploy/CronProcessKillTest.php
+++ b/src/Test/Unit/Process/Deploy/CronProcessKillTest.php
@@ -54,7 +54,7 @@ class CronProcessKillTest extends TestCase
             ->method('execute')
             ->willReturnMap(
                 [
-                    ['exec pgrep -U "$UID" -f "bin/magento cron:run"', [], [111, 222]],
+                    ['exec pgrep -U "$USER" -f "bin/magento cron:run"', [], [111, 222]],
                     ["kill 111", [], []],
                     ["kill 222", [], []],
                 ]
@@ -75,7 +75,7 @@ class CronProcessKillTest extends TestCase
             );
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('exec pgrep -U "$UID" -f "bin/magento cron:run"')
+            ->with('exec pgrep -U "$USER" -f "bin/magento cron:run"')
             ->willThrowException(new \RuntimeException('return code 1', 1));
         $this->process->execute();
     }
@@ -90,7 +90,7 @@ class CronProcessKillTest extends TestCase
             ->with('Trying to kill running cron jobs');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('exec pgrep -U "$UID" -f "bin/magento cron:run"')
+            ->with('exec pgrep -U "$USER" -f "bin/magento cron:run"')
             ->willThrowException(new \RuntimeException('return code 2', 2));
         $this->loggerMock->expects($this->once())
             ->method('warning')
@@ -114,7 +114,7 @@ class CronProcessKillTest extends TestCase
             );
         $this->shellMock->expects($this->at(0))
             ->method('execute')
-            ->with('exec pgrep -U "$UID" -f "bin/magento cron:run"')
+            ->with('exec pgrep -U "$USER" -f "bin/magento cron:run"')
             ->willReturn([111, 222]);
         $this->shellMock->expects($this->at(1))
             ->method('execute')


### PR DESCRIPTION
 - change $UID to $USER

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/ece-tools#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
