### PR TITLE
Bad constraint "symfony/yaml": "^2.3||^3.3"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "psr/container": "^1.0",
     "psr/log": "^1.0",
     "symfony/console": "^2.6||^4.0",
-    "symfony/yaml": "^2.3||^3.3",
+    "symfony/yaml": "^3.3",
     "twig/twig": "^1.0||^2.0"
   },
   "require-dev": {


### PR DESCRIPTION
Bad constraint `"symfony/yaml": "^2.3||^3.3"`

### Description
vendor/magento/ece-tools/src/Config/Environment/Reader.php on line 58 uses Yaml::PARSE_CONSTANT, but this constant is only introduced in Symphony Yaml v3.2
With the current constraints, composer allows us to run Yaml v2.8 due to a different module requiring "^2.0", but the build breaks on `vendor/bin/m2-ece-build`

Solutions it to remove ^2.3 from the ece-tools constraint.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
