### PR TITLE
MAGECLOUD-2862: Post_deploy Phase Cannot Start on PaaS due to Crons Running

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -256,7 +256,6 @@ class Container implements ContainerInterface
                         $this->container->make(DeployProcess\DeployStaticContent::class),
                         $this->container->make(DeployProcess\CompressStaticContent::class),
                         $this->container->make(DeployProcess\DisableGoogleAnalytics::class),
-                        $this->container->make(DeployProcess\EnableCron::class),
 
                         /**
                          * This process runs processes if only post_deploy hook is not configured.
@@ -270,6 +269,7 @@ class Container implements ContainerInterface
             ->give(function () {
                 return $this->container->makeWith(ProcessComposite::class, [
                     'processes' => [
+                        $this->container->make(PostDeployProcess\EnableCron::class),
                         $this->container->make(PostDeployProcess\Backup::class),
                         $this->container->make(PostDeployProcess\CleanCache::class),
                     ],
@@ -376,6 +376,7 @@ class Container implements ContainerInterface
                                 ],
                             ],
                         ]),
+                        $this->container->make(PostDeployProcess\EnableCron::class),
                         $this->container->make(PostDeployProcess\Backup::class),
                         $this->container->make(PostDeployProcess\CleanCache::class),
                         $this->container->make(PostDeployProcess\WarmUp::class),

--- a/src/Process/Deploy/DeployCompletion.php
+++ b/src/Process/Deploy/DeployCompletion.php
@@ -51,7 +51,7 @@ class DeployCompletion implements ProcessInterface
     {
         if ($this->hookChecker->isPostDeployHookEnabled()) {
             $this->logger->info(
-                'Post-deploy hook enabled. Cache cleaning and pre-warming operations ' .
+                'Post-deploy hook enabled. Cron enabling, cache cleaning and pre-warming operations ' .
                 'are postponed to post-deploy stage.'
             );
 

--- a/src/Process/PostDeploy/EnableCron.php
+++ b/src/Process/PostDeploy/EnableCron.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\MagentoCloud\Process\Deploy;
+namespace Magento\MagentoCloud\Process\PostDeploy;
 
 use Magento\MagentoCloud\Config\Deploy\Reader;
 use Magento\MagentoCloud\Config\Deploy\Writer;

--- a/src/Test/Unit/Process/PostDeploy/EnableCronTest.php
+++ b/src/Test/Unit/Process/PostDeploy/EnableCronTest.php
@@ -3,11 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\MagentoCloud\Test\Unit\Process\Deploy;
+namespace Magento\MagentoCloud\Test\Unit\Process\PostDeploy;
 
 use Magento\MagentoCloud\Config\Deploy\Reader;
 use Magento\MagentoCloud\Config\Deploy\Writer;
-use Magento\MagentoCloud\Process\Deploy\EnableCron;
+use Magento\MagentoCloud\Process\PostDeploy\EnableCron;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Moving starting cron to post deploy phase, if post-deploy hook is configured.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-2862

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Redeploy magento with configured post-deploy hook.
2. Check that `INFO: Enable cron` is in post-deploy hook.
3. Redeploy magento without post-deploy hook.
4. Check that `INFO: Enable cron` is in the end of deploy hook.

https://jira.corp.magento.com/browse/MAGETWO-93796

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
