### PR TITLE
MAGECLOUD-3580: Env.php configs are not updated after deleting the ES service

### DIFF
--- a/src/Config/Deploy/Writer.php
+++ b/src/Config/Deploy/Writer.php
@@ -57,7 +57,7 @@ class Writer implements WriterInterface
     /**
      * @inheritdoc
      */
-    public function update(array $config, bool $recursive = true)
+    public function update(array $config)
     {
         $updatedConfig = array_replace($this->reader->read(), $config);
 

--- a/src/Config/Deploy/Writer.php
+++ b/src/Config/Deploy/Writer.php
@@ -67,7 +67,7 @@ class Writer implements WriterInterface
     /**
      * @inheritdoc
      */
-    public function updateRecursively(array $config)
+    public function updateRecursive(array $config)
     {
         $updatedConfig = array_replace_recursive($this->reader->read(), $config);
 

--- a/src/Config/Deploy/Writer.php
+++ b/src/Config/Deploy/Writer.php
@@ -59,9 +59,17 @@ class Writer implements WriterInterface
      */
     public function update(array $config, bool $recursive = true)
     {
-        $updatedConfig = $recursive ?
-            array_replace_recursive($this->reader->read(), $config) :
-            array_replace($this->reader->read(), $config);
+        $updatedConfig = array_replace($this->reader->read(), $config);
+
+        $this->create($updatedConfig);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function updateRecursively(array $config)
+    {
+        $updatedConfig = array_replace_recursive($this->reader->read(), $config);
 
         $this->create($updatedConfig);
     }

--- a/src/Config/Deploy/Writer.php
+++ b/src/Config/Deploy/Writer.php
@@ -57,9 +57,11 @@ class Writer implements WriterInterface
     /**
      * @inheritdoc
      */
-    public function update(array $config)
+    public function update(array $config, bool $recursive = true)
     {
-        $updatedConfig = array_replace_recursive($this->reader->read(), $config);
+        $updatedConfig = $recursive ?
+            array_replace_recursive($this->reader->read(), $config) :
+            array_replace($this->reader->read(), $config);
 
         $this->create($updatedConfig);
     }

--- a/src/Config/Shared.php
+++ b/src/Config/Shared.php
@@ -79,7 +79,7 @@ class Shared implements ConfigInterface
     public function update(array $config)
     {
         $this->reset();
-        $this->writer->updateRecursively($config);
+        $this->writer->updateRecursive($config);
     }
 
     /**

--- a/src/Config/Shared.php
+++ b/src/Config/Shared.php
@@ -79,7 +79,7 @@ class Shared implements ConfigInterface
     public function update(array $config)
     {
         $this->reset();
-        $this->writer->update($config);
+        $this->writer->updateRecursively($config);
     }
 
     /**

--- a/src/Config/Shared/Writer.php
+++ b/src/Config/Shared/Writer.php
@@ -57,10 +57,12 @@ class Writer implements WriterInterface
     /**
      * @inheritdoc
      */
-    public function update(array $config)
+    public function update(array $config, bool $recursive = true)
     {
-        $this->create(
-            array_replace_recursive($this->reader->read(), $config)
-        );
+        $updatedConfig = $recursive ?
+            array_replace_recursive($this->reader->read(), $config) :
+            array_replace($this->reader->read(), $config);
+
+        $this->create($updatedConfig);
     }
 }

--- a/src/Config/Shared/Writer.php
+++ b/src/Config/Shared/Writer.php
@@ -57,7 +57,7 @@ class Writer implements WriterInterface
     /**
      * @inheritdoc
      */
-    public function update(array $config, bool $recursive = true)
+    public function update(array $config)
     {
         $updatedConfig = array_replace($this->reader->read(), $config);
 

--- a/src/Config/Shared/Writer.php
+++ b/src/Config/Shared/Writer.php
@@ -67,7 +67,7 @@ class Writer implements WriterInterface
     /**
      * @inheritdoc
      */
-    public function updateRecursively(array $config)
+    public function updateRecursive(array $config)
     {
         $updatedConfig = array_replace_recursive($this->reader->read(), $config);
 

--- a/src/Config/Shared/Writer.php
+++ b/src/Config/Shared/Writer.php
@@ -59,9 +59,17 @@ class Writer implements WriterInterface
      */
     public function update(array $config, bool $recursive = true)
     {
-        $updatedConfig = $recursive ?
-            array_replace_recursive($this->reader->read(), $config) :
-            array_replace($this->reader->read(), $config);
+        $updatedConfig = array_replace($this->reader->read(), $config);
+
+        $this->create($updatedConfig);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function updateRecursively(array $config)
+    {
+        $updatedConfig = array_replace_recursive($this->reader->read(), $config);
 
         $this->create($updatedConfig);
     }

--- a/src/Config/State.php
+++ b/src/Config/State.php
@@ -85,7 +85,7 @@ class State
             return true;
         }
 
-        $this->writer->updateRecursively(['install' => ['date' => date('r')]]);
+        $this->writer->updateRecursive(['install' => ['date' => date('r')]]);
 
         return true;
     }

--- a/src/Config/State.php
+++ b/src/Config/State.php
@@ -85,7 +85,7 @@ class State
             return true;
         }
 
-        $this->writer->update(['install' => ['date' => date('r')]]);
+        $this->writer->updateRecursively(['install' => ['date' => date('r')]]);
 
         return true;
     }

--- a/src/Filesystem/Writer/WriterInterface.php
+++ b/src/Filesystem/Writer/WriterInterface.php
@@ -25,9 +25,17 @@ interface WriterInterface
      * Updates existence configuration.
      *
      * @param array $config
-     * @param bool $recursive
      * @return void
      * @throws FileSystemException
      */
-    public function update(array $config, bool $recursive = true);
+    public function update(array $config);
+
+    /**
+     * Recursively updates existence configuration.
+     *
+     * @param array $config
+     * @return void
+     * @throws FileSystemException
+     */
+    public function updateRecursively(array $config);
 }

--- a/src/Filesystem/Writer/WriterInterface.php
+++ b/src/Filesystem/Writer/WriterInterface.php
@@ -25,8 +25,9 @@ interface WriterInterface
      * Updates existence configuration.
      *
      * @param array $config
+     * @param bool $recursive
      * @return void
      * @throws FileSystemException
      */
-    public function update(array $config);
+    public function update(array $config, bool $recursive = true);
 }

--- a/src/Filesystem/Writer/WriterInterface.php
+++ b/src/Filesystem/Writer/WriterInterface.php
@@ -37,5 +37,5 @@ interface WriterInterface
      * @return void
      * @throws FileSystemException
      */
-    public function updateRecursively(array $config);
+    public function updateRecursive(array $config);
 }

--- a/src/Process/Deploy/DisableCron.php
+++ b/src/Process/Deploy/DisableCron.php
@@ -53,7 +53,7 @@ class DisableCron implements ProcessInterface
     public function execute()
     {
         $this->logger->info('Disable cron');
-        $this->writer->update(['cron' => ['enabled' => 0]]);
+        $this->writer->updateRecursively(['cron' => ['enabled' => 0]]);
 
         $this->cronProcessKill->execute();
     }

--- a/src/Process/Deploy/DisableCron.php
+++ b/src/Process/Deploy/DisableCron.php
@@ -53,7 +53,7 @@ class DisableCron implements ProcessInterface
     public function execute()
     {
         $this->logger->info('Disable cron');
-        $this->writer->updateRecursively(['cron' => ['enabled' => 0]]);
+        $this->writer->updateRecursive(['cron' => ['enabled' => 0]]);
 
         $this->cronProcessKill->execute();
     }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRoot.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRoot.php
@@ -42,6 +42,6 @@ class DocumentRoot implements ProcessInterface
     public function execute()
     {
         $this->logger->info('The value of the property \'directories/document_root_is_pub\' set as \'true\'');
-        $this->configWriter->update(['directories' => ['document_root_is_pub' => true]]);
+        $this->configWriter->updateRecursively(['directories' => ['document_root_is_pub' => true]]);
     }
 }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRoot.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRoot.php
@@ -42,6 +42,6 @@ class DocumentRoot implements ProcessInterface
     public function execute()
     {
         $this->logger->info('The value of the property \'directories/document_root_is_pub\' set as \'true\'');
-        $this->configWriter->updateRecursively(['directories' => ['document_root_is_pub' => true]]);
+        $this->configWriter->updateRecursive(['directories' => ['document_root_is_pub' => true]]);
     }
 }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
@@ -93,9 +93,9 @@ class SearchEngine implements ProcessInterface
 
             // 2.1.x requires search config to be written to the shared config file: MAGECLOUD-1317
             if ($isMagento21) {
-                $this->sharedWriter->update($config, false);
+                $this->sharedWriter->update($config);
             } else {
-                $this->envWriter->update($config, false);
+                $this->envWriter->update($config);
             }
         } catch (GenericException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
@@ -93,9 +93,9 @@ class SearchEngine implements ProcessInterface
 
             // 2.1.x requires search config to be written to the shared config file: MAGECLOUD-1317
             if ($isMagento21) {
-                $this->sharedWriter->update($config);
+                $this->sharedWriter->update($config, false);
             } else {
-                $this->envWriter->update($config);
+                $this->envWriter->update($config, false);
             }
         } catch (GenericException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);

--- a/src/Process/Deploy/InstallUpdate/Update/SetAdminUrl.php
+++ b/src/Process/Deploy/InstallUpdate/Update/SetAdminUrl.php
@@ -64,7 +64,7 @@ class SetAdminUrl implements ProcessInterface
         $config['backend']['frontName'] = $adminUrl;
 
         try {
-            $this->configWriter->update($config);
+            $this->configWriter->updateRecursively($config);
         } catch (FileSystemException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/src/Process/Deploy/InstallUpdate/Update/SetAdminUrl.php
+++ b/src/Process/Deploy/InstallUpdate/Update/SetAdminUrl.php
@@ -64,7 +64,7 @@ class SetAdminUrl implements ProcessInterface
         $config['backend']['frontName'] = $adminUrl;
 
         try {
-            $this->configWriter->updateRecursively($config);
+            $this->configWriter->updateRecursive($config);
         } catch (FileSystemException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/src/Process/Deploy/SetCryptKey.php
+++ b/src/Process/Deploy/SetCryptKey.php
@@ -79,7 +79,7 @@ class SetCryptKey implements ProcessInterface
         $config['crypt']['key'] = $key;
 
         try {
-            $this->configWriter->updateRecursively($config);
+            $this->configWriter->updateRecursive($config);
         } catch (FileSystemException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/src/Process/Deploy/SetCryptKey.php
+++ b/src/Process/Deploy/SetCryptKey.php
@@ -79,7 +79,7 @@ class SetCryptKey implements ProcessInterface
         $config['crypt']['key'] = $key;
 
         try {
-            $this->configWriter->update($config);
+            $this->configWriter->updateRecursively($config);
         } catch (FileSystemException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/src/Test/Unit/Config/Deploy/WriterTest.php
+++ b/src/Test/Unit/Config/Deploy/WriterTest.php
@@ -96,9 +96,9 @@ class WriterTest extends TestCase
      * @param array $config
      * @param array $currentConfig
      * @param string $updatedConfig
-     * @dataProvider getUpdateRecursivelyDataProvider
+     * @dataProvider getUpdateRecursiveDataProvider
      */
-    public function testUpdateRecursively(array $config, array $currentConfig, $updatedConfig)
+    public function testUpdateRecursive(array $config, array $currentConfig, $updatedConfig)
     {
         $filePath = '/path/to/file';
         $this->fileListMock->expects($this->once())
@@ -111,13 +111,13 @@ class WriterTest extends TestCase
             ->method('filePutContents')
             ->with($filePath, $updatedConfig);
 
-        $this->writer->updateRecursively($config);
+        $this->writer->updateRecursive($config);
     }
 
     /**
      * @return array
      */
-    public function getUpdateRecursivelyDataProvider()
+    public function getUpdateRecursiveDataProvider()
     {
         return [
             [

--- a/src/Test/Unit/Config/Deploy/WriterTest.php
+++ b/src/Test/Unit/Config/Deploy/WriterTest.php
@@ -96,7 +96,69 @@ class WriterTest extends TestCase
      * @param array $config
      * @param array $currentConfig
      * @param string $updatedConfig
-     * @dataProvider readDataProvider
+     * @dataProvider getUpdateRecursivelyDataProvider
+     */
+    public function testUpdateRecursively(array $config, array $currentConfig, $updatedConfig)
+    {
+        $filePath = '/path/to/file';
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
+            ->willReturn($filePath);
+        $this->readerMock->expects($this->once())
+            ->method('read')
+            ->willReturn($currentConfig);
+        $this->fileMock->expects($this->once())
+            ->method('filePutContents')
+            ->with($filePath, $updatedConfig);
+
+        $this->writer->updateRecursively($config);
+    }
+
+    /**
+     * @return array
+     */
+    public function getUpdateRecursivelyDataProvider()
+    {
+        return [
+            [
+                [],
+                [],
+                "<?php\nreturn array (\n);",
+            ],
+            [
+                ['key' => 'value'],
+                ['key1' => 'value1'],
+                "<?php\nreturn array (\n  'key1' => 'value1',\n  'key' => 'value',\n);",
+            ],
+            [
+                ['key1' => 'value1', 'key2' => 'value2'],
+                ['key1' => 'value0', 'key3' => 'value3'],
+                "<?php\nreturn array (\n  'key1' => 'value1',\n  'key3' => 'value3',\n  'key2' => 'value2',\n);",
+            ],
+            [
+                [
+                    'key1' => [
+                        'key12' => 'value2new',
+                        'key13' => 'value3new',
+                    ]
+                ],
+                [
+                    'key1' => [
+                        'key11' => 'value1',
+                        'key12' => 'value2',
+                    ]
+                ],
+                "<?php\nreturn array (\n  'key1' => \n  array (\n    'key11' => 'value1',\n" .
+                "    'key12' => 'value2new',\n    'key13' => 'value3new',\n  ),\n);"
+            ],
+        ];
+    }
+
+    /**
+     * @param array $config
+     * @param array $currentConfig
+     * @param string $updatedConfig
+     * @dataProvider getUpdateDataProvider
      */
     public function testUpdate(array $config, array $currentConfig, $updatedConfig)
     {
@@ -117,7 +179,7 @@ class WriterTest extends TestCase
     /**
      * @return array
      */
-    public function readDataProvider()
+    public function getUpdateDataProvider()
     {
         return [
             [
@@ -135,6 +197,22 @@ class WriterTest extends TestCase
                 ['key1' => 'value0', 'key3' => 'value3'],
                 "<?php\nreturn array (\n  'key1' => 'value1',\n  'key3' => 'value3',\n  'key2' => 'value2',\n);",
             ],
+            [
+                [
+                    'key1' => [
+                        'key12' => 'value2new',
+                        'key13' => 'value3new',
+                    ]
+                ],
+                [
+                    'key1' => [
+                        'key11' => 'value1',
+                        'key12' => 'value2',
+                    ]
+                ],
+                "<?php\nreturn array (\n  'key1' => \n  array (\n" .
+                "    'key12' => 'value2new',\n    'key13' => 'value3new',\n  ),\n);"
+            ]
         ];
     }
 }

--- a/src/Test/Unit/Config/Shared/WriterTest.php
+++ b/src/Test/Unit/Config/Shared/WriterTest.php
@@ -96,9 +96,9 @@ class WriterTest extends TestCase
      * @param array $config
      * @param array $currentConfig
      * @param string $updatedConfig
-     * @dataProvider updateRecursivelyDataProvider
+     * @dataProvider updateRecursiveDataProvider
      */
-    public function testUpdateRecursively(array $config, array $currentConfig, $updatedConfig)
+    public function testUpdateRecursive(array $config, array $currentConfig, $updatedConfig)
     {
         $filePath = '/path/to/file';
         $this->fileListMock->expects($this->once())
@@ -111,13 +111,13 @@ class WriterTest extends TestCase
             ->method('filePutContents')
             ->with($filePath, $updatedConfig);
 
-        $this->writer->updateRecursively($config);
+        $this->writer->updateRecursive($config);
     }
 
     /**
      * @return array
      */
-    public function updateRecursivelyDataProvider(): array
+    public function updateRecursiveDataProvider(): array
     {
         return [
             [

--- a/src/Test/Unit/Config/SharedTest.php
+++ b/src/Test/Unit/Config/SharedTest.php
@@ -129,7 +129,7 @@ class SharedTest extends TestCase
     public function testUpdate()
     {
         $this->writerMock->expects($this->once())
-            ->method('updateRecursively')
+            ->method('updateRecursive')
             ->with(['some' => 'config']);
 
         $this->shared->update(['some' => 'config']);

--- a/src/Test/Unit/Config/SharedTest.php
+++ b/src/Test/Unit/Config/SharedTest.php
@@ -129,7 +129,7 @@ class SharedTest extends TestCase
     public function testUpdate()
     {
         $this->writerMock->expects($this->once())
-            ->method('update')
+            ->method('updateRecursively')
             ->with(['some' => 'config']);
 
         $this->shared->update(['some' => 'config']);

--- a/src/Test/Unit/Config/StateTest.php
+++ b/src/Test/Unit/Config/StateTest.php
@@ -78,7 +78,7 @@ class StateTest extends TestCase
             ->method('listTables')
             ->willReturn($tables);
         $this->writerMock->expects($this->never())
-            ->method('update');
+            ->method('updateRecursively');
 
         $this->assertFalse($this->state->isInstalled());
     }
@@ -105,7 +105,7 @@ class StateTest extends TestCase
             ->method('listTables')
             ->willReturn($tables);
         $this->writerMock->expects($this->never())
-            ->method('update');
+            ->method('updateRecursively');
 
         $this->state->isInstalled();
     }
@@ -137,7 +137,7 @@ class StateTest extends TestCase
             ->method('read')
             ->willReturn([]);
         $this->writerMock->expects($this->once())
-            ->method('update')
+            ->method('updateRecursively')
             ->with($config);
 
         $dateMock = $this->getFunctionMock('Magento\MagentoCloud\Config', 'date');
@@ -166,7 +166,7 @@ class StateTest extends TestCase
             ->method('read')
             ->willReturn($config);
         $this->writerMock->expects($this->never())
-            ->method('update');
+            ->method('updateRecursively');
 
         $this->assertTrue($this->state->isInstalled());
     }

--- a/src/Test/Unit/Config/StateTest.php
+++ b/src/Test/Unit/Config/StateTest.php
@@ -78,7 +78,7 @@ class StateTest extends TestCase
             ->method('listTables')
             ->willReturn($tables);
         $this->writerMock->expects($this->never())
-            ->method('updateRecursively');
+            ->method('updateRecursive');
 
         $this->assertFalse($this->state->isInstalled());
     }
@@ -105,7 +105,7 @@ class StateTest extends TestCase
             ->method('listTables')
             ->willReturn($tables);
         $this->writerMock->expects($this->never())
-            ->method('updateRecursively');
+            ->method('updateRecursive');
 
         $this->state->isInstalled();
     }
@@ -137,7 +137,7 @@ class StateTest extends TestCase
             ->method('read')
             ->willReturn([]);
         $this->writerMock->expects($this->once())
-            ->method('updateRecursively')
+            ->method('updateRecursive')
             ->with($config);
 
         $dateMock = $this->getFunctionMock('Magento\MagentoCloud\Config', 'date');
@@ -166,7 +166,7 @@ class StateTest extends TestCase
             ->method('read')
             ->willReturn($config);
         $this->writerMock->expects($this->never())
-            ->method('updateRecursively');
+            ->method('updateRecursive');
 
         $this->assertTrue($this->state->isInstalled());
     }

--- a/src/Test/Unit/Process/Deploy/DisableCronTest.php
+++ b/src/Test/Unit/Process/Deploy/DisableCronTest.php
@@ -60,7 +60,7 @@ class DisableCronTest extends TestCase
             ->method('info')
             ->with('Disable cron');
         $this->writerMock->expects($this->once())
-            ->method('updateRecursively')
+            ->method('updateRecursive')
             ->with($config);
         $this->cronProcessKillMock->expects($this->once())
             ->method('execute');

--- a/src/Test/Unit/Process/Deploy/DisableCronTest.php
+++ b/src/Test/Unit/Process/Deploy/DisableCronTest.php
@@ -60,7 +60,7 @@ class DisableCronTest extends TestCase
             ->method('info')
             ->with('Disable cron');
         $this->writerMock->expects($this->once())
-            ->method('update')
+            ->method('updateRecursively')
             ->with($config);
         $this->cronProcessKillMock->expects($this->once())
             ->method('execute');

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRootTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRootTest.php
@@ -54,7 +54,7 @@ class DocumentRootTest extends TestCase
             ->method('info')
             ->with('The value of the property \'directories/document_root_is_pub\' set as \'true\'');
         $this->configWriterMock->expects($this->once())
-            ->method('update')
+            ->method('updateRecursively')
             ->with(['directories' => ['document_root_is_pub' => true]]);
 
         $this->process->execute();

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRootTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRootTest.php
@@ -54,7 +54,7 @@ class DocumentRootTest extends TestCase
             ->method('info')
             ->with('The value of the property \'directories/document_root_is_pub\' set as \'true\'');
         $this->configWriterMock->expects($this->once())
-            ->method('updateRecursively')
+            ->method('updateRecursive')
             ->with(['directories' => ['document_root_is_pub' => true]]);
 
         $this->process->execute();

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Update/SetAdminUrlTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Update/SetAdminUrlTest.php
@@ -66,7 +66,7 @@ class SetAdminUrlTest extends TestCase
             ->method('getAdminUrl')
             ->willReturn($frontName);
         $this->configWriterMock->expects($this->once())
-            ->method('updateRecursively')
+            ->method('updateRecursive')
             ->with(['backend' => ['frontName' => $frontName]]);
 
         $this->setAdminUrl->execute();
@@ -84,7 +84,7 @@ class SetAdminUrlTest extends TestCase
             ->method('info')
             ->with('Not updating env.php backend front name. (ADMIN_URL not set)');
         $this->configWriterMock->expects($this->never())
-            ->method('updateRecursively');
+            ->method('updateRecursive');
 
         $this->setAdminUrl->execute();
     }

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Update/SetAdminUrlTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Update/SetAdminUrlTest.php
@@ -66,7 +66,7 @@ class SetAdminUrlTest extends TestCase
             ->method('getAdminUrl')
             ->willReturn($frontName);
         $this->configWriterMock->expects($this->once())
-            ->method('update')
+            ->method('updateRecursively')
             ->with(['backend' => ['frontName' => $frontName]]);
 
         $this->setAdminUrl->execute();
@@ -84,7 +84,7 @@ class SetAdminUrlTest extends TestCase
             ->method('info')
             ->with('Not updating env.php backend front name. (ADMIN_URL not set)');
         $this->configWriterMock->expects($this->never())
-            ->method('update');
+            ->method('updateRecursively');
 
         $this->setAdminUrl->execute();
     }

--- a/src/Test/Unit/Process/Deploy/SetCryptKeyTest.php
+++ b/src/Test/Unit/Process/Deploy/SetCryptKeyTest.php
@@ -71,7 +71,7 @@ class SetCryptKeyTest extends TestCase
             ->method('info')
             ->with('Setting encryption key');
         $this->configWriterMock->expects($this->once())
-            ->method('updateRecursively')
+            ->method('updateRecursive')
             ->with(['crypt' => ['key' => 'TWFnZW50byBSb3g=']]);
 
         $this->process->execute();
@@ -88,7 +88,7 @@ class SetCryptKeyTest extends TestCase
         $this->loggerMock->expects($this->never())
             ->method('info');
         $this->configWriterMock->expects($this->never())
-            ->method('updateRecursively');
+            ->method('updateRecursive');
 
         $this->process->execute();
     }
@@ -103,7 +103,7 @@ class SetCryptKeyTest extends TestCase
         $this->loggerMock->expects($this->never())
             ->method('info');
         $this->configWriterMock->expects($this->never())
-            ->method('updateRecursively');
+            ->method('updateRecursive');
 
         $this->process->execute();
     }

--- a/src/Test/Unit/Process/Deploy/SetCryptKeyTest.php
+++ b/src/Test/Unit/Process/Deploy/SetCryptKeyTest.php
@@ -9,6 +9,7 @@ use Magento\MagentoCloud\Config\Deploy\Reader as ConfigReader;
 use Magento\MagentoCloud\Config\Deploy\Writer as ConfigWriter;
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Process\Deploy\SetCryptKey;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -18,27 +19,27 @@ use Psr\Log\LoggerInterface;
 class SetCryptKeyTest extends TestCase
 {
     /**
-     * @var Environment|Mock
+     * @var Environment|MockObject
      */
     private $environmentMock;
 
     /**
-     * @var LoggerInterface|Mock
+     * @var LoggerInterface|MockObject
      */
     private $loggerMock;
 
     /**
-     * @var ConfigReader|Mock
+     * @var ConfigReader|MockObject
      */
     private $configReaderMock;
 
     /**
-     * @var ConfigWriter|Mock
+     * @var ConfigWriter|MockObject
      */
     private $configWriterMock;
 
     /**
-     * @var DbConnection
+     * @var SetCryptKey
      */
     private $process;
 
@@ -70,7 +71,7 @@ class SetCryptKeyTest extends TestCase
             ->method('info')
             ->with('Setting encryption key');
         $this->configWriterMock->expects($this->once())
-            ->method('update')
+            ->method('updateRecursively')
             ->with(['crypt' => ['key' => 'TWFnZW50byBSb3g=']]);
 
         $this->process->execute();
@@ -87,7 +88,7 @@ class SetCryptKeyTest extends TestCase
         $this->loggerMock->expects($this->never())
             ->method('info');
         $this->configWriterMock->expects($this->never())
-            ->method('update');
+            ->method('updateRecursively');
 
         $this->process->execute();
     }
@@ -102,7 +103,7 @@ class SetCryptKeyTest extends TestCase
         $this->loggerMock->expects($this->never())
             ->method('info');
         $this->configWriterMock->expects($this->never())
-            ->method('update');
+            ->method('updateRecursively');
 
         $this->process->execute();
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed issue with clearance residual search engine configuration. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3580

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.  Add and delete ElasticSearch service 
2. check env.php file

Actual

```
'search' =>
        array (
          'engine' => 'mysql',
          'elasticsearch5_server_hostname' => 'elasticsearch.internal',
          'elasticsearch5_server_port' => 9200,
        ),
```

Expected

```
'search' =>
        array (
          'engine' => 'mysql',
        ),
```
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
