### PR TITLE
MAGECLOUD-3470: Add validator for SearchEngine config integrity

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -246,6 +246,7 @@ class Container implements ContainerInterface
                             'validators' => [
                                 ValidatorInterface::LEVEL_CRITICAL => [
                                     $this->container->make(ConfigValidator\Deploy\DatabaseConfiguration::class),
+                                    $this->container->make(ConfigValidator\Deploy\SearchConfiguration::class),
                                     $this->container->make(ConfigValidator\Deploy\ResourceConfiguration::class),
                                     $this->container->make(ConfigValidator\Deploy\SessionConfiguration::class),
                                     $this->container->make(ConfigValidator\Deploy\ElasticSuiteIntegrity::class),

--- a/src/Config/Validator/Deploy/SearchConfiguration.php
+++ b/src/Config/Validator/Deploy/SearchConfiguration.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Config\Validator\Deploy;
+
+use Magento\MagentoCloud\Config\ConfigMerger;
+use Magento\MagentoCloud\Config\Stage\DeployInterface;
+use Magento\MagentoCloud\Config\Validator;
+use Magento\MagentoCloud\Config\Validator\ResultFactory;
+use Magento\MagentoCloud\Config\ValidatorInterface;
+
+/**
+ * Validates SEARCH_CONFIGURATION variable
+ */
+class SearchConfiguration implements ValidatorInterface
+{
+    /**
+     * @var ResultFactory
+     */
+    private $resultFactory;
+
+    /**
+     * @var DeployInterface
+     */
+    private $stageConfig;
+
+    /**
+     * @var ConfigMerger
+     */
+    private $configMerger;
+
+    /**
+     * @param ResultFactory $resultFactory
+     * @param DeployInterface $stageConfig
+     * @param ConfigMerger $configMerger
+     */
+    public function __construct(
+        ResultFactory $resultFactory,
+        DeployInterface $stageConfig,
+        ConfigMerger $configMerger
+    ) {
+        $this->resultFactory = $resultFactory;
+        $this->stageConfig = $stageConfig;
+        $this->configMerger = $configMerger;
+    }
+
+    /**
+     * Checks that SEARCH_CONFIGURATION variable contains at least 'engine' option if _merge was not set
+     *
+     * @return Validator\ResultInterface
+     */
+    public function validate(): Validator\ResultInterface
+    {
+        $searchConfig = $this->stageConfig->get(DeployInterface::VAR_SEARCH_CONFIGURATION);
+        if ($this->configMerger->isEmpty($searchConfig) || $this->configMerger->isMergeRequired($searchConfig)) {
+            return $this->resultFactory->success();
+        }
+
+        if (!isset($searchConfig['engine'])) {
+            return $this->resultFactory->error(
+                sprintf('Variable %s is not configured properly', DeployInterface::VAR_SEARCH_CONFIGURATION),
+                'At least engine option must be configured'
+            );
+        }
+
+        return $this->resultFactory->success();
+    }
+}

--- a/src/Config/Validator/Deploy/SearchConfiguration.php
+++ b/src/Config/Validator/Deploy/SearchConfiguration.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\MagentoCloud\Config\Validator\Deploy;
 
 use Magento\MagentoCloud\Config\ConfigMerger;
@@ -60,7 +62,7 @@ class SearchConfiguration implements ValidatorInterface
 
         if (!isset($searchConfig['engine'])) {
             return $this->resultFactory->error(
-                sprintf('Variable %s is not configured properly', DeployInterface::VAR_SEARCH_CONFIGURATION),
+                sprintf('Variable "%s" is not configured properly', DeployInterface::VAR_SEARCH_CONFIGURATION),
                 'At least engine option must be configured'
             );
         }

--- a/src/Test/Unit/Config/Validator/Deploy/SearchConfigurationTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/SearchConfigurationTest.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\MagentoCloud\Test\Unit\Config\Validator\Deploy;
 
 use Magento\MagentoCloud\Config\ConfigMerger;

--- a/src/Test/Unit/Config/Validator/Deploy/SearchConfigurationTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/SearchConfigurationTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Config\Validator\Deploy;
+
+use Magento\MagentoCloud\Config\ConfigMerger;
+use Magento\MagentoCloud\Config\Stage\DeployInterface;
+use Magento\MagentoCloud\Config\Validator\Deploy\SearchConfiguration;
+use Magento\MagentoCloud\Config\Validator\Result\Error;
+use Magento\MagentoCloud\Config\Validator\Result\Success;
+use Magento\MagentoCloud\Config\Validator\ResultFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @inheritdoc
+ */
+class SearchConfigurationTest extends TestCase
+{
+    /**
+     * @var SearchConfiguration
+     */
+    private $validator;
+
+    /**
+     * @var ResultFactory|MockObject
+     */
+    private $resultFactoryMock;
+
+    /**
+     * @var DeployInterface|MockObject
+     */
+    private $stageConfigMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->resultFactoryMock = $this->createConfiguredMock(ResultFactory::class, [
+            'success' => $this->createMock(Success::class),
+            'error' => $this->createMock(Error::class)
+        ]);
+        $this->stageConfigMock = $this->getMockForAbstractClass(DeployInterface::class);
+
+        $this->validator = new SearchConfiguration(
+            $this->resultFactoryMock,
+            $this->stageConfigMock,
+            new ConfigMerger()
+        );
+    }
+
+    /**
+     * @param array $searchConfiguration
+     * @param string $expectedResultClass
+     * @dataProvider validateDataProvider
+     */
+    public function testValidate(array $searchConfiguration, string $expectedResultClass)
+    {
+        $this->stageConfigMock->expects($this->once())
+            ->method('get')
+            ->with(DeployInterface::VAR_SEARCH_CONFIGURATION)
+            ->willReturn($searchConfiguration);
+
+        $this->assertInstanceOf($expectedResultClass, $this->validator->validate());
+    }
+
+    /**
+     * @return array
+     */
+    public function validateDataProvider(): array
+    {
+        return [
+            [
+                [],
+                Success::class,
+            ],
+            [
+                [
+                    '_merge' => true
+                ],
+                Success::class,
+            ],
+            [
+                [
+                    'elasticsearh_host' => '9200',
+                ],
+                Error::class,
+            ],
+            [
+
+                [
+                    'elasticsearh_host' => '9200',
+                    '_merge' => true,
+                ],
+                Success::class,
+            ],
+            [
+
+                [
+                    'engine' => 'mysql',
+                ],
+                Success::class,
+            ],
+            [
+
+                [
+                    'engine' => 'mysql',
+                    '_merge' => true,
+                ],
+                Success::class,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added validation for SEARCH_CONFIGURATION variable for containing at least `engine` option if merge not required.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3470

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGECLOUD-57  last 3 steps

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
