### PR TITLE
MAGECLOUD-3046: [Cloud Docker] Remove deprecated CLI container

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -12,9 +12,13 @@ pull: ## Pull latest images
 down: ## Destroy containers
 	docker-compose down -v
 
-up: ## Re-create and start containers
+up: ## Destroy, re-create and start containers
 	docker-compose down -v
 	docker-compose up -d
+	docker-compose run build cloud-build
+	docker-compose run deploy cloud-deploy
+
+redeploy: ## Re-build and re-deploy application
 	docker-compose run build cloud-build
 	docker-compose run deploy cloud-deploy
 
@@ -25,4 +29,4 @@ start: ## Resume containers
 	docker-compose start
 
 bash: ## Connect to bash
-	docker-compose run cli bash
+	docker-compose run deploy bash

--- a/src/Docker/DevBuilder.php
+++ b/src/Docker/DevBuilder.php
@@ -129,8 +129,6 @@ class DevBuilder implements BuilderInterface
                 ],
             ]
         );
-        /** For backward compatibility. */
-        $services['cli'] = $this->getCliService($phpVersion, false, $cliDepends, 'cli.magento2.docker');
         $services['build'] = $this->getCliService($phpVersion, false, $cliDepends, 'build.magento2.docker');
         $services['deploy'] = $this->getCliService($phpVersion, true, $cliDepends, 'deploy.magento2.docker');
         $services['web'] = $this->serviceFactory->create(

--- a/src/Test/Unit/Docker/DevBuilderTest.php
+++ b/src/Test/Unit/Docker/DevBuilderTest.php
@@ -100,7 +100,6 @@ class DevBuilderTest extends TestCase
         $this->assertArrayNotHasKey('redis', $build['services']);
         $this->assertArrayNotHasKey('rabbitmq', $build['services']);
         $this->assertArrayNotHasKey('elasticsearch', $build['services']);
-        $this->assertArrayHasKey('cli', $build['services']);
         $this->assertArrayHasKey('build', $build['services']);
         $this->assertArrayHasKey('deploy', $build['services']);
         $this->assertArrayHasKey('db', $build['services']);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This PR removed deprecated CLI container to promote usage of Build and Deploy containers instead

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://magento2.atlassian.net/browse/MAGECLOUD-3046

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Deploy Magento using Cloud Docker
2. Check that frontend works correctly

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
