### PR TITLE
MAGECLOUD-2710: Add a Variable for Disabling the DisableGoogleAnalytics Function

### DIFF
--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -170,7 +170,7 @@
 #              GENERATED_CODE_SYMLINK: false                                                                          #
 #######################################################################################################################
 # ENABLE_GOOGLE_ANALYTICS - Prevents the disabling of Google Analytics.  By default, Google Analytics is enabled only #
-# oon Production environments. Set this value to true to enable Google Analytics on other environments as well.       #
+# on Production environments. Set this value to true to enable Google Analytics on other environments as well.       #
 # Google Analytics is always enabled in Production.                                                                   #
 # Magento Version: 2.1.4 and later                                                                                    #
 # Default value: false                                                                                                #

--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -169,6 +169,18 @@
 #            deploy:                                                                                                  #
 #              GENERATED_CODE_SYMLINK: false                                                                          #
 #######################################################################################################################
+# ENABLE_GOOLGE_ANALYTICS - Prevents the disabling of Google Analytics.  By default, Google Analytics is only enabled #
+# on production environments.  Setting this to true will enable it on other environments as well.  Google Analytics   #
+# will always be enabled on production.                                                                               #
+# Magento Version: 2.1.4 and later                                                                                    #
+# Default value: false                                                                                                #
+# Possible values: true or false                                                                                      #
+# Stages: deploy                                                                                                      #
+# Example:                                                                                                            #
+#          stage:                                                                                                     #
+#            deploy:                                                                                                  #
+#              ENABLE_GOOLGE_ANALYTICS: false                                                                         #
+#######################################################################################################################
 # MYSQL_USE_SLAVE_CONNECTION - set to true to automatically use a read-only connection to the database                #
 #                              to receive read-only traffic on a non-master node. This improves performance           #
 #                              through load balancing, because only one node needs to handle read-write traffic.      #

--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -170,7 +170,7 @@
 #              GENERATED_CODE_SYMLINK: false                                                                          #
 #######################################################################################################################
 # ENABLE_GOOGLE_ANALYTICS - Prevents the disabling of Google Analytics.  By default, Google Analytics is enabled only #
-# on Production environments. Set this value to true to enable Google Analytics on other environments as well.       #
+# on Production environments. Set this value to true to enable Google Analytics on other environments as well.        #
 # Google Analytics is always enabled in Production.                                                                   #
 # Magento Version: 2.1.4 and later                                                                                    #
 # Default value: false                                                                                                #

--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -169,9 +169,9 @@
 #            deploy:                                                                                                  #
 #              GENERATED_CODE_SYMLINK: false                                                                          #
 #######################################################################################################################
-# ENABLE_GOOLGE_ANALYTICS - Prevents the disabling of Google Analytics.  By default, Google Analytics is only enabled #
-# on production environments.  Setting this to true will enable it on other environments as well.  Google Analytics   #
-# will always be enabled on production.                                                                               #
+# ENABLE_GOOGLE_ANALYTICS - Prevents the disabling of Google Analytics.  By default, Google Analytics is enabled only #
+# oon Production environments. Set this value to true to enable Google Analytics on other environments as well.       #
+# Google Analytics is always enabled in Production.                                                                   #
 # Magento Version: 2.1.4 and later                                                                                    #
 # Default value: false                                                                                                #
 # Possible values: true or false                                                                                      #
@@ -179,7 +179,7 @@
 # Example:                                                                                                            #
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #
-#              ENABLE_GOOLGE_ANALYTICS: false                                                                         #
+#              ENABLE_GOOGLE_ANALYTICS: false                                                                         #
 #######################################################################################################################
 # MYSQL_USE_SLAVE_CONNECTION - set to true to automatically use a read-only connection to the database                #
 #                              to receive read-only traffic on a non-master node. This improves performance           #

--- a/src/Config/Schema.php
+++ b/src/Config/Schema.php
@@ -321,6 +321,16 @@ class Schema
                     StageConfigInterface::STAGE_DEPLOY => [],
                 ],
             ],
+            DeployInterface::VAR_ENABLE_GOOLGE_ANALYTICS => [
+                self::SCHEMA_TYPE => ['boolean'],
+                self::SCHEMA_STAGE => [
+                    StageConfigInterface::STAGE_GLOBAL,
+                    StageConfigInterface::STAGE_DEPLOY
+                ],
+                self::SCHEMA_DEFAULT_VALUE => [
+                    StageConfigInterface::STAGE_DEPLOY => false,
+                ],
+            ],
             DeployInterface::VAR_GENERATED_CODE_SYMLINK => [
                 self::SCHEMA_TYPE => ['boolean'],
                 self::SCHEMA_STAGE => [

--- a/src/Config/Schema.php
+++ b/src/Config/Schema.php
@@ -321,7 +321,7 @@ class Schema
                     StageConfigInterface::STAGE_DEPLOY => [],
                 ],
             ],
-            DeployInterface::VAR_ENABLE_GOOLGE_ANALYTICS => [
+            DeployInterface::VAR_ENABLE_GOOGLE_ANALYTICS => [
                 self::SCHEMA_TYPE => ['boolean'],
                 self::SCHEMA_STAGE => [
                     StageConfigInterface::STAGE_GLOBAL,

--- a/src/Config/Stage/DeployInterface.php
+++ b/src/Config/Stage/DeployInterface.php
@@ -46,4 +46,9 @@ interface DeployInterface extends StageConfigInterface
      * @deprecated use SKIP_SCD instead
      */
     const VAR_DO_DEPLOY_STATIC_CONTENT = 'DO_DEPLOY_STATIC_CONTENT';
+
+    /**
+     * The variable responsible for enabling google analytics in environments other than prod.
+     */
+    const VAR_ENABLE_GOOLGE_ANALYTICS = 'ENABLE_GOOGLE_ANALYTICS';
 }

--- a/src/Config/Stage/DeployInterface.php
+++ b/src/Config/Stage/DeployInterface.php
@@ -50,5 +50,5 @@ interface DeployInterface extends StageConfigInterface
     /**
      * The variable responsible for enabling google analytics in environments other than prod.
      */
-    const VAR_ENABLE_GOOLGE_ANALYTICS = 'ENABLE_GOOGLE_ANALYTICS';
+    const VAR_ENABLE_GOOGLE_ANALYTICS = 'ENABLE_GOOGLE_ANALYTICS';
 }

--- a/src/Process/Deploy/DisableGoogleAnalytics.php
+++ b/src/Process/Deploy/DisableGoogleAnalytics.php
@@ -5,10 +5,12 @@
  */
 namespace Magento\MagentoCloud\Process\Deploy;
 
+use Magento\MagentoCloud\Config\Stage\DeployInterface;
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\DB\ConnectionInterface;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Psr\Log\LoggerInterface;
+use Magento\MagentoCloud\Config\GlobalSection as GlobalConfig;
 
 /**
  * @inheritdoc
@@ -31,15 +33,26 @@ class DisableGoogleAnalytics implements ProcessInterface
     private $environment;
 
     /**
+     * @var GlobalConfig
+     */
+    private $globalConfig;
+
+    /**
      * @param ConnectionInterface $connection
      * @param LoggerInterface $logger
      * @param Environment $environment
+     * @param GlobalConfig $globalConfig
      */
-    public function __construct(ConnectionInterface $connection, LoggerInterface $logger, Environment $environment)
-    {
+    public function __construct(
+        ConnectionInterface $connection,
+        LoggerInterface $logger,
+        Environment $environment,
+        GlobalConfig $globalConfig
+    ) {
         $this->connection = $connection;
         $this->logger = $logger;
         $this->environment = $environment;
+        $this->globalConfig = $globalConfig;
     }
 
     /**
@@ -47,7 +60,9 @@ class DisableGoogleAnalytics implements ProcessInterface
      */
     public function execute()
     {
-        if (!$this->environment->isMasterBranch()) {
+        if (!$this->environment->isMasterBranch() ||
+            $this->globalConfig->get(DeployInterface::VAR_ENABLE_GOOLGE_ANALYTICS)
+        ) {
             $this->logger->info('Disabling Google Analytics');
             $this->connection->affectingQuery(
                 "UPDATE `core_config_data` SET `value` = 0 WHERE `path` = 'google/analytics/active'"

--- a/src/Process/Deploy/DisableGoogleAnalytics.php
+++ b/src/Process/Deploy/DisableGoogleAnalytics.php
@@ -10,7 +10,7 @@ use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\DB\ConnectionInterface;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Psr\Log\LoggerInterface;
-use Magento\MagentoCloud\Config\GlobalSection as GlobalConfig;
+use Magento\MagentoCloud\Config\Stage\Deploy as DeployConfig;
 
 /**
  * @inheritdoc
@@ -33,26 +33,26 @@ class DisableGoogleAnalytics implements ProcessInterface
     private $environment;
 
     /**
-     * @var GlobalConfig
+     * @var DeployConfig
      */
-    private $globalConfig;
+    private $deployConfig;
 
     /**
      * @param ConnectionInterface $connection
      * @param LoggerInterface $logger
      * @param Environment $environment
-     * @param GlobalConfig $globalConfig
+     * @param DeployConfig $globalConfig
      */
     public function __construct(
         ConnectionInterface $connection,
         LoggerInterface $logger,
         Environment $environment,
-        GlobalConfig $globalConfig
+        DeployConfig $deployConfig
     ) {
         $this->connection = $connection;
         $this->logger = $logger;
         $this->environment = $environment;
-        $this->globalConfig = $globalConfig;
+        $this->deployConfig = $deployConfig;
     }
 
     /**
@@ -60,8 +60,8 @@ class DisableGoogleAnalytics implements ProcessInterface
      */
     public function execute()
     {
-        if (!$this->environment->isMasterBranch() ||
-            $this->globalConfig->get(DeployInterface::VAR_ENABLE_GOOLGE_ANALYTICS)
+        if (!$this->environment->isMasterBranch() &&
+            !$this->deployConfig->get(DeployInterface::VAR_ENABLE_GOOGLE_ANALYTICS)
         ) {
             $this->logger->info('Disabling Google Analytics');
             $this->connection->affectingQuery(

--- a/src/Test/Unit/Config/SchemaTest.php
+++ b/src/Test/Unit/Config/SchemaTest.php
@@ -68,6 +68,7 @@ class SchemaTest extends TestCase
                 DeployInterface::VAR_SCD_EXCLUDE_THEMES => '',
                 DeployInterface::VAR_REDIS_USE_SLAVE_CONNECTION => false,
                 DeployInterface::VAR_MYSQL_USE_SLAVE_CONNECTION => false,
+                DeployInterface::VAR_ENABLE_GOOGLE_ANALYTICS => false,
                 DeployInterface::VAR_SCD_MATRIX => [],
             ],
             $this->schema->getDefaults(StageConfigInterface::STAGE_DEPLOY)


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Adding capability to enable google analytics on non-production environments via a new configuration in the .magento.env.yaml

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. MAGECLOUD-2710: Add a Variable for Disabling the DisableGoogleAnalytics Function


### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. https://jira.corp.magento.com/browse/MAGETWO-95879

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
