### PR TITLE
MAGECLOUD-2837: Update ECE-Tools builder with PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ language: php
 php:
   - '7.0'
   - '7.1'
+  - '7.2'
 
 addons:
   apt:
@@ -36,8 +37,7 @@ install:
   - composer update -n --no-suggest
   - ./bin/ece-tools docker:build --test --php ${TRAVIS_PHP_VERSION}
 
-before_script:
-  - docker-compose up -d --build
+before_script: docker-compose up -d
 
 script: ./tests/travis/script.sh
 

--- a/bin/ece-tools
+++ b/bin/ece-tools
@@ -1,6 +1,4 @@
 #!/usr/bin/env php
-set -e
-
 <?php
 /**
  * Copyright © Magento, Inc. All rights reserved.

--- a/bin/ece-tools
+++ b/bin/ece-tools
@@ -1,4 +1,6 @@
 #!/usr/bin/env php
+set -e
+
 <?php
 /**
  * Copyright © Magento, Inc. All rights reserved.

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "license": "proprietary",
   "require": {
     "php": "^7.0",
+    "ext-PDO": "*",
     "ext-json": "*",
     "composer/composer": "@stable",
     "composer/semver": "^1.4",

--- a/src/Docker/BuilderFactory.php
+++ b/src/Docker/BuilderFactory.php
@@ -20,7 +20,7 @@ class BuilderFactory
      */
     private static $map = [
         self::BUILDER_DEV => DevBuilder::class,
-        self::BUILDER_TEST => TestBuilder::class,
+        self::BUILDER_TEST => IntegrationBuilder::class,
     ];
 
     /**

--- a/src/Docker/BuilderInterface.php
+++ b/src/Docker/BuilderInterface.php
@@ -11,6 +11,12 @@ namespace Magento\MagentoCloud\Docker;
 interface BuilderInterface
 {
     const DEFAULT_PHP_VERSION = '7.1';
+    const PHP_VERSIONS = [
+        '7.0',
+        '7.1',
+        '7.2',
+    ];
+
     const DEFAULT_NGINX_VERSION = 'latest';
     const DEFAULT_DB_VERSION = '10';
 

--- a/src/Docker/DevBuilder.php
+++ b/src/Docker/DevBuilder.php
@@ -39,10 +39,7 @@ class DevBuilder implements BuilderInterface
      */
     public function setPhpVersion(string $version)
     {
-        $this->setVersion(self::PHP_VERSION, $version, [
-            '7.0',
-            self::DEFAULT_PHP_VERSION,
-        ]);
+        $this->setVersion(self::PHP_VERSION, $version, self::PHP_VERSIONS);
     }
 
     /**
@@ -179,6 +176,7 @@ class DevBuilder implements BuilderInterface
         } else {
             $composeCacheDirectory = '~/.composer/cache';
         }
+
         return [
             'image' => sprintf(
                 'magento/magento-cloud-docker-php:%s-cli',

--- a/src/Docker/IntegrationBuilder.php
+++ b/src/Docker/IntegrationBuilder.php
@@ -11,7 +11,7 @@ use Magento\MagentoCloud\Config\RepositoryFactory;
 /**
  * @inheritdoc
  */
-class TestBuilder implements BuilderInterface
+class IntegrationBuilder implements BuilderInterface
 {
     /**
      * @var Repository
@@ -31,10 +31,7 @@ class TestBuilder implements BuilderInterface
      */
     public function setPhpVersion(string $version)
     {
-        $this->setVersion(self::PHP_VERSION, $version, [
-            '7.0',
-            self::DEFAULT_PHP_VERSION,
-        ]);
+        $this->setVersion(self::PHP_VERSION, $version, self::PHP_VERSIONS);
     }
 
     /**

--- a/src/Filesystem/DirectoryList.php
+++ b/src/Filesystem/DirectoryList.php
@@ -6,6 +6,7 @@
 namespace Magento\MagentoCloud\Filesystem;
 
 use Magento\MagentoCloud\Package\MagentoVersion;
+use Magento\MagentoCloud\Package\UndefinedPackageException;
 
 /**
  * Directory path configurations.
@@ -62,6 +63,7 @@ class DirectoryList
      * @param string $code
      * @param bool $relativePath
      * @return string
+     * @throws UndefinedPackageException
      */
     public function getPath(string $code, bool $relativePath = false): string
     {
@@ -105,6 +107,7 @@ class DirectoryList
 
     /**
      * @return string
+     * @throws UndefinedPackageException
      */
     public function getInit(): string
     {
@@ -113,6 +116,7 @@ class DirectoryList
 
     /**
      * @return string
+     * @throws UndefinedPackageException
      */
     public function getVar(): string
     {
@@ -121,6 +125,7 @@ class DirectoryList
 
     /**
      * @return string
+     * @throws UndefinedPackageException
      */
     public function getLog(): string
     {
@@ -129,6 +134,7 @@ class DirectoryList
 
     /**
      * @return string
+     * @throws UndefinedPackageException
      */
     public function getGeneratedCode(): string
     {
@@ -137,6 +143,7 @@ class DirectoryList
 
     /**
      * @return string
+     * @throws UndefinedPackageException
      */
     public function getGeneratedMetadata(): string
     {
@@ -147,6 +154,7 @@ class DirectoryList
      * Retrieves writable directories.
      *
      * @return array
+     * @throws UndefinedPackageException
      */
     public function getWritableDirectories(): array
     {
@@ -187,6 +195,7 @@ class DirectoryList
 
     /**
      * @return array
+     * @throws UndefinedPackageException
      */
     private function getDefaultVariadicDirectories(): array
     {

--- a/src/Filesystem/Driver/File.php
+++ b/src/Filesystem/Driver/File.php
@@ -211,7 +211,9 @@ class File
     public function isEmptyDirectory(string $path): bool
     {
         if ($this->isDirectory($path)) {
-            if (count(scandir($path)) > 2) {
+            $dirs = scandir($path, SCANDIR_SORT_NONE);
+
+            if ($dirs && count($dirs) > 2) {
                 return false;
             }
         }

--- a/src/Test/Integration/Cron22Test.php
+++ b/src/Test/Integration/Cron22Test.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Integration;
+
+use Magento\MagentoCloud\Command\Build;
+use Magento\MagentoCloud\Command\Deploy;
+use Magento\MagentoCloud\Application;
+use Magento\MagentoCloud\DB\ConnectionInterface;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * {@inheritdoc}
+ *
+ * @group php71
+ */
+class Cron22Test extends CronTest
+{
+    /**
+     * @inheritdoc
+     */
+    public static function setUpBeforeClass()
+    {
+        Bootstrap::getInstance()->run('2.2.0');
+    }
+
+    /**
+     * @return array
+     */
+    public function cronDataProvider(): array
+    {
+        return [
+            ['version' => '2.2.0', 'locale' => 'fr_FR'],
+            ['version' => '2.2.5', 'locale' => 'ar_KW'],
+            ['version' => '2.2.*', 'locale' => 'fr_FR'],
+        ];
+    }
+}

--- a/src/Test/Integration/CronTest.php
+++ b/src/Test/Integration/CronTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * {@inheritdoc}
  *
- * @group php71
+ * @group php72
  */
 class CronTest extends AbstractTest
 {
@@ -139,9 +139,7 @@ class CronTest extends AbstractTest
     public function cronDataProvider(): array
     {
         return [
-            ['version' => '2.2.0', 'locale' => 'en_US'],
-            ['version' => '2.2.2', 'locale' => 'ar_KW'],
-            ['version' => '@stable', 'locale' => 'fr_FR'],
+            ['version' => '~2.3.0', 'locale' => 'fr_FR'],
         ];
     }
 

--- a/src/Test/Integration/CronTest.php
+++ b/src/Test/Integration/CronTest.php
@@ -57,13 +57,14 @@ class CronTest extends AbstractTest
     }
 
     /**
-     * @param string $version
+     * @param null $version
      * @param string $locale
+     * @param string $stability
      * @dataProvider cronDataProvider
      */
-    public function testCron($version = null, $locale = 'en_US')
+    public function testCron($version = null, $locale = 'en_US', $stability = 'stable')
     {
-        $this->bootstrap->run($version);
+        $this->bootstrap->run($version, $stability);
         $this->bootstrap->execute(sprintf(
             'cd %s && composer install -n --no-dev --no-progress',
             $this->bootstrap->getSandboxDir()
@@ -139,7 +140,7 @@ class CronTest extends AbstractTest
     public function cronDataProvider(): array
     {
         return [
-            ['version' => '~2.3.0', 'locale' => 'fr_FR'],
+            ['version' => '~2.3.0', 'locale' => 'fr_FR', 'stability' => 'beta'],
         ];
     }
 

--- a/src/Test/Unit/Docker/IntegrationBuilderTest.php
+++ b/src/Test/Unit/Docker/IntegrationBuilderTest.php
@@ -8,17 +8,17 @@ namespace Magento\MagentoCloud\Test\Unit\Docker;
 use Illuminate\Contracts\Config\Repository;
 use Magento\MagentoCloud\Config\RepositoryFactory;
 use Magento\MagentoCloud\Docker\Service\ServiceInterface;
-use Magento\MagentoCloud\Docker\TestBuilder;
+use Magento\MagentoCloud\Docker\IntegrationBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @inheritdoc
  */
-class TestBuilderTest extends TestCase
+class IntegrationBuilderTest extends TestCase
 {
     /**
-     * @var TestBuilder
+     * @var IntegrationBuilder
      */
     private $builder;
 
@@ -44,7 +44,7 @@ class TestBuilderTest extends TestCase
             ->method('create')
             ->willReturn($this->configMock);
 
-        $this->builder = new TestBuilder(
+        $this->builder = new IntegrationBuilder(
             $this->repositoryFactoryMock
         );
     }
@@ -70,7 +70,7 @@ class TestBuilderTest extends TestCase
     {
         return [
             ['1.9'],
-            [TestBuilder::DEFAULT_NGINX_VERSION,],
+            [IntegrationBuilder::DEFAULT_NGINX_VERSION,],
         ];
     }
 
@@ -107,7 +107,7 @@ class TestBuilderTest extends TestCase
     {
         return [
             ['7.0'],
-            [TestBuilder::DEFAULT_PHP_VERSION,],
+            [IntegrationBuilder::DEFAULT_PHP_VERSION,],
         ];
     }
 
@@ -143,7 +143,7 @@ class TestBuilderTest extends TestCase
     public function setDbVersionDataProvider(): array
     {
         return [
-            [TestBuilder::DEFAULT_DB_VERSION],
+            [IntegrationBuilder::DEFAULT_DB_VERSION],
         ];
     }
 

--- a/src/Test/Unit/Filesystem/FileListTest.php
+++ b/src/Test/Unit/Filesystem/FileListTest.php
@@ -8,7 +8,7 @@ namespace Magento\MagentoCloud\Test\Unit\Filesystem;
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\SystemList;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,12 +22,12 @@ class FileListTest extends TestCase
     private $fileList;
 
     /**
-     * @var DirectoryList|Mock
+     * @var DirectoryList|MockObject
      */
     private $directoryListMock;
 
     /**
-     * @var SystemList|Mock
+     * @var SystemList|MockObject
      */
     private $systemListMock;
 
@@ -81,5 +81,15 @@ class FileListTest extends TestCase
     public function testGetMagentoComposer()
     {
         $this->assertSame('magento_root/composer.json', $this->fileList->getMagentoComposer());
+    }
+
+    public function testGetMagentoDockerCompose()
+    {
+        $this->assertSame('magento_root/docker-compose.yml', $this->fileList->getMagentoDockerCompose());
+    }
+
+    public function testGetToolsDockerCompose()
+    {
+        $this->assertSame('root/docker-compose.yml', $this->fileList->getToolsDockerCompose());
     }
 }

--- a/src/Test/Unit/Package/MagentoVersionTest.php
+++ b/src/Test/Unit/Package/MagentoVersionTest.php
@@ -10,8 +10,9 @@ use Composer\Semver\Comparator;
 use Composer\Semver\Semver;
 use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\Package\Manager;
+use Magento\MagentoCloud\Package\UndefinedPackageException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
 use Magento\MagentoCloud\Config\GlobalSection as GlobalConfig;
 
 /**
@@ -25,17 +26,17 @@ class MagentoVersionTest extends TestCase
     private $magentoVersion;
 
     /**
-     * @var Manager|Mock
+     * @var Manager|MockObject
      */
     private $managerMock;
 
     /**
-     * @var PackageInterface|Mock
+     * @var PackageInterface|MockObject
      */
     private $packageMock;
 
     /**
-     * @var GlobalConfig|Mock
+     * @var GlobalConfig|MockObject
      */
     private $globalConfigMock;
 
@@ -97,6 +98,8 @@ class MagentoVersionTest extends TestCase
 
     /**
      * Test getting the version number from the installed version of Magento.
+     *
+     * @throws UndefinedPackageException
      */
     public function testGetVersionFromBasePackage()
     {
@@ -111,6 +114,8 @@ class MagentoVersionTest extends TestCase
             ->method('getVersion')
             ->willReturn('2.2.1');
 
+        $this->assertSame('2.2.1', $this->magentoVersion->getVersion());
+        // Test lazy-load.
         $this->assertSame('2.2.1', $this->magentoVersion->getVersion());
     }
 

--- a/src/Test/Unit/Util/PasswordGeneratorTest.php
+++ b/src/Test/Unit/Util/PasswordGeneratorTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Util;
+
+use Magento\MagentoCloud\Util\PasswordGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @inheritdoc
+ */
+class PasswordGeneratorTest extends TestCase
+{
+    /**
+     * @var PasswordGenerator
+     */
+    private $generator;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->generator = new PasswordGenerator();
+    }
+
+    public function testGenerateSaltAndHash()
+    {
+        $this->generator->generateSaltAndHash('some password');
+    }
+
+    public function testGenerateRandomPassword()
+    {
+        $this->generator->generateRandomPassword();
+    }
+
+    public function testGenerateRandomString()
+    {
+        $this->generator->generateRandomString(5);
+    }
+}

--- a/tests/integration/Bootstrap.php
+++ b/tests/integration/Bootstrap.php
@@ -63,8 +63,9 @@ class Bootstrap
 
     /**
      * @param string $version
+     * @param string $stability
      */
-    public function run($version = '@stable')
+    public function run(string $version = '@stable', string $stability = 'stable')
     {
         $sandboxDir = $this->getSandboxDir();
 
@@ -82,7 +83,8 @@ class Bootstrap
         }
 
         $this->shell->execute(sprintf(
-            'composer create-project --no-dev --repository-url=%s %s %s %s',
+            'composer create-project --no-dev --stability=%s --repository-url=%s %s %s "%s"',
+            $stability,
             getenv('MAGENTO_REPO') ?: 'https://repo.magento.com/',
             getenv('MAGENTO_PROJECT') ?: 'magento/project-enterprise-edition',
             $sandboxDir,

--- a/tests/travis/script.sh
+++ b/tests/travis/script.sh
@@ -21,7 +21,7 @@ case $TEST_SUITE in
                 $BASH -c "${DIR_TOOLS}/vendor/bin/phpunit --group php70 --verbose --configuration ${DIR_TOOLS}/tests/integration"
                 ;;
             7.1)
-                $BASH -c "${DIR_TOOLS}/vendor/bin/phpunit --exclude-group php70 --exclude-group php72 --verbose --configuration ${DIR_TOOLS}/tests/integration"
+                $BASH -c "${DIR_TOOLS}/vendor/bin/phpunit --exclude-group php70,php72 --verbose --configuration ${DIR_TOOLS}/tests/integration"
                 ;;
             7.2)
                 $BASH -c "${DIR_TOOLS}/vendor/bin/phpunit --group php72 --verbose --configuration ${DIR_TOOLS}/tests/integration"

--- a/tests/travis/script.sh
+++ b/tests/travis/script.sh
@@ -21,7 +21,10 @@ case $TEST_SUITE in
                 $BASH -c "${DIR_TOOLS}/vendor/bin/phpunit --group php70 --verbose --configuration ${DIR_TOOLS}/tests/integration"
                 ;;
             7.1)
-                $BASH -c "${DIR_TOOLS}/vendor/bin/phpunit --exclude-group php70 --verbose --configuration ${DIR_TOOLS}/tests/integration"
+                $BASH -c "${DIR_TOOLS}/vendor/bin/phpunit --exclude-group php70 --exclude-group php72 --verbose --configuration ${DIR_TOOLS}/tests/integration"
+                ;;
+            7.2)
+                $BASH -c "${DIR_TOOLS}/vendor/bin/phpunit --group php72 --verbose --configuration ${DIR_TOOLS}/tests/integration"
                 ;;
         esac
         ;;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://magento2.atlassian.net/browse/MAGECLOUD-2837

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Change the template's `require` section to:
```
    "require": {
        "magento/product-enterprise-edition": "~2.3.0",
        "magento/ece-tools": "dev-MAGECLOUD-2837"
    }
```
2. Update `autoload` section:
```
        "psr-4": {
            "Magento\\Framework\\": "lib/internal/Magento/Framework/",
            "Magento\\Setup\\": "setup/src/Magento/Setup/",
            "Magento\\": "app/code/Magento/",
            "Zend\\Mvc\\Controller\\": "setup/src/Zend/Mvc/Controller/"
        },
```
3. https://jira.corp.magento.com/browse/MAGETWO-93955 (on step 1 use `./vendor/bin/ece-tools docker:build --php 7.2`)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
