### PR TITLE
MAGECLOUD-3228: Installation from git is broken with 2.3.1-develop due to ElasticSerch 6.5

### DIFF
--- a/src/Command/Dev/UpdateComposer/ClearModuleRequirements.php
+++ b/src/Command/Dev/UpdateComposer/ClearModuleRequirements.php
@@ -62,7 +62,7 @@ foreach ({$reposArrayToString} as \$repoName) {
         \$composerJson = json_decode(file_get_contents(\$moduleDir . '/composer.json'), true);
 
         foreach (\$composerJson['require'] as \$requireName => \$requireVersion) {
-            if (preg_match('|^magento\/|elasticsearch\/|i', \$requireName)) {
+            if (preg_match('{^(magento\/|elasticsearch\/)}i', \$requireName)) {
                 unset(\$composerJson['require'][\$requireName]);
             }
         }

--- a/src/Command/Dev/UpdateComposer/ClearModuleRequirements.php
+++ b/src/Command/Dev/UpdateComposer/ClearModuleRequirements.php
@@ -62,7 +62,7 @@ foreach ({$reposArrayToString} as \$repoName) {
         \$composerJson = json_decode(file_get_contents(\$moduleDir . '/composer.json'), true);
 
         foreach (\$composerJson['require'] as \$requireName => \$requireVersion) {
-            if (strpos(\$requireName, 'magento/') !== false) {
+            if (preg_match('|^magento\/|elasticsearch\/|i', \$requireName)) {
                 unset(\$composerJson['require'][\$requireName]);
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Fix installation from git after adding ElasticSearch6 module into magento core.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3228

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://wiki.corp.magento.com/pages/viewpage.action?spaceKey=MCP&title=ECE+Tools+-+Simple+Flow+to+Deploy+Magento+to+ECE+from+GitHub+Branch

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
