### PR TITLE
MAGECLOUD-2740: Website locale data is removed by config:dump CLI command

### DIFF
--- a/src/Command/ConfigDump/Generate.php
+++ b/src/Command/ConfigDump/Generate.php
@@ -128,8 +128,8 @@ class Generate
          * Only saving general/locale/code.
          */
 
-        $newConfig = $this->filterData($newConfig, 'stores');
-        $newConfig = $this->filterData($newConfig, 'websites');
+        $newConfig = $this->filterSystemData($newConfig, 'stores');
+        $newConfig = $this->filterSystemData($newConfig, 'websites');
 
         /**
          * Un-setting base_url.
@@ -154,13 +154,13 @@ class Generate
     }
 
     /**
-     * Leaves only necessary for deployment data
+     * Removes all data from provided scopes in system section, except general/locale/code
      *
-     * @param array $config
-     * @param string $scope
-     * @return array
+     * @param array $config Config data
+     * @param string $scope Name of scope: websites or stores
+     * @return array Result of config data after filtering
      */
-    private function filterData(&$config, $scope)
+    private function filterSystemData($config, $scope)
     {
         $scopeCodes = isset($config['system'][$scope])
             ? array_keys($config['system'][$scope])
@@ -168,9 +168,9 @@ class Generate
 
         foreach ($scopeCodes as $code) {
             if (isset($config['system'][$scope][$code]['general']['locale']['code'])) {
-                $temp = $config['system'][$scope][$code]['general']['locale']['code'];
+                $localeCode = $config['system'][$scope][$code]['general']['locale']['code'];
                 unset($config['system'][$scope][$code]);
-                $config['system'][$scope][$code]['general']['locale']['code'] = $temp;
+                $config['system'][$scope][$code]['general']['locale']['code'] = $localeCode;
             } else {
                 unset($config['system'][$scope][$code]);
             }

--- a/src/Command/ConfigDump/Generate.php
+++ b/src/Command/ConfigDump/Generate.php
@@ -32,6 +32,7 @@ class Generate
         'system/default/dev/css',
         'system/default/advanced/modules_disable_output',
         'system/stores',
+        'system/websites',
     ];
 
     /**
@@ -98,7 +99,6 @@ class Generate
     {
         if ($this->magentoVersion->isGreaterOrEqual('2.2')) {
             $this->configKeys[] = 'modules';
-            $this->configKeys[] = 'system/websites';
         }
 
         $configFile = $this->sharedConfig->resolve();
@@ -127,18 +127,9 @@ class Generate
         /**
          * Only saving general/locale/code.
          */
-        $storeCodes = isset($newConfig['system']['stores'])
-            ? array_keys($newConfig['system']['stores'])
-            : [];
-        foreach ($storeCodes as $storeCode) {
-            if (isset($newConfig['system']['stores'][$storeCode]['general']['locale']['code'])) {
-                $temp = $newConfig['system']['stores'][$storeCode]['general']['locale']['code'];
-                unset($newConfig['system']['stores'][$storeCode]);
-                $newConfig['system']['stores'][$storeCode]['general']['locale']['code'] = $temp;
-            } else {
-                unset($newConfig['system']['stores'][$storeCode]);
-            }
-        }
+
+        $newConfig = $this->filterData($newConfig, 'stores');
+        $newConfig = $this->filterData($newConfig, 'websites');
 
         /**
          * Un-setting base_url.
@@ -160,5 +151,31 @@ class Generate
             $configFile,
             $this->phpFormatter->format($newConfig)
         );
+    }
+
+    /**
+     * Leaves only necessary for deployment data
+     *
+     * @param array $config
+     * @param string $scope
+     * @return array
+     */
+    private function filterData(&$config, $scope)
+    {
+        $scopeCodes = isset($config['system'][$scope])
+            ? array_keys($config['system'][$scope])
+            : [];
+
+        foreach ($scopeCodes as $code) {
+            if (isset($config['system'][$scope][$code]['general']['locale']['code'])) {
+                $temp = $config['system'][$scope][$code]['general']['locale']['code'];
+                unset($config['system'][$scope][$code]);
+                $config['system'][$scope][$code]['general']['locale']['code'] = $temp;
+            } else {
+                unset($config['system'][$scope][$code]);
+            }
+        }
+
+        return $config;
     }
 }

--- a/src/Test/Unit/Command/ConfigDump/_files/app/etc/config.php
+++ b/src/Test/Unit/Command/ConfigDump/_files/app/etc/config.php
@@ -471,6 +471,21 @@ return [
             ],
         ],
         'websites' => [
+            'base' => [
+                'general' => [
+                    'locale' => [
+                        'code' => 'kz_KZ'
+                    ],
+                ],
+                'design' => [
+                    'package' => [
+                        'name' => 'default',
+                    ],
+                    'theme' => [
+                        'default' => 'default',
+                    ],
+                ],
+            ],
             'admin' => [
                 'web' => [
                     'routers' => [

--- a/src/Test/Unit/Command/ConfigDump/_files/app/etc/generated_config.php
+++ b/src/Test/Unit/Command/ConfigDump/_files/app/etc/generated_config.php
@@ -88,15 +88,10 @@ return [
             ],
         ],
         'websites' => [
-            'admin' => [
-                'web' => [
-                    'routers' => [
-                        'frontend' => [
-                            'disabled' => 'true',
-                        ],
-                    ],
-                    'default' => [
-                        'no_route' => 'admin/noroute/index',
+            'base' => [
+                'general' => [
+                    'locale' => [
+                        'code' => 'kz_KZ'
                     ],
                 ],
             ],

--- a/src/Test/Unit/Command/ConfigDump/_files/app/etc/generated_config_2.1.php
+++ b/src/Test/Unit/Command/ConfigDump/_files/app/etc/generated_config_2.1.php
@@ -87,6 +87,15 @@ return [
                 ],
             ],
         ],
+        'websites' => [
+            'base' => [
+                'general' => [
+                    'locale' => [
+                        'code' => 'kz_KZ'
+                    ],
+                ],
+            ],
+        ],
     ],
     'admin_user' => [
         'locale' => [


### PR DESCRIPTION
### Description
ece-tools config:dump CLI command removed all custom data for websites

### Fixed Issues (if relevant)
1. https://magento2.atlassian.net/browse/MAGECLOUD-2740
Website locale data is removed by config:dump CLI command

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. https://jira.corp.magento.com/browse/MAGETWO-69172

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
