### PR TITLE
MAGECLOUD-2844: Add Docker service for Elasticsearch

### DIFF
--- a/dist/docker/config.php
+++ b/dist/docker/config.php
@@ -18,6 +18,12 @@ return [
                     'port' => '6379'
                 ]
             ],
+            'elasticsearch' => [
+                [
+                    'host' => 'elasticsearch',
+                    'port' => '9200',
+                ],
+            ],
         ]
     )),
     'MAGENTO_CLOUD_ROUTES' => base64_encode(json_encode(

--- a/src/Docker/DevBuilder.php
+++ b/src/Docker/DevBuilder.php
@@ -95,6 +95,7 @@ class DevBuilder implements BuilderInterface
             'services' => [
                 'varnish' => $this->serviceFactory->create(ServiceFactory::SERVICE_VARNISH)->get(),
                 'redis' => $this->serviceFactory->create(ServiceFactory::SERVICE_REDIS)->get(),
+                'elasticsearch' => $this->serviceFactory->create(ServiceFactory::SERVICE_ELASTICSEARCH)->get(),
                 'fpm' => $this->getFpmService(),
                 /** For backward compatibility. */
                 'cli' => $this->getCliService(false),

--- a/src/Docker/Service/ElasticSearchService.php
+++ b/src/Docker/Service/ElasticSearchService.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Docker\Service;
+
+/**
+ * @inheritdoc
+ */
+class ElasticSearchService implements ServiceInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function get(): array
+    {
+        return [
+            'image' => 'magento/magento-cloud-docker-elasticsearch:5.2',
+        ];
+    }
+}

--- a/src/Docker/Service/ServiceFactory.php
+++ b/src/Docker/Service/ServiceFactory.php
@@ -14,6 +14,7 @@ class ServiceFactory
 {
     const SERVICE_VARNISH = 'varnish';
     const SERVICE_REDIS = 'redis';
+    const SERVICE_ELASTICSEARCH = 'elasticsearch';
 
     /**
      * @var array
@@ -21,6 +22,7 @@ class ServiceFactory
     private static $map = [
         self::SERVICE_VARNISH => VarnishService::class,
         self::SERVICE_REDIS => RedisService::class,
+        self::SERVICE_ELASTICSEARCH => ElasticSearchService::class,
     ];
 
     /**

--- a/src/Test/Unit/Docker/Service/ElasticSearchServiceTest.php
+++ b/src/Test/Unit/Docker/Service/ElasticSearchServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Docker\Service;
+
+use Magento\MagentoCloud\Docker\Service\ElasticSearchService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @inheritdoc
+ */
+class ElasticSearchServiceTest extends TestCase
+{
+    /**
+     * @var ElasticSearchService
+     */
+    private $service;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->service = new ElasticSearchService();
+    }
+
+    public function testGet()
+    {
+        $this->assertSame(['image' => 'magento/magento-cloud-docker-elasticsearch:5.2'], $this->service->get());
+    }
+}


### PR DESCRIPTION
### Description

Add builder for ElasticSearch 5.2 to ECE Tools.

### Fixed Issues (if relevant)

[MAGECLOUD-2844](https://magento2.atlassian.net/browse/MAGECLOUD-2844)

### Manual testing scenarios

[MAGETWO-95855](https://jira.corp.magento.com/browse/MAGETWO-95855)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
