### PR TITLE
MAGECLOUD-2891: [Cloud Docker] Verify Xdebug functionality

### DIFF
--- a/dist/docker/global.php
+++ b/dist/docker/global.php
@@ -2,11 +2,11 @@
 
 return [
     'PHP_MEMORY_LIMIT' => '2048M',
-    'PHP_ENABLE_XDEBUG' => 'false',
     'DEBUG' => 'false',
     'ENABLE_SENDMAIL' => 'false',
     'UPLOAD_MAX_FILESIZE' => '64M',
     'MAGENTO_ROOT' => '/var/www/magento',
-    'PHP_IDE_CONFIG' => 'serverName=magento_cloud_docker',
-    'XDEBUG_CONFIG' => 'remote_host=host.docker.internal',
+    'PHP_ENABLE_XDEBUG' => 'false',
+    'PHP_IDE_CONFIG' => 'serverName=magento_cloud_docker', #name of your server in IDE
+    'XDEBUG_CONFIG' => 'remote_host=host.docker.internal', #docker host for developer environments
 ];

--- a/dist/docker/global.php
+++ b/dist/docker/global.php
@@ -8,5 +8,5 @@ return [
     'MAGENTO_ROOT' => '/var/www/magento',
     'PHP_ENABLE_XDEBUG' => 'false',
     'PHP_IDE_CONFIG' => 'serverName=magento_cloud_docker', #name of your server in IDE
-    'XDEBUG_CONFIG' => 'remote_host=host.docker.internal', #docker host for developer environments
+    'XDEBUG_CONFIG' => 'remote_host=host.docker.internal', #docker host for developer environments, can be different for your OS
 ];

--- a/dist/docker/global.php
+++ b/dist/docker/global.php
@@ -7,4 +7,6 @@ return [
     'ENABLE_SENDMAIL' => 'false',
     'UPLOAD_MAX_FILESIZE' => '64M',
     'MAGENTO_ROOT' => '/var/www/magento',
+    'PHP_IDE_CONFIG' => 'serverName=magento_cloud_docker',
+    'XDEBUG_CONFIG' => 'remote_host=host.docker.internal',
 ];

--- a/src/Command/Docker/ConfigConvert.php
+++ b/src/Command/Docker/ConfigConvert.php
@@ -87,7 +87,8 @@ class ConfigConvert extends Command
             $content = '';
 
             foreach ($this->file->requireFile($sourcePath) as $variable => $value) {
-                $content .= $variable . '=' . $value . PHP_EOL;
+                $formattedValue = is_bool($value) ? var_export($value, true) : $value;
+                $content .= $variable . '=' . $formattedValue . PHP_EOL;
             }
 
             $this->file->filePutContents($envPath, $content);

--- a/src/Test/Unit/Command/Docker/ConfigConvertTest.php
+++ b/src/Test/Unit/Command/Docker/ConfigConvertTest.php
@@ -82,25 +82,32 @@ class ConfigConvertTest extends TestCase
                     ],
                 ],
                 [
-
                     'magento_root/docker/global.php',
                     [
                         'MAGENTO_RUN_MODE' => 'production',
+                        'DEBUG' => false,
+                        'ENABLE_SENDMAIL' => true,
+                        'PHP_ENABLE_XDEBUG' => true,
                     ],
                 ],
             ]);
         $this->fileMock->expects($this->exactly(2))
             ->method('filePutContents')
-            ->willReturnMap([
+            ->withConsecutive(
                 [
                     'magento_root/docker/config.env',
-                    $this->contains('MAGENTO_CLOUD_VARIABLES=eyJBRE1JTl9FTUFJT'),
+                    $this->stringStartsWith('MAGENTO_CLOUD_VARIABLES=eyJBRE1JTl9FTUFJTCI6InRlc3Qy'),
                 ],
                 [
                     'magento_root/docker/global.env',
-                    'MAGENTO_RUN_MODE=InByb2R1Y3Rpb24i',
-                ],
-            ]);
+                    implode(PHP_EOL, [
+                        'MAGENTO_RUN_MODE=production',
+                        'DEBUG=false',
+                        'ENABLE_SENDMAIL=true',
+                        'PHP_ENABLE_XDEBUG=true',
+                    ]) . PHP_EOL,
+                ]
+            );
 
         $this->command->execute($inputMock, $outputMock);
     }
@@ -144,21 +151,27 @@ class ConfigConvertTest extends TestCase
                     'magento_root/docker/global.php.dist',
                     [
                         'MAGENTO_RUN_MODE' => 'production',
+                        'DEBUG' => false,
+                        'PHP_ENABLE_XDEBUG' => true,
                     ],
                 ],
             ]);
         $this->fileMock->expects($this->exactly(2))
             ->method('filePutContents')
-            ->willReturnMap([
+            ->withConsecutive(
                 [
                     'magento_root/docker/config.env',
-                    $this->contains('MAGENTO_CLOUD_VARIABLES=eyJBRE1JTl9FTUFJT'),
+                    $this->stringStartsWith('MAGENTO_CLOUD_VARIABLES=eyJBRE1JTl9FTUFJT'),
                 ],
                 [
                     'magento_root/docker/global.env',
-                    'MAGENTO_RUN_MODE=InByb2R1Y3Rpb24i',
-                ],
-            ]);
+                    implode(PHP_EOL, [
+                        'MAGENTO_RUN_MODE=production',
+                        'DEBUG=false',
+                        'PHP_ENABLE_XDEBUG=true',
+                    ]) . PHP_EOL,
+                ]
+            );
 
         $this->command->execute($inputMock, $outputMock);
     }
@@ -202,21 +215,27 @@ class ConfigConvertTest extends TestCase
                     'magento_root/docker/global.php.dist',
                     [
                         'MAGENTO_RUN_MODE' => 'production',
+                        'DEBUG' => false,
+                        'PHP_ENABLE_XDEBUG' => true,
                     ],
                 ],
             ]);
         $this->fileMock->expects($this->exactly(2))
             ->method('filePutContents')
-            ->willReturnMap([
+            ->withConsecutive(
                 [
                     'magento_root/docker/config.env',
-                    $this->contains('MAGENTO_CLOUD_VARIABLES=eyJBRE1JTl9FTUFJT'),
+                    $this->stringStartsWith('MAGENTO_CLOUD_VARIABLES=eyJBRE1JTl9FTUFJT'),
                 ],
                 [
                     'magento_root/docker/global.env',
-                    'MAGENTO_RUN_MODE=InByb2R1Y3Rpb24i',
-                ],
-            ]);
+                    implode(PHP_EOL, [
+                        'MAGENTO_RUN_MODE=production',
+                        'DEBUG=false',
+                        'PHP_ENABLE_XDEBUG=true',
+                    ]) . PHP_EOL,
+                ]
+            );
         $this->fileMock->expects($this->exactly(2))
             ->method('deleteFile')
             ->withConsecutive(


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Fixed issue with `docker:config:convert` command when boolean values from global.php were converted to `1` or empty value in global.env. Such converted is causing unexpectable behavior during `docker-compose build`. 
For example, if `DEBUG` was true in `global.php` after running `docker:config:convert` command it became as `DEBUG=1` in `global.env` and next condition `[ "$DEBUG" = "true" ]` will be false in `docker-entrypoint.sh` but expected to be true.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-2891

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
- Run steps from https://devdocs.magento.com/guides/v2.1/cloud/docker/docker-config.html
- After step 6 check that `docker/global.env` contains true/false values for boolean variables from `docker/config.php` (PHP_ENABLE_XDEBUG, DEBUG, ENABLE_SENDMAIL)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
