### PR TITLE
MAGECLOUD-3172: Update default Redis DB IDs

### DIFF
--- a/src/Config/Factory/Cache.php
+++ b/src/Config/Factory/Cache.php
@@ -18,12 +18,12 @@ class Cache
     /**
      * Redis database to store default cache data
      */
-    const REDIS_DATABASE_DEFAULT = 0;
+    const REDIS_DATABASE_DEFAULT = 1;
 
     /**
      * Redis database to store page cache data
      */
-    const REDIS_DATABASE_PAGE_CACHE = 1;
+    const REDIS_DATABASE_PAGE_CACHE = 2;
 
     /**
      * @var Environment

--- a/src/Config/Factory/Cache.php
+++ b/src/Config/Factory/Cache.php
@@ -16,6 +16,16 @@ use Psr\Log\LoggerInterface;
 class Cache
 {
     /**
+     * Redis database to store default cache data
+     */
+    const REDIS_DATABASE_DEFAULT = 0;
+
+    /**
+     * Redis database to store page cache data
+     */
+    const REDIS_DATABASE_PAGE_CACHE = 1;
+
+    /**
      * @var Environment
      */
     private $environment;
@@ -93,7 +103,6 @@ class Cache
             'backend_options' => [
                 'server' => $redisConfig[0]['host'],
                 'port' => $redisConfig[0]['port'],
-                'database' => 1,
             ],
         ];
 
@@ -115,8 +124,14 @@ class Cache
 
         return $this->configMerger->mergeConfigs([
             'frontend' => [
-                'default' => $redisCache,
-                'page_cache' => $redisCache,
+                'default' => array_replace_recursive(
+                    $redisCache,
+                    ['backend_options' => ['database' => self::REDIS_DATABASE_DEFAULT]]
+                ),
+                'page_cache' => array_replace_recursive(
+                    $redisCache,
+                    ['backend_options' => ['database' => self::REDIS_DATABASE_PAGE_CACHE]]
+                ),
             ],
         ], $envCacheConfiguration);
     }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Session/Config.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Session/Config.php
@@ -19,7 +19,7 @@ class Config
     /**
      * Redis database to store session data
      */
-    const REDIS_DATABASE_SESSION = 2;
+    const REDIS_DATABASE_SESSION = 0;
     /**
      * @var Environment
      */

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/Session/Config.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/Session/Config.php
@@ -17,6 +17,10 @@ use Magento\MagentoCloud\Package\Manager;
 class Config
 {
     /**
+     * Redis database to store session data
+     */
+    const REDIS_DATABASE_SESSION = 2;
+    /**
      * @var Environment
      */
     private $environment;
@@ -93,7 +97,7 @@ class Config
             'redis' => [
                 'host' => $redisConfig[0]['host'],
                 'port' => $redisConfig[0]['port'],
-                'database' => 0,
+                'database' => self::REDIS_DATABASE_SESSION,
             ],
         ];
 

--- a/src/Test/Unit/Config/Factory/CacheTest.php
+++ b/src/Test/Unit/Config/Factory/CacheTest.php
@@ -202,7 +202,7 @@ class CacheTest extends TestCase
                     'backend_options' => [
                         'server' => 'master.host',
                         'port' => 'master.port',
-                        'database' => 1
+                        'database' => Cache::REDIS_DATABASE_DEFAULT
                     ],
                 ],
                 'page_cache' => [
@@ -210,7 +210,7 @@ class CacheTest extends TestCase
                     'backend_options' => [
                         'server' => 'master.host',
                         'port' => 'master.port',
-                        'database' => 1
+                        'database' => Cache::REDIS_DATABASE_PAGE_CACHE
                     ],
                 ],
             ]
@@ -354,7 +354,7 @@ class CacheTest extends TestCase
                     'backend_options' => [
                         'server' => 'master.host',
                         'port' => 'master.port',
-                        'database' => 1
+                        'database' => Cache::REDIS_DATABASE_DEFAULT
                     ],
                 ],
                 'page_cache' => [
@@ -362,7 +362,7 @@ class CacheTest extends TestCase
                     'backend_options' => [
                         'server' => 'master.host',
                         'port' => 'master.port',
-                        'database' => 1
+                        'database' => Cache::REDIS_DATABASE_PAGE_CACHE
                     ],
                 ],
             ]

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/Session/ConfigTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/Session/ConfigTest.php
@@ -136,7 +136,7 @@ class ConfigTest extends TestCase
             'redis' => [
                 'host' => 'host',
                 'port' => 'port',
-                'database' => 0,
+                'database' => Config::REDIS_DATABASE_SESSION,
                 'disable_locking' => 1
             ],
         ];
@@ -233,7 +233,7 @@ class ConfigTest extends TestCase
             'redis' => [
                 'host' => 'host',
                 'port' => 'port',
-                'database' => 0,
+                'database' => Config::REDIS_DATABASE_SESSION,
                 'disable_locking' => 0
             ],
         ];


### PR DESCRIPTION
### Description
https://magento2.atlassian.net/browse/MAGECLOUD-3172

### Fixed Issues (if relevant)
1. magento/ece-tools#MAGECLOUD-3172: Update default Redis DB IDs

Manual Test:
https://jira.corp.magento.com/browse/MAGETWO-99172

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
