### PR TITLE
MAGECLOUD-2925: Raise additional log message levels

### DIFF
--- a/src/Process/Build/CompileDi.php
+++ b/src/Process/Build/CompileDi.php
@@ -55,12 +55,13 @@ class CompileDi implements ProcessInterface
     {
         $verbosityLevel = $this->stageConfig->get(BuildInterface::VAR_VERBOSE_COMMANDS);
 
-        $this->logger->info('Running DI compilation');
+        $this->logger->notice('Running DI compilation');
 
         try {
             $this->shell->execute("php ./bin/magento setup:di:compile {$verbosityLevel} --ansi --no-interaction");
         } catch (ShellException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }
+        $this->logger->notice('End of running DI compilation');
     }
 }

--- a/src/Process/Build/RefreshModules.php
+++ b/src/Process/Build/RefreshModules.php
@@ -43,12 +43,13 @@ class RefreshModules implements ProcessInterface
      */
     public function execute()
     {
-        $this->logger->info('Reconciling installed modules with shared config.');
+        $this->logger->notice('Reconciling installed modules with shared config.');
 
         try {
             $this->config->refresh();
         } catch (ShellException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }
+        $this->logger->notice('End of reconciling modules.');
     }
 }

--- a/src/Process/ValidateConfiguration.php
+++ b/src/Process/ValidateConfiguration.php
@@ -44,7 +44,7 @@ class ValidateConfiguration implements ProcessInterface
      */
     public function execute()
     {
-        $this->logger->info('Validating configuration');
+        $this->logger->notice('Validating configuration');
 
         $maxLevel = 0;
         $messages = [];
@@ -70,7 +70,7 @@ class ValidateConfiguration implements ProcessInterface
             }
         }
 
-        $this->logger->info('End of validation');
+        $this->logger->notice('End of validation');
 
         if (!$messages || !$maxLevel) {
             return;

--- a/src/Test/Unit/Process/Build/CompileDiTest.php
+++ b/src/Test/Unit/Process/Build/CompileDiTest.php
@@ -61,9 +61,12 @@ class CompileDiTest extends TestCase
             ->method('get')
             ->with(BuildInterface::VAR_VERBOSE_COMMANDS)
             ->willReturn('-vvv');
-        $this->loggerMock->expects($this->once())
-            ->method('info')
-            ->with('Running DI compilation');
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('notice')
+            ->withConsecutive(
+                ['Running DI compilation'],
+                ['End of running DI compilation']
+            );
         $this->shellMock->expects($this->once())
             ->method('execute')
             ->with('php ./bin/magento setup:di:compile -vvv --ansi --no-interaction');

--- a/src/Test/Unit/Process/Build/RefreshModulesTest.php
+++ b/src/Test/Unit/Process/Build/RefreshModulesTest.php
@@ -48,9 +48,12 @@ class RefreshModulesTest extends TestCase
 
     public function testExecute()
     {
-        $this->loggerMock->expects($this->once())
-            ->method('info')
-            ->with('Reconciling installed modules with shared config.');
+        $this->loggerMock->expects($this->exactly(2))
+            ->method('notice')
+            ->withConsecutive(
+                ['Reconciling installed modules with shared config.'],
+                ['End of reconciling modules.']
+            );
         $this->configMock->expects($this->once())
             ->method('refresh');
 

--- a/src/Test/Unit/Process/ValidateConfigurationTest.php
+++ b/src/Test/Unit/Process/ValidateConfigurationTest.php
@@ -36,7 +36,7 @@ class ValidateConfigurationTest extends TestCase
         );
 
         $this->loggerMock->expects($this->exactly(2))
-            ->method('info')
+            ->method('notice')
             ->withConsecutive(
                 ['Validating configuration'],
                 ['End of validation']
@@ -70,7 +70,7 @@ class ValidateConfigurationTest extends TestCase
             ->method('validate');
 
         $this->loggerMock->expects($this->exactly(2))
-            ->method('info')
+            ->method('notice')
             ->withConsecutive(
                 ['Validating configuration'],
                 ['End of validation']
@@ -108,7 +108,7 @@ class ValidateConfigurationTest extends TestCase
             ->willReturn($warningResultMock);
 
         $this->loggerMock->expects($this->exactly(2))
-            ->method('info')
+            ->method('notice')
             ->withConsecutive(
                 ['Validating configuration'],
                 ['End of validation']
@@ -163,7 +163,7 @@ class ValidateConfigurationTest extends TestCase
             ->willReturn($this->createMock(Result\Success::class));
 
         $this->loggerMock->expects($this->exactly(2))
-            ->method('info')
+            ->method('notice')
             ->withConsecutive(
                 ['Validating configuration'],
                 ['End of validation']


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Increased to notice and add logging to bookend subsections of the build/deploy process.
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. MAGECLOUD-2925

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set MIN_LOGGING_LEVEL to notice in the .magento.env.yaml
2. Deploy to Magento Cloud

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
