### PR TITLE
MAGECLOUD-2919: Wrong Log Level for Starting/Finishing Deployment Phases

### DIFF
--- a/src/Command/Build/Generate.php
+++ b/src/Command/Build/Generate.php
@@ -71,9 +71,9 @@ class Generate extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            $this->logger->info('Starting generate command. ' . $this->packageManager->getPrettyInfo());
+            $this->logger->notice('Starting generate command. ' . $this->packageManager->getPrettyInfo());
             $this->process->execute();
-            $this->logger->info('Generate command completed.');
+            $this->logger->notice('Generate command completed.');
         } catch (\Throwable $e) {
             $this->logger->critical($e->getMessage());
 

--- a/src/Command/Build/Transfer.php
+++ b/src/Command/Build/Transfer.php
@@ -61,9 +61,9 @@ class Transfer extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            $this->logger->info('Starting transfer files.');
+            $this->logger->notice('Starting transfer files.');
             $this->process->execute();
-            $this->logger->info('Transfer completed.');
+            $this->logger->notice('Transfer completed.');
         } catch (\Throwable $e) {
             $this->logger->critical($e->getMessage());
 

--- a/src/Process/Build/ApplyPatches.php
+++ b/src/Process/Build/ApplyPatches.php
@@ -43,12 +43,13 @@ class ApplyPatches implements ProcessInterface
      */
     public function execute()
     {
-        $this->logger->info('Applying patches.');
+        $this->logger->notice('Applying patches.');
 
         try {
             $this->manager->applyAll();
         } catch (GenericException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }
+        $this->logger->notice('End of applying patches.');
     }
 }

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -31,7 +31,7 @@ class BackupData implements ProcessInterface
      */
     public function __construct(LoggerInterface $logger, ProcessInterface $processes)
     {
-        $this->loggerr = $logger;
+        $this->logger = $logger;
         $this->processes = $processes;
     }
 

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -40,7 +40,7 @@ class BackupData implements ProcessInterface
      */
     public function execute()
     {
-        $this->logger->info('Copying data to the ./init directory');
+         $this->logger->notice('Copying data to the ./init directory');
         $this->processes->execute();
         $this->logger->notice('End of copying data to the ./init directory');
     }

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -40,7 +40,7 @@ class BackupData implements ProcessInterface
      */
     public function execute()
     {
-         $this->logger->notice('Copying data to the ./init directory');
+        $this->logger->notice('Copying data to the ./init directory');
         $this->processes->execute();
         $this->logger->notice('End of copying data to the ./init directory');
     }

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -31,7 +31,7 @@ class BackupData implements ProcessInterface
      */
     public function __construct(LoggerInterface $logger, ProcessInterface $processes)
     {
-        $this->logger = $logger;
+        $this->loggerr = $logger;
         $this->processes = $processes;
     }
 

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -40,7 +40,8 @@ class BackupData implements ProcessInterface
      */
     public function execute()
     {
-        $this->logger->info('Copying data to the ./init directory');
+        $this->logger->notice('Copying data to the ./init directory');
         $this->processes->execute();
+        $this->logger->notice('End of copying data to the ./init directory');
     }
 }

--- a/src/Process/Build/BackupData.php
+++ b/src/Process/Build/BackupData.php
@@ -40,7 +40,7 @@ class BackupData implements ProcessInterface
      */
     public function execute()
     {
-        $this->logger->notice('Copying data to the ./init directory');
+        $this->logger->info('Copying data to the ./init directory');
         $this->processes->execute();
         $this->logger->notice('End of copying data to the ./init directory');
     }

--- a/src/Process/Build/DeployStaticContent.php
+++ b/src/Process/Build/DeployStaticContent.php
@@ -69,7 +69,9 @@ class DeployStaticContent implements ProcessInterface
             return;
         }
 
+        $this->logger->notice('Generating fresh static content');
         $this->process->execute();
         $this->flagManager->set(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD);
+        $this->logger->notice('End of generating fresh static content');
     }
 }

--- a/src/Process/Deploy/DeployStaticContent.php
+++ b/src/Process/Deploy/DeployStaticContent.php
@@ -97,7 +97,7 @@ class DeployStaticContent implements ProcessInterface
             $this->staticContentCleaner->clean();
         }
 
-        $this->logger->info('Generating fresh static content');
+        $this->logger->notice('Generating fresh static content');
         $this->process->execute();
     }
 }

--- a/src/Process/Deploy/DeployStaticContent.php
+++ b/src/Process/Deploy/DeployStaticContent.php
@@ -99,5 +99,6 @@ class DeployStaticContent implements ProcessInterface
 
         $this->logger->notice('Generating fresh static content');
         $this->process->execute();
+        $this->logger->notice('End of generating fresh static content');
     }
 }

--- a/src/Process/Deploy/InstallUpdate.php
+++ b/src/Process/Deploy/InstallUpdate.php
@@ -59,10 +59,10 @@ class InstallUpdate implements ProcessInterface
     {
         try {
             if (!$this->deployConfig->isInstalled()) {
-                $this->logger->info('Starting install.');
+                $this->logger->notice('Starting install.');
                 $this->installProcess->execute();
             } else {
-                $this->logger->info('Starting update.');
+                $this->logger->notice('Starting update.');
                 $this->updateProcess->execute();
             }
         } catch (GenericException $exception) {

--- a/src/Process/Deploy/InstallUpdate.php
+++ b/src/Process/Deploy/InstallUpdate.php
@@ -61,9 +61,11 @@ class InstallUpdate implements ProcessInterface
             if (!$this->deployConfig->isInstalled()) {
                 $this->logger->notice('Starting install.');
                 $this->installProcess->execute();
+                $this->logger->notice('End of install.');
             } else {
                 $this->logger->notice('Starting update.');
                 $this->updateProcess->execute();
+                $this->logger->notice('End of update.');
             }
         } catch (GenericException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);

--- a/src/Process/Deploy/PreDeploy.php
+++ b/src/Process/Deploy/PreDeploy.php
@@ -65,5 +65,6 @@ class PreDeploy implements ProcessInterface
         } catch (ShellException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }
+        $this->logger->notice('End of pre-deploy.');
     }
 }

--- a/src/Process/Deploy/PreDeploy.php
+++ b/src/Process/Deploy/PreDeploy.php
@@ -57,7 +57,7 @@ class PreDeploy implements ProcessInterface
      */
     public function execute()
     {
-        $this->logger->info('Starting pre-deploy.');
+        $this->logger->notice('Starting pre-deploy.');
         $this->process->execute();
 
         try {

--- a/src/Process/Deploy/PreDeploy/RestoreWritableDirectories.php
+++ b/src/Process/Deploy/PreDeploy/RestoreWritableDirectories.php
@@ -78,7 +78,7 @@ class RestoreWritableDirectories implements ProcessInterface
         }
 
         // Restore mounted directories.
-        $this->logger->info('Recoverable directories were copied back.');
+        $this->logger->notice('Recoverable directories were copied back.');
         $this->flagManager->delete(FlagManager::FLAG_REGENERATE);
     }
 }

--- a/src/Process/Deploy/PreDeploy/RestoreWritableDirectories.php
+++ b/src/Process/Deploy/PreDeploy/RestoreWritableDirectories.php
@@ -78,7 +78,7 @@ class RestoreWritableDirectories implements ProcessInterface
         }
 
         // Restore mounted directories.
-        $this->logger->notice('Recoverable directories were copied back.');
+        $this->logger->notice('Recoverable directories were copied back.');˚
         $this->flagManager->delete(FlagManager::FLAG_REGENERATE);
     }
 }

--- a/src/Process/Deploy/PreDeploy/RestoreWritableDirectories.php
+++ b/src/Process/Deploy/PreDeploy/RestoreWritableDirectories.php
@@ -78,7 +78,7 @@ class RestoreWritableDirectories implements ProcessInterface
         }
 
         // Restore mounted directories.
-        $this->logger->notice('Recoverable directories were copied back.');˚
+        $this->logger->notice('Recoverable directories were copied back.');
         $this->flagManager->delete(FlagManager::FLAG_REGENERATE);
     }
 }

--- a/src/Test/Unit/Command/Build/GenerateTest.php
+++ b/src/Test/Unit/Command/Build/GenerateTest.php
@@ -59,7 +59,7 @@ class GenerateTest extends TestCase
     public function testExecute()
     {
         $this->loggerMock->expects($this->exactly(2))
-            ->method('info')
+            ->method('notice')
             ->withConsecutive(
                 ['Starting generate command. Some info.'],
                 ['Generate command completed.']
@@ -88,7 +88,7 @@ class GenerateTest extends TestCase
             ->method('getPrettyInfo')
             ->willReturn('Some info.');
         $this->loggerMock->expects($this->once())
-            ->method('info')
+            ->method('notice')
             ->with('Starting generate command. Some info.');
         $this->loggerMock->expects($this->once())
             ->method('critical')

--- a/src/Test/Unit/Command/Build/TransferTest.php
+++ b/src/Test/Unit/Command/Build/TransferTest.php
@@ -51,7 +51,7 @@ class TransferTest extends TestCase
     public function testExecute()
     {
         $this->loggerMock->expects($this->exactly(2))
-            ->method('info')
+            ->method('notice')
             ->withConsecutive(
                 ['Starting transfer files.'],
                 ['Transfer completed.']
@@ -74,7 +74,7 @@ class TransferTest extends TestCase
     public function testExecuteWithException()
     {
         $this->loggerMock->expects($this->once())
-            ->method('info')
+            ->method('notice')
             ->with('Starting transfer files.');
         $this->loggerMock->expects($this->once())
             ->method('critical')

--- a/src/Test/Unit/Process/Build/ApplyPatchesTest.php
+++ b/src/Test/Unit/Process/Build/ApplyPatchesTest.php
@@ -50,9 +50,12 @@ class ApplyPatchesTest extends TestCase
 
     public function testExecute()
     {
-        $this->loggerMock->expects($this->once())
-            ->method('info')
-            ->with('Applying patches.');
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('notice')
+            ->withConsecutive(
+                ['Applying patches.'],
+                ['End of applying patches.']
+            );
         $this->managerMock->expects($this->once())
             ->method('applyAll');
 

--- a/src/Test/Unit/Process/Build/BackupDataTest.php
+++ b/src/Test/Unit/Process/Build/BackupDataTest.php
@@ -47,9 +47,12 @@ class BackupDataTest extends TestCase
 
     public function testExecute()
     {
-        $this->loggerMock->expects($this->once())
-            ->method('info')
-            ->with('Copying data to the ./init directory');
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('notice')
+            ->withConsecutive(
+                ['Copying data to the ./init directory'],
+                ['End of copying data to the ./init directory']
+            );
 
         $this->processesMock->expects($this->once())
             ->method('execute');

--- a/src/Test/Unit/Process/Deploy/DeployStaticContentTest.php
+++ b/src/Test/Unit/Process/Deploy/DeployStaticContentTest.php
@@ -94,9 +94,12 @@ class DeployStaticContentTest extends TestCase
             ->method('exists')
             ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
             ->willReturn(false);
-        $this->loggerMock->expects($this->once())
+        $this->loggerMock->expects($this->exactly(2))
             ->method('notice')
-            ->with('Generating fresh static content');
+            ->withConsecutive(
+                ['Generating fresh static content'],
+                ['End of generating fresh static content']
+            );
         $this->stageConfigMock->expects($this->any())
             ->method('get')
             ->willReturnMap([
@@ -121,10 +124,11 @@ class DeployStaticContentTest extends TestCase
             ->method('exists')
             ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
             ->willReturn(false);
-        $this->loggerMock->expects($this->once())
+        $this->loggerMock->expects($this->exactly(2))
             ->method('notice')
             ->withConsecutive(
-                ['Generating fresh static content']
+                ['Generating fresh static content'],
+                ['End of generating fresh static content']
             );
         $this->stageConfigMock->expects($this->any())
             ->method('get')

--- a/src/Test/Unit/Process/Deploy/DeployStaticContentTest.php
+++ b/src/Test/Unit/Process/Deploy/DeployStaticContentTest.php
@@ -95,7 +95,7 @@ class DeployStaticContentTest extends TestCase
             ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
             ->willReturn(false);
         $this->loggerMock->expects($this->once())
-            ->method('info')
+            ->method('notice')
             ->with('Generating fresh static content');
         $this->stageConfigMock->expects($this->any())
             ->method('get')
@@ -122,7 +122,7 @@ class DeployStaticContentTest extends TestCase
             ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
             ->willReturn(false);
         $this->loggerMock->expects($this->once())
-            ->method('info')
+            ->method('notice')
             ->withConsecutive(
                 ['Generating fresh static content']
             );
@@ -164,9 +164,9 @@ class DeployStaticContentTest extends TestCase
             ->willReturn(true);
         $this->loggerMock->expects($this->once())
             ->method('notice')
-            ->with('Skipping static content deploy. SCD on demand is enabled.');
-        $this->loggerMock->expects($this->never())
-            ->method('info');
+            ->withConsecutive(
+                ['Skipping static content deploy. SCD on demand is enabled.']
+            );
         $this->flagManagerMock->expects($this->never())
             ->method('exists');
         $this->staticContentCleanerMock->expects($this->once())

--- a/src/Test/Unit/Process/Deploy/InstallUpdateTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdateTest.php
@@ -61,9 +61,12 @@ class InstallUpdateTest extends TestCase
         $this->stateMock->expects($this->once())
             ->method('isInstalled')
             ->willReturn(false);
-        $this->loggerMock->expects($this->once())
+        $this->loggerMock->expects($this->exactly(2))
             ->method('notice')
-            ->with('Starting install.');
+            ->withConsecutive(
+                ['Starting install.'],
+                ['End of install.']
+            );
         $this->installProcessMock->expects($this->once())
             ->method('execute');
         $this->updateProcessMock->expects($this->never())
@@ -77,9 +80,12 @@ class InstallUpdateTest extends TestCase
         $this->stateMock->expects($this->once())
             ->method('isInstalled')
             ->willReturn(true);
-        $this->loggerMock->expects($this->once())
+        $this->loggerMock->expects($this->exactly(2))
             ->method('notice')
-            ->with('Starting update.');
+            ->withConsecutive(
+                ['Starting update.'],
+                ['End of update.']
+            );
         $this->installProcessMock->expects($this->never())
             ->method('execute');
         $this->updateProcessMock->expects($this->once())

--- a/src/Test/Unit/Process/Deploy/InstallUpdateTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdateTest.php
@@ -62,7 +62,7 @@ class InstallUpdateTest extends TestCase
             ->method('isInstalled')
             ->willReturn(false);
         $this->loggerMock->expects($this->once())
-            ->method('info')
+            ->method('notice')
             ->with('Starting install.');
         $this->installProcessMock->expects($this->once())
             ->method('execute');
@@ -78,7 +78,7 @@ class InstallUpdateTest extends TestCase
             ->method('isInstalled')
             ->willReturn(true);
         $this->loggerMock->expects($this->once())
-            ->method('info')
+            ->method('notice')
             ->with('Starting update.');
         $this->installProcessMock->expects($this->never())
             ->method('execute');

--- a/src/Test/Unit/Process/Deploy/PreDeploy/RestoreWritableDirectoriesTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeploy/RestoreWritableDirectoriesTest.php
@@ -84,7 +84,7 @@ class RestoreWritableDirectoriesTest extends TestCase
                 ['pub/media', 'copy']
             );
         $this->loggerMock->expects($this->once())
-            ->method('info')
+            ->method('notice')
             ->with('Recoverable directories were copied back.');
         $this->flagManagerMock->expects($this->once())
             ->method('delete')

--- a/src/Test/Unit/Process/Deploy/PreDeployTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeployTest.php
@@ -55,9 +55,12 @@ class PreDeployTest extends TestCase
 
     public function testExecute()
     {
-        $this->loggerMock->expects($this->once())
+        $this->loggerMock->expects($this->exactly(2))
             ->method('notice')
-            ->with('Starting pre-deploy.');
+            ->withConsecutive(
+                ['Starting pre-deploy.'],
+                ['End of pre-deploy.']
+            );
         $this->maintenanceModeSwitcher->expects($this->once())
             ->method('enable');
         $this->processMock->expects($this->once())

--- a/src/Test/Unit/Process/Deploy/PreDeployTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeployTest.php
@@ -56,7 +56,7 @@ class PreDeployTest extends TestCase
     public function testExecute()
     {
         $this->loggerMock->expects($this->once())
-            ->method('info')
+            ->method('notice')
             ->with('Starting pre-deploy.');
         $this->maintenanceModeSwitcher->expects($this->once())
             ->method('enable');


### PR DESCRIPTION

### Description
Increased log levels for all major sections to notice, added "End of" messages where appropriate.

### Fixed Issues (if relevant)
1. MAGECLOUD-2919

### Manual testing scenarios
1. Perform build to cloud with log level set to notice
2. Ensure all major phases /sub-phases of the process have a beginning / end notice message

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
