### PR TITLE
MAGECLOUD-2899: Redis Slave Nodes Have no Health Checks / Are not Stable

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -1,9 +1,5 @@
 {
   "magento/magento2-base": {
-    "Fix credis pipeline issue": {
-      "2.1.4 - 2.1.10": "MAGETWO-67097__fix_credis_pipeline_bug__2.1.4.patch",
-      "2.2.0": "MAGETWO-67097__fix_credis_pipeline_bug__2.1.4.patch"
-    },
     "Fix asset locker race condition when using Redis": {
       "2.1.4 - 2.1.14": "MDVA-2470__fix_asset_locking_race_condition__2.1.4.patch",
       "2.2.0 - 2.2.5": "MDVA-2470__fix_asset_locking_race_condition__2.2.0.patch"
@@ -158,10 +154,15 @@
     }
   },
   "colinmollenhour/cache-backend-redis": {
-    "Porting 'retry_reads_on_master' option to older versions: '1.10.2', '1.10.4', '1.10.5'": {
+    "The ability to read from the master Redis instance if the slave Redis is unavailable:": {
       "1.10.2": "MAGECLOUD-2899__fix_redis_slave_configuration__2.1.16.patch",
       "1.10.4": "MAGECLOUD-2899__fix_redis_slave_configuration__2.2.3.patch",
       "1.10.5": "MAGECLOUD-2899__fix_redis_slave_configuration__2.3.0.patch"
+    }
+  },
+  "colinmollenhour/credis": {
+    "Fix credis pipeline issue": {
+      "1.6": "MAGETWO-67097__fix_credis_pipeline_bug__2.1.4.patch"
     }
   }
 }

--- a/patches.json
+++ b/patches.json
@@ -156,5 +156,12 @@
     "Fix monolog Slack Handler bug for magento 2.1.x": {
       "1.16.0": "MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch"
     }
+  },
+  "colinmollenhour/cache-backend-redis": {
+    "Porting 'retry_reads_on_master' option to older versions: '1.10.2', '1.10.4', '1.10.5'": {
+      "1.10.2": "MAGECLOUD-2899__fix_redis_slave_configuration__2.1.16.patch",
+      "1.10.4": "MAGECLOUD-2899__fix_redis_slave_configuration__2.2.3.patch",
+      "1.10.5": "MAGECLOUD-2899__fix_redis_slave_configuration__2.3.0.patch"
+    }
   }
 }

--- a/patches/MAGECLOUD-2899__fix_redis_slave_configuration__2.1.16.patch
+++ b/patches/MAGECLOUD-2899__fix_redis_slave_configuration__2.1.16.patch
@@ -1,0 +1,40 @@
+diff -Nuar a/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php b/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php
+--- a/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php
++++ b/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php
+@@ -111,6 +111,13 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
+      */
+     protected $_luaMaxCStack = 5000;
+ 
++    /**
++     * If 'retry_reads_on_master' is truthy then reads will be retried against master when slave returns "(nil)" value
++     *
++     * @var boolean
++     */
++    protected $_retryReadsOnMaster = false;
++
+     /**
+      * @var stdClass
+      */
+@@ -316,6 +323,10 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
+             $this->_luaMaxCStack = (int) $options['lua_max_c_stack'];
+         }
+ 
++        if (isset($options['retry_reads_on_master'])) {
++            $this->_retryReadsOnMaster = (bool) $options['retry_reads_on_master'];
++        }
++
+         if (isset($options['auto_expire_lifetime'])) {
+             $this->_autoExpireLifetime = (int) $options['auto_expire_lifetime'];
+         }
+@@ -371,6 +382,11 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
+     {
+         if ($this->_slave) {
+             $data = $this->_slave->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
++
++            // Prevent compounded effect of cache flood on asynchronously replicating master/slave setup
++            if ($this->_retryReadsOnMaster && $data === false) {
++                $data = $this->_redis->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
++            }
+         } else {
+             $data = $this->_redis->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
+         }

--- a/patches/MAGECLOUD-2899__fix_redis_slave_configuration__2.2.3.patch
+++ b/patches/MAGECLOUD-2899__fix_redis_slave_configuration__2.2.3.patch
@@ -1,0 +1,40 @@
+diff -Nuar a/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php b/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php
+--- a/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php
++++ b/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php
+@@ -111,6 +111,13 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
+      */
+     protected $_luaMaxCStack = 5000;
+ 
++    /**
++     * If 'retry_reads_on_master' is truthy then reads will be retried against master when slave returns "(nil)" value
++     *
++     * @var boolean
++     */
++    protected $_retryReadsOnMaster = false;
++
+     /**
+      * @var stdClass
+      */
+@@ -326,6 +333,10 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
+             $this->_luaMaxCStack = (int) $options['lua_max_c_stack'];
+         }
+ 
++        if (isset($options['retry_reads_on_master'])) {
++            $this->_retryReadsOnMaster = (bool) $options['retry_reads_on_master'];
++        }
++
+         if (isset($options['auto_expire_lifetime'])) {
+             $this->_autoExpireLifetime = (int) $options['auto_expire_lifetime'];
+         }
+@@ -428,6 +439,11 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
+     {
+         if ($this->_slave) {
+             $data = $this->_slave->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
++
++            // Prevent compounded effect of cache flood on asynchronously replicating master/slave setup
++            if ($this->_retryReadsOnMaster && $data === false) {
++                $data = $this->_redis->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
++            }
+         } else {
+             $data = $this->_redis->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
+         }

--- a/patches/MAGECLOUD-2899__fix_redis_slave_configuration__2.3.0.patch
+++ b/patches/MAGECLOUD-2899__fix_redis_slave_configuration__2.3.0.patch
@@ -1,0 +1,40 @@
+diff -Nuar a/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php b/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php
+--- a/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php
++++ b/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php
+@@ -111,6 +111,13 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
+      */
+     protected $_luaMaxCStack = 5000;
+ 
++    /**
++     * If 'retry_reads_on_master' is truthy then reads will be retried against master when slave returns "(nil)" value
++     *
++     * @var boolean
++     */
++    protected $_retryReadsOnMaster = false;
++
+     /**
+      * @var stdClass
+      */
+@@ -339,6 +346,10 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
+             $this->_luaMaxCStack = (int) $options['lua_max_c_stack'];
+         }
+ 
++        if (isset($options['retry_reads_on_master'])) {
++            $this->_retryReadsOnMaster = (bool) $options['retry_reads_on_master'];
++        }
++
+         if (isset($options['auto_expire_lifetime'])) {
+             $this->_autoExpireLifetime = (int) $options['auto_expire_lifetime'];
+         }
+@@ -441,6 +452,11 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
+     {
+         if ($this->_slave) {
+             $data = $this->_slave->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
++
++            // Prevent compounded effect of cache flood on asynchronously replicating master/slave setup
++            if ($this->_retryReadsOnMaster && $data === false) {
++                $data = $this->_redis->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
++            }
+         } else {
+             $data = $this->_redis->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
+         }

--- a/src/Config/Factory/Cache.php
+++ b/src/Config/Factory/Cache.php
@@ -103,6 +103,7 @@ class Cache
                 $redisCache['frontend_options']['write_control'] = false;
                 $redisCache['backend_options']['load_from_slave'] = $slaveConnectionData;
                 $redisCache['backend_options']['retry_reads_on_master'] = '1';
+                $redisCache['backend_options']['read_timeout'] = '1';
                 $this->logger->info('Set Redis slave connection');
             } else {
                 $this->logger->notice(

--- a/src/Config/Factory/Cache.php
+++ b/src/Config/Factory/Cache.php
@@ -100,7 +100,9 @@ class Cache
         $slaveConnectionData = $this->getSlaveConnection();
         if ($slaveConnectionData) {
             if ($this->isConfigurationCompatibleWithSlaveConnection($envCacheConfiguration, $redisConfig)) {
+                $redisCache['frontend_options']['write_control'] = false;
                 $redisCache['backend_options']['load_from_slave'] = $slaveConnectionData;
+                $redisCache['backend_options']['retry_reads_on_master'] = '1';
                 $this->logger->info('Set Redis slave connection');
             } else {
                 $this->logger->notice(

--- a/src/Config/Factory/Cache.php
+++ b/src/Config/Factory/Cache.php
@@ -101,8 +101,8 @@ class Cache
         if ($slaveConnectionData) {
             if ($this->isConfigurationCompatibleWithSlaveConnection($envCacheConfiguration, $redisConfig)) {
                 $redisCache['backend_options']['load_from_slave'] = $slaveConnectionData;
-                $redisCache['backend_options']['read_timeout'] = '1';
-                $redisCache['backend_options']['retry_reads_on_master'] = '1';
+                $redisCache['backend_options']['read_timeout'] = 1;
+                $redisCache['backend_options']['retry_reads_on_master'] = 1;
                 $redisCache['frontend_options']['write_control'] = false;
                 $this->logger->info('Set Redis slave connection');
             } else {

--- a/src/Config/Factory/Cache.php
+++ b/src/Config/Factory/Cache.php
@@ -100,10 +100,10 @@ class Cache
         $slaveConnectionData = $this->getSlaveConnection();
         if ($slaveConnectionData) {
             if ($this->isConfigurationCompatibleWithSlaveConnection($envCacheConfiguration, $redisConfig)) {
-                $redisCache['frontend_options']['write_control'] = false;
                 $redisCache['backend_options']['load_from_slave'] = $slaveConnectionData;
-                $redisCache['backend_options']['retry_reads_on_master'] = '1';
                 $redisCache['backend_options']['read_timeout'] = '1';
+                $redisCache['backend_options']['retry_reads_on_master'] = '1';
+                $redisCache['frontend_options']['write_control'] = false;
                 $this->logger->info('Set Redis slave connection');
             } else {
                 $this->logger->notice(

--- a/src/Test/Unit/Config/Factory/CacheTest.php
+++ b/src/Test/Unit/Config/Factory/CacheTest.php
@@ -215,15 +215,30 @@ class CacheTest extends TestCase
                 ],
             ]
         ];
+
+        $slaveConfiguration = [
+            'backend_options' => [
+                'load_from_slave' => [
+                    'server' => 'slave.host',
+                    'port' => 'slave.port',
+                ],
+                'read_timeout' => 1,
+                'retry_reads_on_master' => 1,
+            ],
+            'frontend_options' => [
+                'write_control' => false,
+            ]
+        ];
+
         $resultMasterSlaveConnection = $resultMasterOnlyConnection;
-        $resultMasterSlaveConnection['frontend']['default']['backend_options']['load_from_slave'] = [
-            'server' => 'slave.host',
-            'port' => 'slave.port',
-        ];
-        $resultMasterSlaveConnection['frontend']['page_cache']['backend_options']['load_from_slave'] = [
-            'server' => 'slave.host',
-            'port' => 'slave.port',
-        ];
+        $resultMasterSlaveConnection['frontend']['default'] = array_merge_recursive(
+            $resultMasterSlaveConnection['frontend']['default'],
+            $slaveConfiguration
+        );
+        $resultMasterSlaveConnection['frontend']['page_cache'] = array_merge_recursive(
+            $resultMasterSlaveConnection['frontend']['page_cache'],
+            $slaveConfiguration
+        );
 
         $resultMasterSlaveConnectionWithMergedValue = $resultMasterSlaveConnection;
         $resultMasterSlaveConnectionWithMergedValue['frontend']['default']['backend_options']['value'] = 'key';


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-2899
### Description
In a case when using Redis slave, adds a couple of items to the cache settings in file `app/etc/env.php`. 
A feature of this configuration is that in case of failure Redis Slave, Magento should use master for reading.

### Fixed Issues (if relevant)
1. magento/ece-tools#MAGECLOUD-2899: Redis Slave Nodes Have no Health Checks / Are not Stable

### Manual testing scenarios
https://jira.corp.magento.com/browse/MAGECLOUD-48

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
