### PR TITLE
MAGECLOUD-2793: Patch Monolog 1.6.x to Support ECE-Tools Features for Magento 2.1

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -138,6 +138,9 @@
     "Add the possibility to install Magento without admin creation" : {
       "2.1.4 - 2.2.1": "MAGECLOUD-2573__installation_without_admin_creation__2.1.4.patch",
       "2.2.2 - 2.2.7": "MAGECLOUD-2573__installation_without_admin_creation__2.2.2.patch"
+    },
+    "Fix monolog Slack Handler bug for magento 2.1.x": {
+      "~2.1.4": "MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch"
     }
   }
 }

--- a/patches.json
+++ b/patches.json
@@ -138,9 +138,11 @@
     "Add the possibility to install Magento without admin creation" : {
       "2.1.4 - 2.2.1": "MAGECLOUD-2573__installation_without_admin_creation__2.1.4.patch",
       "2.2.2 - 2.2.7": "MAGECLOUD-2573__installation_without_admin_creation__2.2.2.patch"
-    },
+    }
+  },
+  "monolog/monolog": {
     "Fix monolog Slack Handler bug for magento 2.1.x": {
-      "~2.1.4": "MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch"
+      "1.16.0": "MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch"
     }
   }
 }

--- a/patches/MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch
+++ b/patches/MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch
@@ -1,4 +1,4 @@
-diff -Nuar a/src/Monolog/Handler/SlackHandler.php b/src/Monolog/Handler/SlackHandler.php
+diff -Nuar a/vendor/monolog/monolog/src/Monolog/Handler/SlackHandler.php b/vendor/monolog/monolog/src/Monolog/Handler/SlackHandler.php
 index 643b003..ac2af02 100644
 --- a/src/Monolog/Handler/SlackHandler.php
 +++ b/src/Monolog/Handler/SlackHandler.php

--- a/patches/MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch
+++ b/patches/MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch
@@ -142,3 +142,23 @@ index 643b003..ac2af02 100644
       * @return string
       */
      protected function stringify($fields)
+diff -Nuar a/vendor/monolog/monolog/src/Monolog/Handler/SocketHandler.php b/vendor/monolog/monolog/src/Monolog/Handler/SocketHandler.php
+index a3e7252e..e4c3c37f 100644
+--- a/vendor/monolog/monolog/src/Monolog/Handler/SocketHandler.php
++++ b/vendor/monolog/monolog/src/Monolog/Handler/SocketHandler.php
+@@ -41,6 +41,15 @@ class SocketHandler extends AbstractProcessingHandler
+         $this->connectionTimeout = (float) ini_get('default_socket_timeout');
+     }
+
++    /**
++     * @return resource|null
++     */
++    protected function getResource()
++    {
++        return $this->resource;
++    }
++
++
+     /**
+      * Connect (if necessary) and write to the socket
+      *

--- a/patches/MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch
+++ b/patches/MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch
@@ -1,0 +1,144 @@
+diff -Nuar a/src/Monolog/Handler/SlackHandler.php b/src/Monolog/Handler/SlackHandler.php
+index 643b003..ac2af02 100644
+--- a/src/Monolog/Handler/SlackHandler.php
++++ b/src/Monolog/Handler/SlackHandler.php
+@@ -70,15 +70,16 @@ class SlackHandler extends SocketHandler
+     private $lineFormatter;
+
+     /**
+-     * @param string      $token                  Slack API token
+-     * @param string      $channel                Slack channel (encoded ID or name)
+-     * @param string      $username               Name of a bot
+-     * @param bool        $useAttachment          Whether the message should be added to Slack as attachment (plain text otherwise)
+-     * @param string|null $iconEmoji              The emoji name to use (or null)
+-     * @param int         $level                  The minimum logging level at which this handler will be triggered
+-     * @param bool        $bubble                 Whether the messages that are handled can bubble up the stack or not
+-     * @param bool        $useShortAttachment     Whether the the context/extra messages added to Slack as attachments are in a short style
+-     * @param bool        $includeContextAndExtra Whether the attachment should include context and extra data
++     * @param  string                    $token                  Slack API token
++     * @param  string                    $channel                Slack channel (encoded ID or name)
++     * @param  string                    $username               Name of a bot
++     * @param  bool                      $useAttachment          Whether the message should be added to Slack as attachment (plain text otherwise)
++     * @param  string|null               $iconEmoji              The emoji name to use (or null)
++     * @param  int                       $level                  The minimum logging level at which this handler will be triggered
++     * @param  bool                      $bubble                 Whether the messages that are handled can bubble up the stack or not
++     * @param  bool                      $useShortAttachment     Whether the the context/extra messages added to Slack as attachments are in a short style
++     * @param  bool                      $includeContextAndExtra Whether the attachment should include context and extra data
++     * @throws MissingExtensionException If no OpenSSL PHP extension configured
+      */
+     public function __construct($token, $channel, $username = 'Monolog', $useAttachment = true, $iconEmoji = null, $level = Logger::CRITICAL, $bubble = true, $useShortAttachment = false, $includeContextAndExtra = false)
+     {
+@@ -95,7 +96,8 @@ class SlackHandler extends SocketHandler
+         $this->useAttachment = $useAttachment;
+         $this->useShortAttachment = $useShortAttachment;
+         $this->includeContextAndExtra = $includeContextAndExtra;
+-        if ($this->includeContextAndExtra) {
++
++        if ($this->includeContextAndExtra && $this->useShortAttachment) {
+             $this->lineFormatter = new LineFormatter;
+         }
+     }
+@@ -139,35 +141,26 @@ class SlackHandler extends SocketHandler
+             'channel'     => $this->channel,
+             'username'    => $this->username,
+             'text'        => '',
+-            'attachments' => array()
++            'attachments' => array(),
+         );
+
+         if ($this->useAttachment) {
+             $attachment = array(
+                 'fallback' => $record['message'],
+-                'color'    => $this->getAttachmentColor($record['level'])
++                'color'    => $this->getAttachmentColor($record['level']),
++                'fields'   => array(),
+             );
+
+             if ($this->useShortAttachment) {
+-                $attachment['fields'] = array(
+-                    array(
+-                        'title' => $record['level_name'],
+-                        'value' => $record['message'],
+-                        'short' => false
+-                    )
+-                );
++                $attachment['title'] = $record['level_name'];
++                $attachment['text'] = $record['message'];
+             } else {
+-                $attachment['fields'] = array(
+-                    array(
+-                        'title' => 'Message',
+-                        'value' => $record['message'],
+-                        'short' => false
+-                    ),
+-                    array(
+-                        'title' => 'Level',
+-                        'value' => $record['level_name'],
+-                        'short' => true
+-                    )
++                $attachment['title'] = 'Message';
++                $attachment['text'] = $record['message'];
++                $attachment['fields'][] = array(
++                    'title' => 'Level',
++                    'value' => $record['level_name'],
++                    'short' => true,
+                 );
+             }
+
+@@ -177,7 +170,7 @@ class SlackHandler extends SocketHandler
+                         $attachment['fields'][] = array(
+                             'title' => "Extra",
+                             'value' => $this->stringify($record['extra']),
+-                            'short' => $this->useShortAttachment
++                            'short' => $this->useShortAttachment,
+                         );
+                     } else {
+                         // Add all extra fields as individual fields in attachment
+@@ -185,7 +178,7 @@ class SlackHandler extends SocketHandler
+                             $attachment['fields'][] = array(
+                                 'title' => $var,
+                                 'value' => $val,
+-                                'short' => $this->useShortAttachment
++                                'short' => $this->useShortAttachment,
+                             );
+                         }
+                     }
+@@ -196,7 +189,7 @@ class SlackHandler extends SocketHandler
+                         $attachment['fields'][] = array(
+                             'title' => "Context",
+                             'value' => $this->stringify($record['context']),
+-                            'short' => $this->useShortAttachment
++                            'short' => $this->useShortAttachment,
+                         );
+                     } else {
+                         // Add all context fields as individual fields in attachment
+@@ -204,7 +197,7 @@ class SlackHandler extends SocketHandler
+                             $attachment['fields'][] = array(
+                                 'title' => $var,
+                                 'value' => $val,
+-                                'short' => $this->useShortAttachment
++                                'short' => $this->useShortAttachment,
+                             );
+                         }
+                     }
+@@ -248,6 +241,10 @@ class SlackHandler extends SocketHandler
+     protected function write(array $record)
+     {
+         parent::write($record);
++        $res = $this->getResource();
++        if (is_resource($res)) {
++            @fread($res, 2048);
++        }
+         $this->closeSocket();
+     }
+
+@@ -275,8 +272,7 @@ class SlackHandler extends SocketHandler
+     /**
+      * Stringifies an array of key/value pairs to be used in attachment fields
+      *
+-     * @param array $fields
+-     * @access protected
++     * @param  array  $fields
+      * @return string
+      */
+     protected function stringify($fields)

--- a/patches/MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch
+++ b/patches/MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch
@@ -1,7 +1,7 @@
 diff -Nuar a/vendor/monolog/monolog/src/Monolog/Handler/SlackHandler.php b/vendor/monolog/monolog/src/Monolog/Handler/SlackHandler.php
 index 643b003..ac2af02 100644
---- a/src/Monolog/Handler/SlackHandler.php
-+++ b/src/Monolog/Handler/SlackHandler.php
+--- a/vendor/monolog/monolog/src/Monolog/Handler/SlackHandler.php
++++ b/vendor/monolog/monolog/src/Monolog/Handler/SlackHandler.php
 @@ -70,15 +70,16 @@ class SlackHandler extends SocketHandler
      private $lineFormatter;
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Magento 2.1 is locked to using Monolog 1.6. Monolog 1.6 has a bug (resolved in 1.18.1) where the vast majority of Slack messages are not being sent.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-2793

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Configure Slack Handler in `.magento.env.yaml`
```
log:
  slack:
      token: "xoxp-xxxx"   #your token here
      channel: "xxxxx"     # channel name
      username: "SlackHandler"
      min_level: "info"
```
2. Redeploy magento 2.1.x on cloud
3. Check that deployment log messages were send to your Slack chanel from step 1.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
