### PR TITLE
MAGECLOUD-2870: Static assets compression shouldn't break a deploy

### DIFF
--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -114,13 +114,24 @@
 # SCD_COMPRESSION_LEVEL - specifies which gzip compression level (0 to 9) to use when compressing static content;     #
 #                         0 disables compression.                                                                     #
 # Magento Version: 2.1.4 and later                                                                                    #
-# Default value: 6 (build stage) or 4 (deploy stage)                                                                                                     #
+# Default value: 6 (build stage) or 4 (deploy stage)                                                                  #
 # Possible values: from 0 to 9                                                                                        #
 # Stages: global, build and deploy                                                                                    #
 # Example:                                                                                                            #
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #
 #              SCD_COMPRESSION_LEVEL: 5                                                                               #
+#######################################################################################################################
+# SCD_COMPRESSION_TIMEOUT - determine in seconds maximum time for running static compression command                  #
+#                         by default this value is equal to 600 seconds.                                              #
+# Magento Version: 2.1.4 and later                                                                                    #
+# Default value: 600                                                                                                  #
+# Possible values: > 0                                                                                                #
+# Stages: global, build and deploy                                                                                    #
+# Example:                                                                                                            #
+#          stage:                                                                                                     #
+#            deploy:                                                                                                  #
+#              SCD_COMPRESSION_TIMEOUT: 800                                                                           #
 #######################################################################################################################
 # CLEAN_STATIC_FILES - cleans generated static files. By specifying the value of this configuration to 'false',       #
 #                      you can leave the static files which were generated during the previous deployment.            #

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -14,6 +14,7 @@ use Magento\MagentoCloud\Command\Deploy;
 use Magento\MagentoCloud\Command\PostDeploy;
 use Magento\MagentoCloud\Config\Database\ConfigInterface;
 use Magento\MagentoCloud\Config\Database\MergedConfig;
+use Magento\MagentoCloud\Config\Schema;
 use Magento\MagentoCloud\Config\Validator as ConfigValidator;
 use Magento\MagentoCloud\Config\ValidatorInterface;
 use Magento\MagentoCloud\Filesystem\DirectoryCopier;
@@ -64,6 +65,7 @@ class Container implements ContainerInterface
         /**
          * Binding.
          */
+        $this->container->singleton(Schema::class);
         $this->container->singleton(DirectoryList::class);
         $this->container->singleton(FileList::class);
         $this->container->singleton(DeployProcess\InstallUpdate\ConfigUpdate\SearchEngine::class);

--- a/src/Config/Schema.php
+++ b/src/Config/Schema.php
@@ -96,6 +96,18 @@ class Schema
                     StageConfigInterface::STAGE_DEPLOY => 4,
                 ],
             ],
+            StageConfigInterface::VAR_SCD_COMPRESSION_TIMEOUT => [
+                self::SCHEMA_TYPE => ['integer'],
+                self::SCHEMA_STAGE => [
+                    StageConfigInterface::STAGE_GLOBAL,
+                    StageConfigInterface::STAGE_BUILD,
+                    StageConfigInterface::STAGE_DEPLOY
+                ],
+                self::SCHEMA_DEFAULT_VALUE => [
+                    StageConfigInterface::STAGE_BUILD => 600,
+                    StageConfigInterface::STAGE_DEPLOY => 600,
+                ],
+            ],
             StageConfigInterface::VAR_SCD_STRATEGY => [
                 self::SCHEMA_TYPE => ['string'],
                 self::SCHEMA_VALUE_VALIDATION => ['compact', 'quick', 'standard'],

--- a/src/Config/StageConfigInterface.php
+++ b/src/Config/StageConfigInterface.php
@@ -27,6 +27,7 @@ interface StageConfigInterface
      * Deployment variables.
      */
     const VAR_SCD_COMPRESSION_LEVEL = 'SCD_COMPRESSION_LEVEL';
+    const VAR_SCD_COMPRESSION_TIMEOUT = 'SCD_COMPRESSION_TIMEOUT';
     const VAR_SCD_STRATEGY = 'SCD_STRATEGY';
     const VAR_SCD_THREADS = 'SCD_THREADS';
     const VAR_SKIP_SCD = 'SKIP_SCD';

--- a/src/DB/Connection.php
+++ b/src/DB/Connection.php
@@ -6,7 +6,6 @@
 namespace Magento\MagentoCloud\DB;
 
 use Magento\MagentoCloud\DB\Data\ConnectionFactory;
-use Magento\MagentoCloud\DB\Data\ConnectionInterface as DatabaseConnectionInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -32,9 +31,9 @@ class Connection implements ConnectionInterface
     private $fetchMode = \PDO::FETCH_ASSOC;
 
     /**
-     * @var DatabaseConnectionInterface
+     * @var ConnectionFactory
      */
-    private $connectionData;
+    private $connectionFactory;
 
     /**
      * @param LoggerInterface $logger
@@ -43,7 +42,7 @@ class Connection implements ConnectionInterface
     public function __construct(LoggerInterface $logger, ConnectionFactory $connectionFactory)
     {
         $this->logger = $logger;
-        $this->connectionData = $connectionFactory->create(ConnectionFactory::CONNECTION_MAIN);
+        $this->connectionFactory = $connectionFactory;
     }
 
     /**
@@ -184,14 +183,15 @@ class Connection implements ConnectionInterface
             return;
         }
 
+        $connectionData = $this->connectionFactory->create(ConnectionFactory::CONNECTION_MAIN);
         $this->pdo = new \PDO(
             sprintf(
                 'mysql:dbname=%s;host=%s',
-                $this->connectionData->getDbName(),
-                $this->connectionData->getHost()
+                $connectionData->getDbName(),
+                $connectionData->getHost()
             ),
-            $this->connectionData->getUser(),
-            $this->connectionData->getPassword(),
+            $connectionData->getUser(),
+            $connectionData->getPassword(),
             [
                 \PDO::ATTR_PERSISTENT => true,
             ]

--- a/src/Process/Build/CompressStaticContent.php
+++ b/src/Process/Build/CompressStaticContent.php
@@ -77,6 +77,7 @@ class CompressStaticContent implements ProcessInterface
         if ($this->flagManager->exists(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)) {
             $this->compressor->process(
                 $this->stageConfig->get(BuildInterface::VAR_SCD_COMPRESSION_LEVEL),
+                $this->stageConfig->get(BuildInterface::VAR_SCD_COMPRESSION_TIMEOUT),
                 $this->stageConfig->get(BuildInterface::VAR_VERBOSE_COMMANDS)
             );
         } else {

--- a/src/Process/Deploy/CompressStaticContent.php
+++ b/src/Process/Deploy/CompressStaticContent.php
@@ -81,6 +81,7 @@ class CompressStaticContent implements ProcessInterface
         ) {
             $this->staticContentCompressor->process(
                 $this->stageConfig->get(DeployInterface::VAR_SCD_COMPRESSION_LEVEL),
+                $this->stageConfig->get(DeployInterface::VAR_SCD_COMPRESSION_TIMEOUT),
                 $this->stageConfig->get(DeployInterface::VAR_VERBOSE_COMMANDS)
             );
         } else {

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/DbConnection.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/DbConnection.php
@@ -11,7 +11,6 @@ use Magento\MagentoCloud\Config\Database\ResourceConfig;
 use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
 use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
 use Magento\MagentoCloud\Config\Stage\DeployInterface;
-use Magento\MagentoCloud\DB\Data\ConnectionInterface;
 use Magento\MagentoCloud\DB\Data\RelationshipConnectionFactory;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Psr\Log\LoggerInterface;
@@ -57,9 +56,9 @@ class DbConnection implements ProcessInterface
     private $configMerger;
 
     /**
-     * @var ConnectionInterface
+     * @var $connectionFactory
      */
-    private $connectionData;
+    private $connectionFactory;
 
     /**
      * @param DeployInterface $stageConfig
@@ -88,7 +87,7 @@ class DbConnection implements ProcessInterface
         $this->configReader = $configReader;
         $this->configMerger = $configMerger;
         $this->logger = $logger;
-        $this->connectionData = $connectionFactory->create(RelationshipConnectionFactory::CONNECTION_MAIN);
+        $this->connectionFactory = $connectionFactory;
     }
 
     /**
@@ -112,8 +111,9 @@ class DbConnection implements ProcessInterface
     private function addLoggingAboutSlaveConnection()
     {
         $envDbConfig = $this->stageConfig->get(DeployInterface::VAR_DATABASE_CONFIGURATION);
+        $connectionData = $this->connectionFactory->create(RelationshipConnectionFactory::CONNECTION_MAIN);
 
-        if (!$this->connectionData->getHost()
+        if (!$connectionData->getHost()
             || !$this->stageConfig->get(DeployInterface::VAR_MYSQL_USE_SLAVE_CONNECTION)
             || (!$this->configMerger->isEmpty($envDbConfig) && !$this->configMerger->isMergeRequired($envDbConfig))
         ) {

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/DbConnection.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/DbConnection.php
@@ -56,7 +56,7 @@ class DbConnection implements ProcessInterface
     private $configMerger;
 
     /**
-     * @var $connectionFactory
+     * @var RelationshipConnectionFactory
      */
     private $connectionFactory;
 

--- a/src/Process/Deploy/InstallUpdate/Install/Setup.php
+++ b/src/Process/Deploy/InstallUpdate/Install/Setup.php
@@ -64,6 +64,11 @@ class Setup implements ProcessInterface
     private $connectionData;
 
     /**
+     * @var ConnectionFactory
+     */
+    private $connectionFactory;
+
+    /**
      * @param LoggerInterface $logger
      * @param UrlManager $urlManager
      * @param Environment $environment
@@ -86,7 +91,7 @@ class Setup implements ProcessInterface
         $this->logger = $logger;
         $this->urlManager = $urlManager;
         $this->environment = $environment;
-        $this->connectionData = $connectionFactory->create(ConnectionFactory::CONNECTION_MAIN);
+        $this->connectionFactory = $connectionFactory;
         $this->shell = $shell;
         $this->passwordGenerator = $passwordGenerator;
         $this->fileList = $fileList;
@@ -102,7 +107,7 @@ class Setup implements ProcessInterface
 
         $command = $this->getBaseCommand();
 
-        $dbPassword = $this->connectionData->getPassword();
+        $dbPassword = $this->getConnectionData()->getPassword();
         if (strlen($dbPassword)) {
             $command .= ' --db-password=' . escapeshellarg($dbPassword);
         }
@@ -137,9 +142,9 @@ class Setup implements ProcessInterface
             . ' --base-url-secure=' . escapeshellarg($urlSecure)
             . ' --language=' . escapeshellarg($this->environment->getAdminLocale())
             . ' --timezone=America/Los_Angeles'
-            . ' --db-host=' . escapeshellarg($this->connectionData->getHost())
-            . ' --db-name=' . escapeshellarg($this->connectionData->getDbName())
-            . ' --db-user=' . escapeshellarg($this->connectionData->getUser())
+            . ' --db-host=' . escapeshellarg($this->getConnectionData()->getHost())
+            . ' --db-name=' . escapeshellarg($this->getConnectionData()->getDbName())
+            . ' --db-user=' . escapeshellarg($this->getConnectionData()->getUser())
             . ' --backend-frontname=' . escapeshellarg($this->environment->getAdminUrl()
                 ?: Environment::DEFAULT_ADMIN_URL)
             . ($this->environment->getAdminEmail() ? $this->getAdminCredentials() : '')
@@ -160,5 +165,17 @@ class Setup implements ProcessInterface
             . ' --admin-email=' . escapeshellarg($this->environment->getAdminEmail())
             . ' --admin-password=' . escapeshellarg($this->environment->getAdminPassword()
                 ?: $this->passwordGenerator->generateRandomPassword());
+    }
+
+    /**
+     * @return ConnectionInterface
+     */
+    private function getConnectionData(): ConnectionInterface
+    {
+        if (!$this->connectionData instanceof ConnectionInterface) {
+            $this->connectionData = $this->connectionFactory->create(ConnectionFactory::CONNECTION_MAIN);
+        }
+
+        return $this->connectionData;
     }
 }

--- a/src/Test/Unit/Config/SchemaTest.php
+++ b/src/Test/Unit/Config/SchemaTest.php
@@ -38,6 +38,7 @@ class SchemaTest extends TestCase
                 BuildInterface::VAR_SCD_STRATEGY => '',
                 BuildInterface::VAR_SKIP_SCD => false,
                 BuildInterface::VAR_SCD_COMPRESSION_LEVEL => 6,
+                BuildInterface::VAR_SCD_COMPRESSION_TIMEOUT => 600,
                 BuildInterface::VAR_SCD_THREADS => 1,
                 BuildInterface::VAR_SCD_EXCLUDE_THEMES => '',
                 BuildInterface::VAR_VERBOSE_COMMANDS => '',
@@ -53,6 +54,7 @@ class SchemaTest extends TestCase
             [
                 DeployInterface::VAR_SCD_STRATEGY => '',
                 DeployInterface::VAR_SCD_COMPRESSION_LEVEL => 4,
+                DeployInterface::VAR_SCD_COMPRESSION_TIMEOUT => 600,
                 DeployInterface::VAR_SEARCH_CONFIGURATION => [],
                 DeployInterface::VAR_QUEUE_CONFIGURATION => [],
                 DeployInterface::VAR_CACHE_CONFIGURATION => [],

--- a/src/Test/Unit/DB/ConnectionTest.php
+++ b/src/Test/Unit/DB/ConnectionTest.php
@@ -57,7 +57,7 @@ class ConnectionTest extends TestCase
 
         /** @var ConnectionFactory|MockObject $connectionFactoryMock */
         $connectionFactoryMock = $this->createMock(ConnectionFactory::class);
-        $connectionFactoryMock->expects($this->once())
+        $connectionFactoryMock->expects($this->any())
             ->method('create')
             ->willReturn($this->connectionDataMock);
 

--- a/src/Test/Unit/Process/Build/CompressStaticContentTest.php
+++ b/src/Test/Unit/Process/Build/CompressStaticContentTest.php
@@ -73,16 +73,17 @@ class CompressStaticContentTest extends TestCase
             ->method('exists')
             ->with(FlagManager::FLAG_STATIC_CONTENT_DEPLOY_IN_BUILD)
             ->willReturn(true);
-        $this->stageConfigMock->expects($this->exactly(2))
+        $this->stageConfigMock->expects($this->exactly(3))
             ->method('get')
             ->willReturnMap([
                 [BuildInterface::VAR_SCD_COMPRESSION_LEVEL, 6],
+                [BuildInterface::VAR_SCD_COMPRESSION_TIMEOUT, 500],
                 [BuildInterface::VAR_VERBOSE_COMMANDS, ''],
             ]);
         $this->compressorMock
             ->expects($this->once())
             ->method('process')
-            ->with(6);
+            ->with(6, 500);
 
         $this->process->execute();
     }

--- a/src/Test/Unit/Process/Deploy/CompressStaticContentTest.php
+++ b/src/Test/Unit/Process/Deploy/CompressStaticContentTest.php
@@ -78,10 +78,11 @@ class CompressStaticContentTest extends TestCase
             ->method('get')
             ->with(GlobalConfig::VAR_SCD_ON_DEMAND)
             ->willReturn(false);
-        $this->stageConfigMock->expects($this->exactly(3))
+        $this->stageConfigMock->expects($this->exactly(4))
             ->method('get')
             ->willReturnMap([
                 [DeployInterface::VAR_SCD_COMPRESSION_LEVEL, 4],
+                [DeployInterface::VAR_SCD_COMPRESSION_TIMEOUT, 500],
                 [DeployInterface::VAR_SKIP_SCD, false],
                 [DeployInterface::VAR_VERBOSE_COMMANDS, ''],
             ]);
@@ -93,7 +94,7 @@ class CompressStaticContentTest extends TestCase
         $this->compressorMock
             ->expects($this->once())
             ->method('process')
-            ->with(4);
+            ->with(4, 500);
 
         $this->process->execute();
     }

--- a/src/Test/Unit/Util/StaticContentCompressorTest.php
+++ b/src/Test/Unit/Util/StaticContentCompressorTest.php
@@ -64,12 +64,13 @@ class StaticContentCompressorTest extends TestCase
 
     /**
      * @param int $compressionLevel
+     * @param int $compressionTimeout
      * @dataProvider compressionDataProvider
      */
-    public function testCompression(int $compressionLevel)
+    public function testCompression(int $compressionLevel, int $compressionTimeout)
     {
         $directoryListDirStatic = 'this/is/a/test/static/directory';
-        $timeout = '/usr/bin/timeout';
+        $timeoutCommand = '/usr/bin/timeout';
         $bash = '/bin/bash';
 
         $this->directoryListMock
@@ -78,8 +79,9 @@ class StaticContentCompressorTest extends TestCase
             ->willReturn($directoryListDirStatic);
 
         $expectedCommand = sprintf(
-            '%s -k 30 600 %s -c %s',
-            $timeout,
+            '%s -k 30 %s %s -c %s',
+            $timeoutCommand,
+            $compressionTimeout,
             $bash,
             escapeshellarg(
                 sprintf(
@@ -100,13 +102,13 @@ class StaticContentCompressorTest extends TestCase
             ->with($expectedCommand);
         $this->utilityManagerMock->method('get')
             ->willReturnMap([
-                [UtilityManager::UTILITY_TIMEOUT, $timeout],
+                [UtilityManager::UTILITY_TIMEOUT, $timeoutCommand],
                 [UtilityManager::UTILITY_BASH, $bash],
             ]);
         $this->loggerMock->expects($this->once())
             ->method('info');
 
-        $this->staticContentCompressor->process($compressionLevel, '-v');
+        $this->staticContentCompressor->process($compressionLevel, $compressionTimeout, '-v');
     }
 
     /**
@@ -115,7 +117,8 @@ class StaticContentCompressorTest extends TestCase
     public function compressionDataProvider(): array
     {
         return [
-            [4],
+            [4, 500],
+            [9, 100000],
         ];
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Added possibility for configuration timeout time for compression of static files. Previously it was hardcoded as 600s and it wasn't enough in some cases.
Removed from constructors creation of connection data objects via `ConnectionFactory` and moved to methods where it required.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-2870

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGECLOUD-28
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
