### PR TITLE
Move compression from generate to transfer (#191853)

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -193,7 +193,6 @@ class Container implements ContainerInterface
                         $this->container->make(BuildProcess\CompileDi::class),
                         $this->container->make(BuildProcess\ComposerDumpAutoload::class),
                         $this->container->make(BuildProcess\DeployStaticContent::class),
-                        $this->container->make(BuildProcess\CompressStaticContent::class),
                     ],
                 ]);
             }
@@ -203,6 +202,7 @@ class Container implements ContainerInterface
             function () {
                 return $this->container->makeWith(ProcessComposite::class, [
                     'processes' => [
+                        $this->container->make(BuildProcess\CompressStaticContent::class),
                         $this->container->make(BuildProcess\ClearInitDirectory::class),
                         $this->container->make(BuildProcess\BackupData::class),
                     ],


### PR DESCRIPTION
### Description
When generating JS bundles or other front-end assets during the build stage the compression happens too early and the generated code isn’t compressed. This commit fixes it by moving the compression to the beginning of the transfer step


### Fixed Issues (if relevant)
Magento cloud support ticket #191853

### Manual testing scenarios
No manual tests. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
