### PR TITLE
MAGECLOUD-2841: Add RabbitMQ service to Docker build

### DIFF
--- a/dist/docker/config.php
+++ b/dist/docker/config.php
@@ -18,6 +18,14 @@ return [
                     'port' => '6379'
                 ]
             ],
+            'rabbitmq' => [
+                [
+                    'host' => 'rabbitmq',
+                    'port' => '5672',
+                    'username' => 'guest',
+                    'password' => 'guest',
+                ]
+            ],
         ]
     )),
     'MAGENTO_CLOUD_ROUTES' => base64_encode(json_encode(

--- a/src/Docker/DevBuilder.php
+++ b/src/Docker/DevBuilder.php
@@ -98,6 +98,7 @@ class DevBuilder implements BuilderInterface
             'services' => [
                 'varnish' => $this->serviceFactory->create(ServiceFactory::SERVICE_VARNISH)->get(),
                 'redis' => $this->serviceFactory->create(ServiceFactory::SERVICE_REDIS)->get(),
+                'rabbitmq' => $this->serviceFactory->create(ServiceFactory::SERVICE_RABBITMQ)->get(),
                 'fpm' => $this->getFpmService(),
                 /** For backward compatibility. */
                 'cli' => $this->getCliService(false),

--- a/src/Docker/Service/RabbitMqService.php
+++ b/src/Docker/Service/RabbitMqService.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Docker\Service;
+
+/**
+ * @inheritdoc
+ */
+class RabbitMqService implements ServiceInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function get(): array
+    {
+        return ['image' => 'rabbitmq:latest'];
+    }
+}

--- a/src/Docker/Service/ServiceFactory.php
+++ b/src/Docker/Service/ServiceFactory.php
@@ -14,6 +14,7 @@ class ServiceFactory
 {
     const SERVICE_VARNISH = 'varnish';
     const SERVICE_REDIS = 'redis';
+    const SERVICE_RABBITMQ = 'rabbitmq';
 
     /**
      * @var array
@@ -21,6 +22,7 @@ class ServiceFactory
     private static $map = [
         self::SERVICE_VARNISH => VarnishService::class,
         self::SERVICE_REDIS => RedisService::class,
+        self::SERVICE_RABBITMQ => RabbitMqService::class,
     ];
 
     /**

--- a/src/Test/Unit/Docker/Service/RabbitMqServiceTest.php
+++ b/src/Test/Unit/Docker/Service/RabbitMqServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Docker\Service;
+
+use Magento\MagentoCloud\Docker\Service\RabbitMqService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @inheritdoc
+ */
+class RabbitMqServiceTest extends TestCase
+{
+    /**
+     * @var RabbitMqService
+     */
+    private $service;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->service = new RabbitMqService();
+    }
+
+    public function testGet()
+    {
+        $this->assertSame(['image' => 'rabbitmq:latest'], $this->service->get());
+    }
+}


### PR DESCRIPTION
### Description

Add the official RabbitMQ image to `docker:build`

### Fixed Issues (if relevant)

[MAGECLOUD-2841](https://magento2.atlassian.net/browse/MAGECLOUD-2841)

### Manual testing scenarios

[MAGETWO-95758](https://jira.corp.magento.com/browse/MAGETWO-95758)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
