### PR TITLE
MAGECLOUD-3003: Validation of DATABASE_CONFIGURATION is broken in ece-tools 2002.0.15 with magento 2.1.16

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -235,7 +235,6 @@ class Container implements ContainerInterface
                     'processes' => [
                         $this->container->make(DeployProcess\PreDeploy::class),
                         $this->container->make(DeployProcess\DisableCron::class),
-                        $this->container->make(DeployProcess\UnlockCronJobs::class),
                         $this->container->make(\Magento\MagentoCloud\Process\ValidateConfiguration::class, [
                             'validators' => [
                                 ValidatorInterface::LEVEL_CRITICAL => [
@@ -255,6 +254,7 @@ class Container implements ContainerInterface
                                 ],
                             ],
                         ]),
+                        $this->container->make(DeployProcess\UnlockCronJobs::class),
                         $this->container->make(DeployProcess\SetCryptKey::class),
                         $this->container->make(DeployProcess\InstallUpdate::class),
                         $this->container->make(DeployProcess\DeployStaticContent::class),


### PR DESCRIPTION
### Description
Deploy process fails with a critical mysql exception instead of validation error in case when mysql is not configured properly.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3003

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGETWO-97166 for versions 2.1.x and 2.2.x

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
