### PR TITLE
MAGECLOUD-3035: Can't connect to the database after setting up additional MySQL connection (Connecting MBI)

### DIFF
--- a/src/Process/Deploy/PreDeploy.php
+++ b/src/Process/Deploy/PreDeploy.php
@@ -7,7 +7,6 @@ namespace Magento\MagentoCloud\Process\Deploy;
 
 use Magento\MagentoCloud\Process\ProcessException;
 use Magento\MagentoCloud\Process\ProcessInterface;
-use Magento\MagentoCloud\Shell\ShellException;
 use Magento\MagentoCloud\Util\MaintenanceModeSwitcher;
 use Psr\Log\LoggerInterface;
 
@@ -62,7 +61,7 @@ class PreDeploy implements ProcessInterface
 
         try {
             $this->maintenanceModeSwitcher->enable();
-        } catch (ShellException $exception) {
+        } catch (\RuntimeException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }
         $this->logger->notice('End of pre-deploy.');

--- a/src/Test/Unit/Process/Deploy/PreDeployTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeployTest.php
@@ -68,4 +68,20 @@ class PreDeployTest extends TestCase
 
         $this->process->execute();
     }
+
+    /**
+     * @expectedException \Magento\MagentoCloud\Process\ProcessException
+     * @expectedExceptionMessage some error
+     */
+    public function testExecuteWithMaintenanceModeException()
+    {
+        $this->loggerMock->expects($this->exactly(1))
+            ->method('notice')
+            ->with('Starting pre-deploy.');
+        $this->maintenanceModeSwitcher->expects($this->once())
+            ->method('enable')
+            ->willThrowException(new \RuntimeException('some error'));
+
+        $this->process->execute();
+    }
 }

--- a/src/Test/Unit/Util/MaintenanceModeSwitcherTest.php
+++ b/src/Test/Unit/Util/MaintenanceModeSwitcherTest.php
@@ -107,7 +107,7 @@ class MaintenanceModeSwitcherTest extends TestCase
             ->willThrowException(new ShellException('command error'));
         $this->loggerMock->expects($this->once())
             ->method('warning')
-            ->with('Command maintenance:enable finished with an error. Creating maintenance flag flag manually.');
+            ->with('Command maintenance:enable finished with an error. Creating maintenance flag file manually.');
         $this->directoryListMock->expects($this->once())
             ->method('getVar')
             ->willReturn('/var');
@@ -155,7 +155,7 @@ class MaintenanceModeSwitcherTest extends TestCase
             ->willThrowException(new ShellException('command error'));
         $this->loggerMock->expects($this->once())
             ->method('warning')
-            ->with('Command maintenance:disable finished with an error. Deleting maintenance flag flag manually.');
+            ->with('Command maintenance:disable finished with an error. Deleting maintenance flag file manually.');
         $this->directoryListMock->expects($this->once())
             ->method('getVar')
             ->willReturn('/var');

--- a/src/Test/Unit/Util/MaintenanceModeSwitcherTest.php
+++ b/src/Test/Unit/Util/MaintenanceModeSwitcherTest.php
@@ -107,7 +107,7 @@ class MaintenanceModeSwitcherTest extends TestCase
             ->willThrowException(new ShellException('command error'));
         $this->loggerMock->expects($this->once())
             ->method('warning')
-            ->with('Command maintenance:enable finished with an error. Creating maintenance flag file manually.');
+            ->with('Command maintenance:enable finished with an error. Creating a maintenance flag file manually.');
         $this->directoryListMock->expects($this->once())
             ->method('getVar')
             ->willReturn('/var');
@@ -155,7 +155,7 @@ class MaintenanceModeSwitcherTest extends TestCase
             ->willThrowException(new ShellException('command error'));
         $this->loggerMock->expects($this->once())
             ->method('warning')
-            ->with('Command maintenance:disable finished with an error. Deleting maintenance flag file manually.');
+            ->with('Command maintenance:disable finished with an error. Deleting a maintenance flag file manually.');
         $this->directoryListMock->expects($this->once())
             ->method('getVar')
             ->willReturn('/var');

--- a/src/Test/Unit/Util/MaintenanceModeSwitcherTest.php
+++ b/src/Test/Unit/Util/MaintenanceModeSwitcherTest.php
@@ -130,38 +130,26 @@ class MaintenanceModeSwitcherTest extends TestCase
         $this->shellMock->expects($this->once())
             ->method('execute')
             ->with('php ./bin/magento maintenance:disable --ansi --no-interaction -v');
-        $this->loggerMock->expects($this->never())
-            ->method('warning');
-        $this->fileMock->expects($this->never())
-            ->method('deleteFile');
-        $this->directoryListMock->expects($this->never())
-            ->method('getVar');
 
         $this->maintenanceModeSwitcher->disable();
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage command error
+     */
     public function testDisableCommandException()
     {
         $this->stageConfigMock->expects($this->once())
             ->method('get')
             ->with(DeployInterface::VAR_VERBOSE_COMMANDS)
             ->willReturn('-v');
-        $this->loggerMock->expects($this->once())
-            ->method('notice')
-            ->with('Maintenance mode is disabled.');
+        $this->loggerMock->expects($this->never())
+            ->method('notice');
         $this->shellMock->expects($this->once())
             ->method('execute')
             ->with('php ./bin/magento maintenance:disable --ansi --no-interaction -v')
             ->willThrowException(new ShellException('command error'));
-        $this->loggerMock->expects($this->once())
-            ->method('warning')
-            ->with('Command maintenance:disable finished with an error. Deleting a maintenance flag file manually.');
-        $this->directoryListMock->expects($this->once())
-            ->method('getVar')
-            ->willReturn('/var');
-        $this->fileMock->expects($this->once())
-            ->method('deleteFile')
-            ->with('/var/.maintenance.flag');
 
         $this->maintenanceModeSwitcher->disable();
     }

--- a/src/Test/Unit/Util/MaintenanceModeSwitcherTest.php
+++ b/src/Test/Unit/Util/MaintenanceModeSwitcherTest.php
@@ -6,6 +6,9 @@
 namespace Magento\MagentoCloud\Test\Unit\Util;
 
 use Magento\MagentoCloud\Config\Stage\DeployInterface;
+use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Shell\ShellException;
 use Magento\MagentoCloud\Shell\ShellInterface;
 use Magento\MagentoCloud\Util\MaintenanceModeSwitcher;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -33,6 +36,16 @@ class MaintenanceModeSwitcherTest extends TestCase
     private $stageConfigMock;
 
     /**
+     * @var File|MockObject
+     */
+    private $fileMock;
+
+    /**
+     * @var DirectoryList|MockObject
+     */
+    private $directoryListMock;
+
+    /**
      * @var MaintenanceModeSwitcher
      */
     private $maintenanceModeSwitcher;
@@ -45,11 +58,15 @@ class MaintenanceModeSwitcherTest extends TestCase
         $this->shellMock = $this->getMockForAbstractClass(ShellInterface::class);
         $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
         $this->stageConfigMock = $this->getMockForAbstractClass(DeployInterface::class);
+        $this->fileMock = $this->createMock(File::class);
+        $this->directoryListMock = $this->createMock(DirectoryList::class);
 
         $this->maintenanceModeSwitcher = new MaintenanceModeSwitcher(
             $this->shellMock,
             $this->loggerMock,
-            $this->stageConfigMock
+            $this->stageConfigMock,
+            $this->fileMock,
+            $this->directoryListMock
         );
     }
 
@@ -65,6 +82,38 @@ class MaintenanceModeSwitcherTest extends TestCase
         $this->shellMock->expects($this->once())
             ->method('execute')
             ->with('php ./bin/magento maintenance:enable --ansi --no-interaction -v');
+        $this->loggerMock->expects($this->never())
+            ->method('warning');
+        $this->fileMock->expects($this->never())
+            ->method('touch');
+        $this->directoryListMock->expects($this->never())
+            ->method('getVar');
+
+        $this->maintenanceModeSwitcher->enable();
+    }
+
+    public function testEnableCommandException()
+    {
+        $this->stageConfigMock->expects($this->once())
+            ->method('get')
+            ->with(DeployInterface::VAR_VERBOSE_COMMANDS)
+            ->willReturn('-v');
+        $this->loggerMock->expects($this->once())
+            ->method('notice')
+            ->with('Enabling Maintenance mode');
+        $this->shellMock->expects($this->once())
+            ->method('execute')
+            ->with('php ./bin/magento maintenance:enable --ansi --no-interaction -v')
+            ->willThrowException(new ShellException('command error'));
+        $this->loggerMock->expects($this->once())
+            ->method('warning')
+            ->with('Command maintenance:enable finished with an error. Creating maintenance flag flag manually.');
+        $this->directoryListMock->expects($this->once())
+            ->method('getVar')
+            ->willReturn('/var');
+        $this->fileMock->expects($this->once())
+            ->method('touch')
+            ->with('/var/.maintenance.flag');
 
         $this->maintenanceModeSwitcher->enable();
     }
@@ -81,6 +130,38 @@ class MaintenanceModeSwitcherTest extends TestCase
         $this->shellMock->expects($this->once())
             ->method('execute')
             ->with('php ./bin/magento maintenance:disable --ansi --no-interaction -v');
+        $this->loggerMock->expects($this->never())
+            ->method('warning');
+        $this->fileMock->expects($this->never())
+            ->method('deleteFile');
+        $this->directoryListMock->expects($this->never())
+            ->method('getVar');
+
+        $this->maintenanceModeSwitcher->disable();
+    }
+
+    public function testDisableCommandException()
+    {
+        $this->stageConfigMock->expects($this->once())
+            ->method('get')
+            ->with(DeployInterface::VAR_VERBOSE_COMMANDS)
+            ->willReturn('-v');
+        $this->loggerMock->expects($this->once())
+            ->method('notice')
+            ->with('Maintenance mode is disabled.');
+        $this->shellMock->expects($this->once())
+            ->method('execute')
+            ->with('php ./bin/magento maintenance:disable --ansi --no-interaction -v')
+            ->willThrowException(new ShellException('command error'));
+        $this->loggerMock->expects($this->once())
+            ->method('warning')
+            ->with('Command maintenance:disable finished with an error. Deleting maintenance flag flag manually.');
+        $this->directoryListMock->expects($this->once())
+            ->method('getVar')
+            ->willReturn('/var');
+        $this->fileMock->expects($this->once())
+            ->method('deleteFile')
+            ->with('/var/.maintenance.flag');
 
         $this->maintenanceModeSwitcher->disable();
     }

--- a/src/Util/MaintenanceModeSwitcher.php
+++ b/src/Util/MaintenanceModeSwitcher.php
@@ -95,7 +95,7 @@ class MaintenanceModeSwitcher
      * Disable maintenance mode
      *
      * @return void
-     * @throws \RuntimeException
+     * @throws \RuntimeException In case when maintenance:disable finished with an error
      */
     public function disable()
     {
@@ -105,10 +105,7 @@ class MaintenanceModeSwitcher
                 $this->stageConfig->get(DeployInterface::VAR_VERBOSE_COMMANDS)
             ));
         } catch (ShellException $e) {
-            $this->logger->warning(
-                'Command maintenance:disable finished with an error. Deleting a maintenance flag file manually.'
-            );
-            $this->file->deleteFile($this->getMaintenanceFlagPath());
+            throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
         $this->logger->notice('Maintenance mode is disabled.');
     }

--- a/src/Util/MaintenanceModeSwitcher.php
+++ b/src/Util/MaintenanceModeSwitcher.php
@@ -84,8 +84,9 @@ class MaintenanceModeSwitcher
                 $this->stageConfig->get(DeployInterface::VAR_VERBOSE_COMMANDS)
             ));
         } catch (ShellException $e) {
-            $this->logger->warning('Command maintenance:enable finished with an error: ' . $e->getMessage());
-            $this->logger->notice('Setting maintenance flag manually.');
+            $this->logger->warning(
+                'Command maintenance:enable finished with an error. Creating maintenance flag flag manually.'
+            );
             $this->file->touch($this->getMaintenanceFlagPath());
         }
     }
@@ -104,8 +105,9 @@ class MaintenanceModeSwitcher
                 $this->stageConfig->get(DeployInterface::VAR_VERBOSE_COMMANDS)
             ));
         } catch (ShellException $e) {
-            $this->logger->warning('Command maintenance:disable finished with an error: ' . $e->getMessage());
-            $this->logger->notice('Deleting maintenance flag manually.');
+            $this->logger->warning(
+                'Command maintenance:disable finished with an error. Deleting maintenance flag flag manually.'
+            );
             $this->file->deleteFile($this->getMaintenanceFlagPath());
         }
         $this->logger->notice('Maintenance mode is disabled.');

--- a/src/Util/MaintenanceModeSwitcher.php
+++ b/src/Util/MaintenanceModeSwitcher.php
@@ -85,7 +85,7 @@ class MaintenanceModeSwitcher
             ));
         } catch (ShellException $e) {
             $this->logger->warning(
-                'Command maintenance:enable finished with an error. Creating maintenance flag flag manually.'
+                'Command maintenance:enable finished with an error. Creating maintenance flag file manually.'
             );
             $this->file->touch($this->getMaintenanceFlagPath());
         }
@@ -106,7 +106,7 @@ class MaintenanceModeSwitcher
             ));
         } catch (ShellException $e) {
             $this->logger->warning(
-                'Command maintenance:disable finished with an error. Deleting maintenance flag flag manually.'
+                'Command maintenance:disable finished with an error. Deleting maintenance flag file manually.'
             );
             $this->file->deleteFile($this->getMaintenanceFlagPath());
         }

--- a/src/Util/MaintenanceModeSwitcher.php
+++ b/src/Util/MaintenanceModeSwitcher.php
@@ -85,7 +85,7 @@ class MaintenanceModeSwitcher
             ));
         } catch (ShellException $e) {
             $this->logger->warning(
-                'Command maintenance:enable finished with an error. Creating maintenance flag file manually.'
+                'Command maintenance:enable finished with an error. Creating a maintenance flag file manually.'
             );
             $this->file->touch($this->getMaintenanceFlagPath());
         }
@@ -106,7 +106,7 @@ class MaintenanceModeSwitcher
             ));
         } catch (ShellException $e) {
             $this->logger->warning(
-                'Command maintenance:disable finished with an error. Deleting maintenance flag file manually.'
+                'Command maintenance:disable finished with an error. Deleting a maintenance flag file manually.'
             );
             $this->file->deleteFile($this->getMaintenanceFlagPath());
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3035

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGETWO-97665

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
