### PR TITLE
#409 replaced redis-cli with PHP PECL Redis class usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - echo "COMPOSER_MAGENTO_USERNAME=${REPO_USERNAME}" >> ./docker/composer.env
   - echo "COMPOSER_MAGENTO_PASSWORD=${REPO_PASSWORD}" >> ./docker/composer.env
   - if [ $XDEBUG == "true" ]; then echo "PHP_ENABLE_XDEBUG=true" >> ./docker/global.env; fi;
-  - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - pecl install redis
 
 install:
   - composer update -n --no-suggest

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - echo "COMPOSER_MAGENTO_USERNAME=${REPO_USERNAME}" >> ./docker/composer.env
   - echo "COMPOSER_MAGENTO_PASSWORD=${REPO_PASSWORD}" >> ./docker/composer.env
   - if [ $XDEBUG == "true" ]; then echo "PHP_ENABLE_XDEBUG=true" >> ./docker/global.env; fi;
-  - before_script: echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 install:
   - composer update -n --no-suggest

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
   - echo "COMPOSER_MAGENTO_USERNAME=${REPO_USERNAME}" >> ./docker/composer.env
   - echo "COMPOSER_MAGENTO_PASSWORD=${REPO_PASSWORD}" >> ./docker/composer.env
   - if [ $XDEBUG == "true" ]; then echo "PHP_ENABLE_XDEBUG=true" >> ./docker/global.env; fi;
+  - before_script: echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 install:
   - composer update -n --no-suggest

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - echo "COMPOSER_MAGENTO_USERNAME=${REPO_USERNAME}" >> ./docker/composer.env
   - echo "COMPOSER_MAGENTO_PASSWORD=${REPO_PASSWORD}" >> ./docker/composer.env
   - if [ $XDEBUG == "true" ]; then echo "PHP_ENABLE_XDEBUG=true" >> ./docker/global.env; fi;
-  - pecl install redis
+  - printf "\n" | pecl install redis
 
 install:
   - composer update -n --no-suggest

--- a/src/Process/Deploy/PreDeploy/CleanRedisCache.php
+++ b/src/Process/Deploy/PreDeploy/CleanRedisCache.php
@@ -57,9 +57,12 @@ class CleanRedisCache implements ProcessInterface
         if (count($redis) > 0) {
             $redisHost = $redis[0]['host'];
             $redisPort = $redis[0]['port'];
-            $redisCacheDb = '1';
+            $redisCacheDb = 1;
             $this->logger->info('Clearing redis cache');
-            $this->shell->execute("redis-cli -h $redisHost -p $redisPort -n $redisCacheDb flushdb");
+            $redisClient = new \Redis();
+            $redisClient->connect($redisHost, $redisPort);
+            $redisClient->select($redisCacheDb);
+            $redisClient->flushDB();
         }
     }
 }

--- a/src/Test/Unit/Process/Deploy/PreDeploy/CleanRedisCacheTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeploy/CleanRedisCacheTest.php
@@ -91,4 +91,3 @@ class CleanRedisCacheTest extends TestCase
         $this->process->execute();
     }
 }
-

--- a/src/Test/Unit/Process/Deploy/PreDeploy/CleanRedisCacheTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeploy/CleanRedisCacheTest.php
@@ -20,7 +20,7 @@ class CleanRedisCacheTest extends TestCase
     /**
      * @var ShellInterface|Mock
      */
-    private $shellMock;
+    private $redisMock;
 
     /**
      * @var Environment|Mock
@@ -39,7 +39,7 @@ class CleanRedisCacheTest extends TestCase
 
     protected function setUp()
     {
-        $this->shellMock = $this->getMockBuilder(ShellInterface::class)
+        $this->redisMock = $this->getMockBuilder(\Redis::class)
             ->getMockForAbstractClass();
         $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
             ->getMockForAbstractClass();
@@ -47,7 +47,7 @@ class CleanRedisCacheTest extends TestCase
 
         $this->process = new CleanRedisCache(
             $this->loggerMock,
-            $this->shellMock,
+            $this->redisMock,
             $this->environmentMock
         );
     }
@@ -68,9 +68,11 @@ class CleanRedisCacheTest extends TestCase
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Clearing redis cache');
-        $this->shellMock->expects($this->once())
-            ->method('execute')
-            ->with('redis-cli -h localhost -p 1234 -n 1 flushdb');
+        $this->redisMock->expects($this->once())
+            ->method('connect')
+            ->with('localhost', 1234);
+        $this->redisMock->expects($this->once())
+            ->method('flushDB');
 
         $this->process->execute();
     }
@@ -83,9 +85,10 @@ class CleanRedisCacheTest extends TestCase
             ->willReturn([]);
         $this->loggerMock->expects($this->never())
             ->method('info');
-        $this->shellMock->expects($this->never())
-            ->method('execute');
+        $this->redisMock->expects($this->never())
+            ->method('connect');
 
         $this->process->execute();
     }
 }
+


### PR DESCRIPTION
When defining the Redis connection in the cloud environment variable MAGENTO_CLOUD_RELATIONSHIPS and run `vendor/bin/ece-tools deploy` the class `Magento\MagentoCloud\Process\Deploy\PreDeploy\CleanRedisCache` will try to execute a shell command using `redis-cli`.

Since we use a different Docker setup this binary is missing and the deployment fails. IMHO `redis-cli` is an unnecessary dependency of ece-tools and should be replaced by using `Redis` class like Magento/CmRedis do to avoid additional dependencies.