### PR TITLE
MAGECLOUD-2956: Exception during build phase: Undefined class constant 'PARSE_CONSTANT'

### DIFF
--- a/src/Config/Environment/Reader.php
+++ b/src/Config/Environment/Reader.php
@@ -54,8 +54,12 @@ class Reader implements ReaderInterface
         if ($this->config === null) {
             $path = $this->configFileList->getEnvConfig();
 
-            $this->config = !$this->file->isExists($path) ?
-                [] : (array)Yaml::parse($this->file->fileGetContents($path), Yaml::PARSE_CONSTANT);
+            if (!$this->file->isExists($path)) {
+                $this->config = [];
+            } else {
+                $parseFlag = defined(Yaml::class . '::PARSE_CONSTANT') ? Yaml::PARSE_CONSTANT : 0;
+                $this->config = (array)Yaml::parse($this->file->fileGetContents($path), $parseFlag);
+            }
         }
 
         return $this->config;

--- a/src/Test/Unit/Config/Environment/ReaderTest.php
+++ b/src/Test/Unit/Config/Environment/ReaderTest.php
@@ -11,6 +11,7 @@ use Magento\MagentoCloud\Filesystem\Driver\File;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * @inheritdoc
@@ -111,6 +112,10 @@ class ReaderTest extends TestCase
 
     public function testReadWithConstants()
     {
+        if (!defined(Yaml::class . '::PARSE_CONSTANT')) {
+            $this->markTestSkipped();
+        }
+
         $baseDir = __DIR__ . '/_file/';
 
         $this->configFileListMock->expects($this->once())


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-2956

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGETWO-95466

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
