### PR TITLE
MAGECLOUD-2923: Whole Cron Configuration Is Removed from ENV.php on Every Deployment

### DIFF
--- a/src/Process/PostDeploy/EnableCron.php
+++ b/src/Process/PostDeploy/EnableCron.php
@@ -58,7 +58,7 @@ class EnableCron implements ProcessInterface
     {
         $this->logger->info('Enable cron');
         $config = $this->reader->read();
-        unset($config['cron']);
+        unset($config['cron']['enabled']);
         $this->writer->create($config);
     }
 }

--- a/src/Test/Unit/Process/PostDeploy/EnableCronTest.php
+++ b/src/Test/Unit/Process/PostDeploy/EnableCronTest.php
@@ -55,8 +55,8 @@ class EnableCronTest extends TestCase
 
     public function testExecute()
     {
-        $config = ['cron' => ['enabled' => 0], 'other_conf' => 'value'];
-        $configResult = ['other_conf' => 'value'];
+        $config = ['cron' => ['enabled' => 0, 'other_cron_config' => 1], 'other_conf' => 'value'];
+        $configResult = ['cron' => ['other_cron_config' => 1], 'other_conf' => 'value'];
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Enable cron');


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://magento2.atlassian.net/browse/MAGECLOUD-2923

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. https://jira.corp.magento.com/browse/MAGETWO-93796

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
