### PR TITLE
MAGECLOUD-2797: Warm up pages in post deploy does not use appropriate base url

### DIFF
--- a/src/Process/PostDeploy/WarmUp.php
+++ b/src/Process/PostDeploy/WarmUp.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\RequestException;
 use Magento\MagentoCloud\Config\Stage\PostDeployInterface;
 use Magento\MagentoCloud\Http\ClientFactory;
 use Magento\MagentoCloud\Http\RequestFactory;
+use Magento\MagentoCloud\Process\ProcessException;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Magento\MagentoCloud\Util\UrlManager;
 use Psr\Log\LoggerInterface;
@@ -73,24 +74,30 @@ class WarmUp implements ProcessInterface
         $client = $this->clientFactory->create();
         $promises = [];
 
-        foreach ($pages as $page) {
-            $url = rtrim($this->urlManager->getBaseUrl(), '/') . '/' . $page;
-            $request = $this->requestFactory->create('GET', $url);
+        try {
+            $baseUrl = rtrim($this->urlManager->getBaseUrl(), '/');
 
-            $promises[] = $client->sendAsync($request)->then(function () use ($url) {
-                $this->logger->info('Warmed up page: ' . $url);
-            }, function (RequestException $exception) use ($url) {
-                $context = $exception->getResponse()
-                    ? [
-                        'error' => $exception->getResponse()->getReasonPhrase(),
-                        'code' => $exception->getResponse()->getStatusCode(),
-                    ]
-                    : [];
+            foreach ($pages as $page) {
+                $url = $baseUrl . '/' . $page;
+                $request = $this->requestFactory->create('GET', $url);
 
-                $this->logger->error('Warming up failed: ' . $url, $context);
-            });
+                $promises[] = $client->sendAsync($request)->then(function () use ($url) {
+                    $this->logger->info('Warmed up page: ' . $url);
+                }, function (RequestException $exception) use ($url) {
+                    $context = $exception->getResponse()
+                        ? [
+                            'error' => $exception->getResponse()->getReasonPhrase(),
+                            'code' => $exception->getResponse()->getStatusCode(),
+                        ]
+                        : [];
+
+                    $this->logger->error('Warming up failed: ' . $url, $context);
+                });
+            }
+
+            \GuzzleHttp\Promise\unwrap($promises);
+        } catch (\Throwable $exception) {
+            throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }
-
-        \GuzzleHttp\Promise\unwrap($promises);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://magento2.atlassian.net/browse/MAGECLOUD-2797

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
**Must be executed in prod or staging with a domain name**

1. Modify .magento.env.yaml to warm up a few pages, the following works with sample data:
```
stage:
  global:
    SCD_ON_DEMAND: true
  post-deploy:
    WARM_UP_PAGES:
      - index.php/women/tops-women.html
      - index.php/women/bottoms-women.html
```
2. git add + commit + push the code
3. Wait for deploy to finish
4. Check post_deploy.log
5. post-deploy.log does not contain warm-up errors and works with correct URL

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
