### PR TITLE
MAGECLOUD-2882: Duplication beetwen SCD_EXCLUDE_THEME and SCD_MATRIX

### DIFF
--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -9,17 +9,6 @@
 #            global:                                                                                                  #
 #              SCD_THREADS: 2                                                                                         #
 #######################################################################################################################
-# SCD_EXCLUDE_THEMES - this option does not generate static content for the specified theme location(s).              #
-#                      This is helpful when static content deployment occurs during the build/deploy phase.           #
-#                      Use commas to separate multiple theme locations.                                               #
-# Magento Version: 2.1.4 and later                                                                                    #
-# Default value: empty line                                                                                           #
-# Stages: global, build and deploy                                                                                    #
-# Example:                                                                                                            #
-#          stage:                                                                                                     #
-#            build:                                                                                                   #
-#              SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme"                                                   #
-#######################################################################################################################
 # SCD_MATRIX - allows you to configure multiple locales per theme as long as the theme is not excluded using          #
 #              the SCD_EXCLUDE_THEMES variable during deployment. This is ideal if you want to speed up the           #
 #              deployment process by reducing the amount of unnecessary theme files. For example, you can deploy      #
@@ -41,6 +30,18 @@
 #            deploy:                                                                                                  #
 #              SCD_MATRIX:                                                                                            #
 #                "magento/backend": []                                                                                #
+#######################################################################################################################
+# SCD_EXCLUDE_THEMES - Deprecated use SCD_MATRIX instead.                                                             #
+#                      This option does not generate static content for the specified theme location(s).              #
+#                      This is helpful when static content deployment occurs during the build/deploy phase.           #
+#                      Use commas to separate multiple theme locations.                                               #
+# Magento Version: 2.1.4 and later                                                                                    #
+# Default value: empty line                                                                                           #
+# Stages: global, build and deploy                                                                                    #
+# Example:                                                                                                            #
+#          stage:                                                                                                     #
+#            build:                                                                                                   #
+#              SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme"                                                   #
 #######################################################################################################################
 # SCD_STRATEGY - allows you to customize the deployment strategy for static content.                                  #
 # Magento Version: 2.2.0 and later (Magento 2.1.* supports the standard strategy only)                                #

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -179,6 +179,7 @@ class Container implements ContainerInterface
                                 ValidatorInterface::LEVEL_WARNING => [
                                     $this->container->make(ConfigValidator\Build\ConfigFileExists::class),
                                     $this->container->make(ConfigValidator\Build\DeprecatedBuildOptionsIni::class),
+                                    $this->container->make(ConfigValidator\Build\StageConfigDeprecatedVariables::class),
                                     $this->container->make(ConfigValidator\Build\ModulesExists::class),
                                     $this->container->make(ConfigValidator\Build\AppropriateVersion::class),
                                     $this->container->make(ConfigValidator\Build\ScdOptionsIgnorance::class),

--- a/src/Config/Schema.php
+++ b/src/Config/Schema.php
@@ -18,6 +18,7 @@ class Schema
     const SCHEMA_STAGE = 'stage';
     const SCHEMA_SYSTEM = 'system';
     const SCHEMA_DEFAULT_VALUE = 'default_values';
+    const SCHEMA_REPLACEMENT = 'replacement';
 
     /**
      * @var array
@@ -425,6 +426,20 @@ class Schema
                     StageConfigInterface::STAGE_GLOBAL => 'SAMEORIGIN'
                 ]
             ]
+        ];
+    }
+
+    /**
+     * Returns array of deprecated variables.
+     *
+     * @return array
+     */
+    public function getDeprecatedSchema()
+    {
+        return [
+            StageConfigInterface::VAR_SCD_EXCLUDE_THEMES => [
+                self::SCHEMA_REPLACEMENT => StageConfigInterface::VAR_SCD_MATRIX,
+            ],
         ];
     }
 }

--- a/src/Config/StageConfigInterface.php
+++ b/src/Config/StageConfigInterface.php
@@ -37,7 +37,7 @@ interface StageConfigInterface
     const VAR_X_FRAME_CONFIGURATION = 'X_FRAME_CONFIGURATION';
 
     /**
-     * @deprecated use SCD_MATRIX instead
+     * @deprecated use SCD_MATRIX instead.
      */
     const VAR_SCD_EXCLUDE_THEMES = 'SCD_EXCLUDE_THEMES';
 

--- a/src/Config/StageConfigInterface.php
+++ b/src/Config/StageConfigInterface.php
@@ -29,13 +29,17 @@ interface StageConfigInterface
     const VAR_SCD_COMPRESSION_LEVEL = 'SCD_COMPRESSION_LEVEL';
     const VAR_SCD_STRATEGY = 'SCD_STRATEGY';
     const VAR_SCD_THREADS = 'SCD_THREADS';
-    const VAR_SCD_EXCLUDE_THEMES = 'SCD_EXCLUDE_THEMES';
     const VAR_SKIP_SCD = 'SKIP_SCD';
     const VAR_VERBOSE_COMMANDS = 'VERBOSE_COMMANDS';
     const VAR_SCD_ON_DEMAND = 'SCD_ON_DEMAND';
     const VAR_SKIP_HTML_MINIFICATION = 'SKIP_HTML_MINIFICATION';
     const VAR_SCD_MATRIX = 'SCD_MATRIX';
     const VAR_X_FRAME_CONFIGURATION = 'X_FRAME_CONFIGURATION';
+
+    /**
+     * @deprecated use SCD_MATRIX instead
+     */
+    const VAR_SCD_EXCLUDE_THEMES = 'SCD_EXCLUDE_THEMES';
 
     /**
      * Environment variables.

--- a/src/Config/Validator/Build/StageConfigDeprecatedVariables.php
+++ b/src/Config/Validator/Build/StageConfigDeprecatedVariables.php
@@ -78,7 +78,7 @@ class StageConfigDeprecatedVariables implements ValidatorInterface
 
         if ($errors) {
             return $this->resultFactory->create(Validator\ResultInterface::ERROR, [
-                'error' => 'Some configuration in your .magento.env.yaml file is deprecated.',
+                'error' => 'Some configurations in your .magento.env.yaml file is deprecated.',
                 'suggestion' => implode(PHP_EOL, $errors),
             ]);
         }

--- a/src/Config/Validator/Build/StageConfigDeprecatedVariables.php
+++ b/src/Config/Validator/Build/StageConfigDeprecatedVariables.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Config\Validator\Build;
+
+use Magento\MagentoCloud\Config\Schema;
+use Magento\MagentoCloud\Config\StageConfigInterface;
+use Magento\MagentoCloud\Config\Validator;
+use Magento\MagentoCloud\Config\ValidatorInterface;
+use Magento\MagentoCloud\Config\Environment\Reader as EnvironmentReader;
+
+/**
+ * Validates on using deprecated variables in .magento.env.yaml.
+ */
+class StageConfigDeprecatedVariables implements ValidatorInterface
+{
+    /**
+     * @var EnvironmentReader
+     */
+    private $environmentReader;
+
+    /**
+     * @var Validator\ResultFactory
+     */
+    private $resultFactory;
+
+    /**
+     * @var Schema
+     */
+    private $schema;
+
+    /**
+     * @param EnvironmentReader $environmentReader
+     * @param Validator\ResultFactory $resultFactory
+     * @param Schema $schema
+     */
+    public function __construct(
+        EnvironmentReader $environmentReader,
+        Validator\ResultFactory $resultFactory,
+        Schema $schema
+    ) {
+        $this->environmentReader = $environmentReader;
+        $this->resultFactory = $resultFactory;
+        $this->schema = $schema;
+    }
+
+    /**
+     * Validates if .magento.env.yaml contains deprecated variables described in @see Schema::getDeprecatedSchema()
+     *
+     * @inheritdoc
+     */
+    public function validate(): Validator\ResultInterface
+    {
+        $config = $this->environmentReader->read()[StageConfigInterface::SECTION_STAGE] ?? [];
+        $deprecatedSchema = $this->schema->getDeprecatedSchema();
+        $errors = [];
+
+        foreach ($config as $stage => $stageConfig) {
+            if (!is_array($stageConfig)) {
+                continue;
+            }
+            foreach ($stageConfig as $key => $value) {
+                if (!isset($deprecatedSchema[$key]) || isset($errors[$key])) {
+                    continue;
+                }
+
+                $error = sprintf('The %s variable is deprecated.', $key);
+
+                if (isset($deprecatedSchema[$key][Schema::SCHEMA_REPLACEMENT])) {
+                    $error .= sprintf(' Use %s instead.', $deprecatedSchema[$key][Schema::SCHEMA_REPLACEMENT]);
+                }
+
+                $errors[$key] = $error;
+            }
+        }
+
+        if ($errors) {
+            return $this->resultFactory->create(Validator\ResultInterface::ERROR, [
+                'error' => 'Some configuration in your .magento.env.yaml file is deprecated.',
+                'suggestion' => implode(PHP_EOL, $errors),
+            ]);
+        }
+
+        return $this->resultFactory->create(Validator\ResultInterface::SUCCESS);
+    }
+}

--- a/src/Config/Validator/Build/StageConfigDeprecatedVariables.php
+++ b/src/Config/Validator/Build/StageConfigDeprecatedVariables.php
@@ -57,11 +57,11 @@ class StageConfigDeprecatedVariables implements ValidatorInterface
         $deprecatedSchema = $this->schema->getDeprecatedSchema();
         $errors = [];
 
-        foreach ($config as $stage => $stageConfig) {
+        foreach ($config as $stageConfig) {
             if (!is_array($stageConfig)) {
                 continue;
             }
-            foreach ($stageConfig as $key => $value) {
+            foreach (array_keys($stageConfig) as $key) {
                 if (!isset($deprecatedSchema[$key]) || isset($errors[$key])) {
                     continue;
                 }

--- a/src/Config/Validator/Deploy/DeprecatedVariables.php
+++ b/src/Config/Validator/Deploy/DeprecatedVariables.php
@@ -60,6 +60,14 @@ class DeprecatedVariables implements ValidatorInterface
             );
         }
 
+        if (isset($variables[DeployInterface::VAR_SCD_EXCLUDE_THEMES])) {
+            $errors[] = sprintf(
+                'The %s variable is deprecated. Use %s instead.',
+                DeployInterface::VAR_SCD_EXCLUDE_THEMES,
+                DeployInterface::VAR_SCD_MATRIX
+            );
+        }
+
         if ($this->environment->getEnv(DeployInterface::VAR_STATIC_CONTENT_THREADS)
             || isset($variables[DeployInterface::VAR_STATIC_CONTENT_THREADS])
         ) {

--- a/src/Test/Unit/Config/Validator/Build/StageConfigDeprecatedVariablesTest.php
+++ b/src/Test/Unit/Config/Validator/Build/StageConfigDeprecatedVariablesTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Config\Validator\Build;
+
+use Magento\MagentoCloud\Config\Schema;
+use Magento\MagentoCloud\Config\StageConfigInterface;
+use Magento\MagentoCloud\Config\Validator\Build\StageConfigDeprecatedVariables;
+use Magento\MagentoCloud\Config\Validator\Result\Error;
+use Magento\MagentoCloud\Config\Validator\Result\Success;
+use Magento\MagentoCloud\Config\Validator\ResultFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Magento\MagentoCloud\Config\Environment\Reader as EnvironmentReader;
+
+/**
+ * @inheritdoc
+ */
+class StageConfigDeprecatedVariablesTest extends TestCase
+{
+    /**
+     * @var StageConfigDeprecatedVariables
+     */
+    private $validator;
+
+    /**
+     * @var EnvironmentReader|MockObject
+     */
+    private $environmentReaderMock;
+
+    /**
+     * @var ResultFactory|MockObject
+     */
+    private $resultFactoryMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->environmentReaderMock = $this->createMock(EnvironmentReader::class);
+        $this->resultFactoryMock = $this->createMock(ResultFactory::class);
+
+        $this->validator = new StageConfigDeprecatedVariables(
+            $this->environmentReaderMock,
+            $this->resultFactoryMock,
+            new Schema()
+        );
+    }
+
+    public function testValidateSuccess()
+    {
+        $this->environmentReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn([]);
+        $this->resultFactoryMock->expects($this->once())
+            ->method('create')
+            ->with('success', [])
+            ->willReturn($this->createMock(Success::class));
+
+        $this->assertInstanceOf(Success::class, $this->validator->validate());
+    }
+
+    public function testValidateScdExcludeThemesIsDeprecated()
+    {
+        $this->environmentReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn([
+                StageConfigInterface::SECTION_STAGE => [
+                    StageConfigInterface::STAGE_DEPLOY => [
+                        StageConfigInterface::VAR_SCD_EXCLUDE_THEMES => 'theme1'
+                    ],
+                ],
+            ]);
+        $this->resultFactoryMock->expects($this->once())
+            ->method('create')
+            ->with('error', [
+                'error' => 'Some configuration in your .magento.env.yaml file is deprecated.',
+                'suggestion' => 'The SCD_EXCLUDE_THEMES variable is deprecated. Use SCD_MATRIX instead.'
+            ])
+            ->willReturn($this->createMock(Error::class));
+
+        $this->assertInstanceOf(Error::class, $this->validator->validate());
+    }
+}

--- a/src/Test/Unit/Config/Validator/Build/StageConfigDeprecatedVariablesTest.php
+++ b/src/Test/Unit/Config/Validator/Build/StageConfigDeprecatedVariablesTest.php
@@ -77,7 +77,7 @@ class StageConfigDeprecatedVariablesTest extends TestCase
         $this->resultFactoryMock->expects($this->once())
             ->method('create')
             ->with('error', [
-                'error' => 'Some configuration in your .magento.env.yaml file is deprecated.',
+                'error' => 'Some configurations in your .magento.env.yaml file is deprecated.',
                 'suggestion' => 'The SCD_EXCLUDE_THEMES variable is deprecated. Use SCD_MATRIX instead.'
             ])
             ->willReturn($this->createMock(Error::class));

--- a/src/Test/Unit/Config/Validator/Deploy/DeprecatedVariablesTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/DeprecatedVariablesTest.php
@@ -116,6 +116,11 @@ class DeprecatedVariablesTest extends TestCase
                 [DeployInterface::VAR_DO_DEPLOY_STATIC_CONTENT => 1],
                 Error::class,
             ],
+            [
+                [DeployInterface::VAR_SCD_EXCLUDE_THEMES => 'theme'],
+                [],
+                Error::class,
+            ],
         ];
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Added deprecation for the SCD_EXCLUDE_THEME variable. This variable became redundant after adding SCD_MATRIX.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-2882

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGETWO-97873

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
