### PR TITLE
MAGECLOUD-3195: Fix patch "MAGETWO-57414__load_static_assets_without_…

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -20,7 +20,8 @@
       "~2.1.4": "MAGETWO-57413__move_vendor_path_autoloader__2.1.4.patch"
     },
     "Allow static assets to be loaded without URL rewrites": {
-      "~2.1.4": "MAGETWO-57414__load_static_assets_without_rewrites__2.1.4.patch"
+      "2.1.4 - 2.1.16": "MAGETWO-57414__load_static_assets_without_rewrites__2.1.4.patch",
+      "~2.1.17": "MAGETWO-57414__load_static_assets_without_rewrites__2.1.17.patch"
     },
     "Don't attempt to use non-existent setup areas": {
       "~2.1.4": "MAGETWO-45357__avoid_nonexistent_setup_area__2.1.4.patch"

--- a/patches/MAGETWO-57414__load_static_assets_without_rewrites__2.1.17.patch
+++ b/patches/MAGETWO-57414__load_static_assets_without_rewrites__2.1.17.patch
@@ -1,0 +1,58 @@
+Ticket MAGETWO-57414
+diff -Naur a/vendor/magento/framework/App/StaticResource.php b/vendor/magento/framework/App/StaticResource.php
+index d591deb..6344322 100644
+--- a/vendor/magento/framework/App/StaticResource.php
++++ b/vendor/magento/framework/App/StaticResource.php
+@@ -94,24 +94,40 @@ class StaticResource implements \Magento\Framework\AppInterface
+     {
+         // disabling profiling when retrieving static resource
+         \Magento\Framework\Profiler::reset();
+-        $appMode = $this->state->getMode();
+-        if ($appMode == \Magento\Framework\App\State::MODE_PRODUCTION) {
++        $path = $this->getResourcePath();
++        if (!isset($path)) {
+             $this->response->setHttpResponseCode(404);
+-        } else {
+-            $path = $this->request->get('resource');
+-            $params = $this->parsePath($path);
+-            $this->state->setAreaCode($params['area']);
+-            $this->objectManager->configure($this->configLoader->load($params['area']));
+-            $file = $params['file'];
+-            unset($params['file']);
+-            $asset = $this->assetRepo->createAsset($file, $params);
+-            $this->response->setFilePath($asset->getSourceFile());
+-            $this->publisher->publish($asset);
++            return $this->response;
+         }
++
++        $params = $this->parsePath($path);
++        $this->state->setAreaCode($params['area']);
++        $this->objectManager->configure($this->configLoader->load($params['area']));
++        $file = $params['file'];
++        unset($params['file']);
++        $asset = $this->assetRepo->createAsset($file, $params);
++        $this->response->setFilePath($asset->getSourceFile());
++        $this->publisher->publish($asset);
+         return $this->response;
+     }
+
+     /**
++     * Retrieve the path from either the GET parameter or the request
++     * URI, depending on whether webserver rewrites are in use.
++     */
++    protected function getResourcePath() {
++        $path = $this->request->get('resource');
++        if (isset($path)) {
++            return $path;
++        }
++
++        $path = $this->request->getUri()->getPath();
++        if (preg_match("~^/static/(?:version\d*/)?(.*)$~", $path, $matches)) {
++            return $matches[1];
++        }
++    }
++
++    /**
+      * @inheritdoc
+      */
+     public function catchException(Bootstrap $bootstrap, \Exception $exception)


### PR DESCRIPTION
…rewrites__2.1.4.patch" for 2.1.17

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://magento2.atlassian.net/browse/MAGECLOUD-3195

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
