### PR TITLE
MAGECLOUD-3668: Custom data in env.php removed after redeploy

### DIFF
--- a/src/Config/Deploy/Writer.php
+++ b/src/Config/Deploy/Writer.php
@@ -59,16 +59,6 @@ class Writer implements WriterInterface
      */
     public function update(array $config)
     {
-        $updatedConfig = array_replace($this->reader->read(), $config);
-
-        $this->create($updatedConfig);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function updateRecursive(array $config)
-    {
         $updatedConfig = array_replace_recursive($this->reader->read(), $config);
 
         $this->create($updatedConfig);

--- a/src/Config/Shared.php
+++ b/src/Config/Shared.php
@@ -79,7 +79,7 @@ class Shared implements ConfigInterface
     public function update(array $config)
     {
         $this->reset();
-        $this->writer->updateRecursive($config);
+        $this->writer->update($config);
     }
 
     /**

--- a/src/Config/Shared/Writer.php
+++ b/src/Config/Shared/Writer.php
@@ -59,16 +59,6 @@ class Writer implements WriterInterface
      */
     public function update(array $config)
     {
-        $updatedConfig = array_replace($this->reader->read(), $config);
-
-        $this->create($updatedConfig);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function updateRecursive(array $config)
-    {
         $updatedConfig = array_replace_recursive($this->reader->read(), $config);
 
         $this->create($updatedConfig);

--- a/src/Config/State.php
+++ b/src/Config/State.php
@@ -85,7 +85,7 @@ class State
             return true;
         }
 
-        $this->writer->updateRecursive(['install' => ['date' => date('r')]]);
+        $this->writer->update(['install' => ['date' => date('r')]]);
 
         return true;
     }

--- a/src/Filesystem/Writer/WriterInterface.php
+++ b/src/Filesystem/Writer/WriterInterface.php
@@ -22,20 +22,11 @@ interface WriterInterface
     public function create(array $config);
 
     /**
-     * Updates existence configuration.
-     *
-     * @param array $config
-     * @return void
-     * @throws FileSystemException
-     */
-    public function update(array $config);
-
-    /**
      * Recursively updates existence configuration.
      *
      * @param array $config
      * @return void
      * @throws FileSystemException
      */
-    public function updateRecursive(array $config);
+    public function update(array $config);
 }

--- a/src/Process/Deploy/DisableCron.php
+++ b/src/Process/Deploy/DisableCron.php
@@ -53,7 +53,7 @@ class DisableCron implements ProcessInterface
     public function execute()
     {
         $this->logger->info('Disable cron');
-        $this->writer->updateRecursive(['cron' => ['enabled' => 0]]);
+        $this->writer->update(['cron' => ['enabled' => 0]]);
 
         $this->cronProcessKill->execute();
     }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRoot.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRoot.php
@@ -42,6 +42,6 @@ class DocumentRoot implements ProcessInterface
     public function execute()
     {
         $this->logger->info('The value of the property \'directories/document_root_is_pub\' set as \'true\'');
-        $this->configWriter->updateRecursive(['directories' => ['document_root_is_pub' => true]]);
+        $this->configWriter->update(['directories' => ['document_root_is_pub' => true]]);
     }
 }

--- a/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
+++ b/src/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngine.php
@@ -9,10 +9,13 @@ namespace Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate;
 
 use Magento\MagentoCloud\App\GenericException;
 use Magento\MagentoCloud\Config\Deploy\Writer as EnvWriter;
+use Magento\MagentoCloud\Config\Deploy\Reader as EnvReader;
 use Magento\MagentoCloud\Config\Shared\Writer as SharedWriter;
+use Magento\MagentoCloud\Config\Shared\Reader as SharedReader;
+use Magento\MagentoCloud\Filesystem\Reader\ReaderInterface;
+use Magento\MagentoCloud\Filesystem\Writer\WriterInterface;
 use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\Config\SearchEngine as SearchEngineConfig;
-use Magento\MagentoCloud\Package\UndefinedPackageException;
 use Magento\MagentoCloud\Process\ProcessException;
 use Magento\MagentoCloud\Process\ProcessInterface;
 use Psr\Log\LoggerInterface;
@@ -50,22 +53,38 @@ class SearchEngine implements ProcessInterface
     private $searchEngineConfig;
 
     /**
+     * @var EnvReader
+     */
+    private $envReader;
+
+    /**
+     * @var SharedReader
+     */
+    private $sharedReader;
+
+    /**
      * @param LoggerInterface $logger
      * @param EnvWriter $envWriter
+     * @param EnvReader $envReader
      * @param SharedWriter $sharedWriter
+     * @param SharedReader $sharedReader
      * @param MagentoVersion $version
      * @param SearchEngineConfig $searchEngineConfig
      */
     public function __construct(
         LoggerInterface $logger,
         EnvWriter $envWriter,
+        EnvReader $envReader,
         SharedWriter $sharedWriter,
+        SharedReader $sharedReader,
         MagentoVersion $version,
         SearchEngineConfig $searchEngineConfig
     ) {
         $this->logger = $logger;
         $this->envWriter = $envWriter;
+        $this->envReader = $envReader;
         $this->sharedWriter = $sharedWriter;
+        $this->sharedReader = $sharedReader;
         $this->magentoVersion = $version;
         $this->searchEngineConfig = $searchEngineConfig;
     }
@@ -81,24 +100,38 @@ class SearchEngine implements ProcessInterface
         try {
             $config = $this->searchEngineConfig->getConfig();
             $engine = $this->searchEngineConfig->getName();
-        } catch (UndefinedPackageException $exception) {
-            throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
-        }
 
-        $this->logger->info('Updating search engine configuration.');
-        $this->logger->info('Set search engine to: ' . $engine);
+            $this->logger->info('Updating search engine configuration.');
+            $this->logger->info('Set search engine to: ' . $engine);
 
-        try {
             $isMagento21 = $this->magentoVersion->satisfies('2.1.*');
 
             // 2.1.x requires search config to be written to the shared config file: MAGECLOUD-1317
             if ($isMagento21) {
-                $this->sharedWriter->update($config);
+                $this->updateSearchConfiguration($config, $this->sharedReader, $this->sharedWriter);
             } else {
-                $this->envWriter->update($config);
+                $this->updateSearchConfiguration($config, $this->envReader, $this->envWriter);
             }
         } catch (GenericException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }
+    }
+
+    /**
+     * Unset previous search configuration and updates with new one from $searchConfig array
+     *
+     * @param array $searchConfig
+     * @param ReaderInterface $reader
+     * @param WriterInterface $writer
+     * @throws \Magento\MagentoCloud\Filesystem\FileSystemException
+     */
+    private function updateSearchConfiguration(array $searchConfig, ReaderInterface $reader, WriterInterface $writer)
+    {
+        $config = $reader->read();
+
+        unset($config['system']['default']['smile_elasticsuite_core_base_settings']);
+        unset($config['system']['default']['catalog']['search']);
+
+        $writer->create(array_merge_recursive($config, $searchConfig));
     }
 }

--- a/src/Process/Deploy/InstallUpdate/Update/SetAdminUrl.php
+++ b/src/Process/Deploy/InstallUpdate/Update/SetAdminUrl.php
@@ -64,7 +64,7 @@ class SetAdminUrl implements ProcessInterface
         $config['backend']['frontName'] = $adminUrl;
 
         try {
-            $this->configWriter->updateRecursive($config);
+            $this->configWriter->update($config);
         } catch (FileSystemException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/src/Process/Deploy/SetCryptKey.php
+++ b/src/Process/Deploy/SetCryptKey.php
@@ -79,7 +79,7 @@ class SetCryptKey implements ProcessInterface
         $config['crypt']['key'] = $key;
 
         try {
-            $this->configWriter->updateRecursive($config);
+            $this->configWriter->update($config);
         } catch (FileSystemException $exception) {
             throw new ProcessException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/src/Test/Unit/Config/Deploy/WriterTest.php
+++ b/src/Test/Unit/Config/Deploy/WriterTest.php
@@ -96,68 +96,6 @@ class WriterTest extends TestCase
      * @param array $config
      * @param array $currentConfig
      * @param string $updatedConfig
-     * @dataProvider getUpdateRecursiveDataProvider
-     */
-    public function testUpdateRecursive(array $config, array $currentConfig, $updatedConfig)
-    {
-        $filePath = '/path/to/file';
-        $this->fileListMock->expects($this->once())
-            ->method('getEnv')
-            ->willReturn($filePath);
-        $this->readerMock->expects($this->once())
-            ->method('read')
-            ->willReturn($currentConfig);
-        $this->fileMock->expects($this->once())
-            ->method('filePutContents')
-            ->with($filePath, $updatedConfig);
-
-        $this->writer->updateRecursive($config);
-    }
-
-    /**
-     * @return array
-     */
-    public function getUpdateRecursiveDataProvider()
-    {
-        return [
-            [
-                [],
-                [],
-                "<?php\nreturn array (\n);",
-            ],
-            [
-                ['key' => 'value'],
-                ['key1' => 'value1'],
-                "<?php\nreturn array (\n  'key1' => 'value1',\n  'key' => 'value',\n);",
-            ],
-            [
-                ['key1' => 'value1', 'key2' => 'value2'],
-                ['key1' => 'value0', 'key3' => 'value3'],
-                "<?php\nreturn array (\n  'key1' => 'value1',\n  'key3' => 'value3',\n  'key2' => 'value2',\n);",
-            ],
-            [
-                [
-                    'key1' => [
-                        'key12' => 'value2new',
-                        'key13' => 'value3new',
-                    ]
-                ],
-                [
-                    'key1' => [
-                        'key11' => 'value1',
-                        'key12' => 'value2',
-                    ]
-                ],
-                "<?php\nreturn array (\n  'key1' => \n  array (\n    'key11' => 'value1',\n" .
-                "    'key12' => 'value2new',\n    'key13' => 'value3new',\n  ),\n);"
-            ],
-        ];
-    }
-
-    /**
-     * @param array $config
-     * @param array $currentConfig
-     * @param string $updatedConfig
      * @dataProvider getUpdateDataProvider
      */
     public function testUpdate(array $config, array $currentConfig, $updatedConfig)
@@ -210,8 +148,71 @@ class WriterTest extends TestCase
                         'key12' => 'value2',
                     ]
                 ],
-                "<?php\nreturn array (\n  'key1' => \n  array (\n" .
+                "<?php\nreturn array (\n  'key1' => \n  array (\n    'key11' => 'value1',\n" .
                 "    'key12' => 'value2new',\n    'key13' => 'value3new',\n  ),\n);"
+            ],
+            [
+                [
+                    'system' => [
+                        'default' => [
+                            'catalog' => [
+                                'search' => [
+                                    'engine' => 'elasticsearch'
+                                ],
+                            ],
+                        ],
+                    ],
+                    'key1' => [
+                        'key12' => 'value2new',
+                        'key13' => 'value3new',
+                    ]
+                ],
+                [
+                    'system' => [
+                        'default' => [
+                            'category' => [
+                                'option' => 'value'
+                            ],
+                            'catalog' => [
+                                'search' => [
+                                    'engine' => 'mysql',
+                                    'host' => 'localhost',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'key1' => [
+                        'key11' => 'value1',
+                        'key12' => 'value2',
+                    ]
+                ],
+                "<?php
+return array (
+  'system' => 
+  array (
+    'default' => 
+    array (
+      'category' => 
+      array (
+        'option' => 'value',
+      ),
+      'catalog' => 
+      array (
+        'search' => 
+        array (
+          'engine' => 'elasticsearch',
+          'host' => 'localhost',
+        ),
+      ),
+    ),
+  ),
+  'key1' => 
+  array (
+    'key11' => 'value1',
+    'key12' => 'value2new',
+    'key13' => 'value3new',
+  ),
+);"
             ]
         ];
     }

--- a/src/Test/Unit/Config/Shared/WriterTest.php
+++ b/src/Test/Unit/Config/Shared/WriterTest.php
@@ -96,9 +96,9 @@ class WriterTest extends TestCase
      * @param array $config
      * @param array $currentConfig
      * @param string $updatedConfig
-     * @dataProvider updateRecursiveDataProvider
+     * @dataProvider updateDataProvider
      */
-    public function testUpdateRecursive(array $config, array $currentConfig, $updatedConfig)
+    public function testupdate(array $config, array $currentConfig, $updatedConfig)
     {
         $filePath = '/path/to/file';
         $this->fileListMock->expects($this->once())
@@ -111,13 +111,13 @@ class WriterTest extends TestCase
             ->method('filePutContents')
             ->with($filePath, $updatedConfig);
 
-        $this->writer->updateRecursive($config);
+        $this->writer->update($config);
     }
 
     /**
      * @return array
      */
-    public function updateRecursiveDataProvider(): array
+    public function updateDataProvider(): array
     {
         return [
             [
@@ -151,68 +151,6 @@ class WriterTest extends TestCase
                 "<?php\nreturn array (\n  'key1' => \n  array (\n    'key11' => 'value1',\n" .
                 "    'key12' => 'value2new',\n    'key13' => 'value3new',\n  ),\n);"
             ],
-        ];
-    }
-
-    /**
-     * @param array $config
-     * @param array $currentConfig
-     * @param string $updatedConfig
-     * @dataProvider getUpdateDataProvider
-     */
-    public function testUpdate(array $config, array $currentConfig, $updatedConfig)
-    {
-        $filePath = '/path/to/file';
-        $this->fileListMock->expects($this->once())
-            ->method('getConfig')
-            ->willReturn($filePath);
-        $this->readerMock->expects($this->once())
-            ->method('read')
-            ->willReturn($currentConfig);
-        $this->fileMock->expects($this->once())
-            ->method('filePutContents')
-            ->with($filePath, $updatedConfig);
-
-        $this->writer->update($config);
-    }
-
-    /**
-     * @return array
-     */
-    public function getUpdateDataProvider()
-    {
-        return [
-            [
-                [],
-                [],
-                "<?php\nreturn array (\n);",
-            ],
-            [
-                ['key' => 'value'],
-                ['key1' => 'value1'],
-                "<?php\nreturn array (\n  'key1' => 'value1',\n  'key' => 'value',\n);",
-            ],
-            [
-                ['key1' => 'value1', 'key2' => 'value2'],
-                ['key1' => 'value0', 'key3' => 'value3'],
-                "<?php\nreturn array (\n  'key1' => 'value1',\n  'key3' => 'value3',\n  'key2' => 'value2',\n);",
-            ],
-            [
-                [
-                    'key1' => [
-                        'key12' => 'value2new',
-                        'key13' => 'value3new',
-                    ]
-                ],
-                [
-                    'key1' => [
-                        'key11' => 'value1',
-                        'key12' => 'value2',
-                    ]
-                ],
-                "<?php\nreturn array (\n  'key1' => \n  array (\n" .
-                "    'key12' => 'value2new',\n    'key13' => 'value3new',\n  ),\n);"
-            ]
         ];
     }
 }

--- a/src/Test/Unit/Config/SharedTest.php
+++ b/src/Test/Unit/Config/SharedTest.php
@@ -129,7 +129,7 @@ class SharedTest extends TestCase
     public function testUpdate()
     {
         $this->writerMock->expects($this->once())
-            ->method('updateRecursive')
+            ->method('update')
             ->with(['some' => 'config']);
 
         $this->shared->update(['some' => 'config']);

--- a/src/Test/Unit/Config/StateTest.php
+++ b/src/Test/Unit/Config/StateTest.php
@@ -78,7 +78,7 @@ class StateTest extends TestCase
             ->method('listTables')
             ->willReturn($tables);
         $this->writerMock->expects($this->never())
-            ->method('updateRecursive');
+            ->method('update');
 
         $this->assertFalse($this->state->isInstalled());
     }
@@ -105,7 +105,7 @@ class StateTest extends TestCase
             ->method('listTables')
             ->willReturn($tables);
         $this->writerMock->expects($this->never())
-            ->method('updateRecursive');
+            ->method('update');
 
         $this->state->isInstalled();
     }
@@ -137,7 +137,7 @@ class StateTest extends TestCase
             ->method('read')
             ->willReturn([]);
         $this->writerMock->expects($this->once())
-            ->method('updateRecursive')
+            ->method('update')
             ->with($config);
 
         $dateMock = $this->getFunctionMock('Magento\MagentoCloud\Config', 'date');
@@ -166,7 +166,7 @@ class StateTest extends TestCase
             ->method('read')
             ->willReturn($config);
         $this->writerMock->expects($this->never())
-            ->method('updateRecursive');
+            ->method('update');
 
         $this->assertTrue($this->state->isInstalled());
     }

--- a/src/Test/Unit/Process/Deploy/DisableCronTest.php
+++ b/src/Test/Unit/Process/Deploy/DisableCronTest.php
@@ -60,7 +60,7 @@ class DisableCronTest extends TestCase
             ->method('info')
             ->with('Disable cron');
         $this->writerMock->expects($this->once())
-            ->method('updateRecursive')
+            ->method('update')
             ->with($config);
         $this->cronProcessKillMock->expects($this->once())
             ->method('execute');

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRootTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/DocumentRootTest.php
@@ -54,7 +54,7 @@ class DocumentRootTest extends TestCase
             ->method('info')
             ->with('The value of the property \'directories/document_root_is_pub\' set as \'true\'');
         $this->configWriterMock->expects($this->once())
-            ->method('updateRecursive')
+            ->method('update')
             ->with(['directories' => ['document_root_is_pub' => true]]);
 
         $this->process->execute();

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngineTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngineTest.php
@@ -147,6 +147,7 @@ class SearchEngineTest extends TestCase
 
     /**
      * @return array
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function executeDataProvider(): array
     {

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngineTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/ConfigUpdate/SearchEngineTest.php
@@ -7,14 +7,17 @@ declare(strict_types=1);
 
 namespace Magento\MagentoCloud\Test\Unit\Process\Deploy\InstallUpdate\ConfigUpdate;
 
+use Magento\MagentoCloud\Config\Deploy\Reader as EnvReader;
 use Magento\MagentoCloud\Config\Deploy\Writer as EnvWriter;
+use Magento\MagentoCloud\Config\SearchEngine as SearchEngineConfig;
+use Magento\MagentoCloud\Config\Shared\Reader as SharedReader;
 use Magento\MagentoCloud\Config\Shared\Writer as SharedWriter;
 use Magento\MagentoCloud\Filesystem\FileSystemException;
 use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\Package\UndefinedPackageException;
 use Magento\MagentoCloud\Process\Deploy\InstallUpdate\ConfigUpdate\SearchEngine;
-use Magento\MagentoCloud\Config\SearchEngine as SearchEngineConfig;
 use Magento\MagentoCloud\Process\ProcessException;
+use PHPUnit\Framework\MockObject\Matcher\InvokedCount;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -55,12 +58,24 @@ class SearchEngineTest extends TestCase
     private $configMock;
 
     /**
+     * @var EnvReader|MockObject
+     */
+    private $envReaderMock;
+
+    /**
+     * @var SharedReader|MockObject
+     */
+    private $sharedReaderMock;
+
+    /**
      * @inheritdoc
      */
     protected function setUp()
     {
         $this->envWriterMock = $this->createMock(EnvWriter::class);
+        $this->envReaderMock = $this->createMock(EnvReader::class);
         $this->sharedWriterMock = $this->createMock(SharedWriter::class);
+        $this->sharedReaderMock = $this->createMock(SharedReader::class);
         $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
         $this->magentoVersionMock = $this->createMock(MagentoVersion::class);
         $this->configMock = $this->createMock(SearchEngineConfig::class);
@@ -68,22 +83,39 @@ class SearchEngineTest extends TestCase
         $this->process = new SearchEngine(
             $this->loggerMock,
             $this->envWriterMock,
+            $this->envReaderMock,
             $this->sharedWriterMock,
+            $this->sharedReaderMock,
             $this->magentoVersionMock,
             $this->configMock
         );
     }
 
     /**
+     * @param bool $is21
+     * @param InvokedCount $useSharedWriter
+     * @param InvokedCount $useSharedReader
+     * @param InvokedCount $useEnvWriter
+     * @param InvokedCount $useEnvReader
+     * @param array $searchConfig
+     * @param array $fileConfig
+     * @param array $expectedConfig
      * @throws ProcessException
+     * @dataProvider executeDataProvider
      */
-    public function testExecute()
-    {
-        $config['system']['default']['catalog']['search'] = ['engine' => 'mysql'];
-
+    public function testExecute(
+        bool $is21,
+        InvokedCount $useSharedWriter,
+        InvokedCount $useSharedReader,
+        InvokedCount $useEnvWriter,
+        InvokedCount $useEnvReader,
+        array $searchConfig,
+        array $fileConfig,
+        array $expectedConfig
+    ) {
         $this->configMock->expects($this->once())
             ->method('getConfig')
-            ->willReturn($config);
+            ->willReturn($searchConfig);
         $this->configMock->expects($this->once())
             ->method('getName')
             ->willReturn('mysql');
@@ -96,46 +128,19 @@ class SearchEngineTest extends TestCase
         $this->magentoVersionMock->expects($this->once())
             ->method('satisfies')
             ->with('2.1.*')
-            ->willReturn(false);
-        $this->sharedWriterMock->expects($this->never())
-            ->method('update')
-            ->with($config);
-        $this->envWriterMock->expects($this->once())
-            ->method('update')
-            ->with($config);
-
-        $this->process->execute();
-    }
-
-    /**
-     * @throws ProcessException
-     */
-    public function testExecute21()
-    {
-        $config['system']['default']['catalog']['search'] = ['engine' => 'mysql'];
-
-        $this->configMock->expects($this->once())
-            ->method('getConfig')
-            ->willReturn($config);
-        $this->configMock->expects($this->once())
-            ->method('getName')
-            ->willReturn('mysql');
-        $this->loggerMock->expects($this->exactly(2))
-            ->method('info')
-            ->withConsecutive(
-                ['Updating search engine configuration.'],
-                ['Set search engine to: mysql']
-            );
-        $this->magentoVersionMock->expects($this->once())
-            ->method('satisfies')
-            ->with('2.1.*')
-            ->willReturn(true);
-        $this->sharedWriterMock->expects($this->once())
-            ->method('update')
-            ->with($config);
-        $this->envWriterMock->expects($this->never())
-            ->method('update')
-            ->with($config);
+            ->willReturn($is21);
+        $this->sharedReaderMock->expects($useSharedReader)
+            ->method('read')
+            ->willReturn($fileConfig);
+        $this->sharedWriterMock->expects($useSharedWriter)
+            ->method('create')
+            ->with($expectedConfig);
+        $this->envReaderMock->expects($useEnvReader)
+            ->method('read')
+            ->willReturn($fileConfig);
+        $this->envWriterMock->expects($useEnvWriter)
+            ->method('create')
+            ->with($expectedConfig);
 
         $this->process->execute();
     }
@@ -145,17 +150,139 @@ class SearchEngineTest extends TestCase
      */
     public function executeDataProvider(): array
     {
+        $mysqlSearchConfig['system']['default']['catalog']['search'] = ['engine' => 'mysql'];
+        $elasticSearchConfig = [
+            'system' => [
+                'default' => [
+                    'smile_elasticsuite_core_base_settings' => [
+                        'option3' => 'value3',
+                        'option4' => 'value4'
+                    ],
+                    'catalog' => [
+                        'search' => [
+                            'engine' => 'elasticsearch5',
+                            'elasticsearh5_host' => 'localhost',
+                            'elasticsearh5_port' => '9200',
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $fileConfig = [
+            'config' => 'value',
+            'system' => [
+                'default' => [
+                    'smile_elasticsuite_core_base_settings' => [
+                        'option1' => 'value1',
+                        'option2' => 'value2'
+                    ],
+                    'category' => [
+                        'option' => 'value'
+                    ],
+                    'catalog' => [
+                        'search' => [
+                            'engine' => 'elasticsearch',
+                            'elasticsearh_host' => 'localhost',
+                            'elasticsearh_port' => '9200',
+                        ]
+                    ]
+                ],
+                'store1' => [
+                    'category' => [
+                        'option' => 'value'
+                    ],
+                ],
+            ]
+        ];
+        $mysqlExpectedConfig = [
+            'config' => 'value',
+            'system' => [
+                'default' => [
+                    'catalog' => [
+                        'search' => [
+                            'engine' => 'mysql'
+                        ],
+                    ],
+                    'category' => [
+                        'option' => 'value'
+                    ],
+                ],
+                'store1' => [
+                    'category' => [
+                        'option' => 'value'
+                    ],
+                ],
+            ]
+        ];
+        $elasticExpectedConfig = [
+            'config' => 'value',
+            'system' => [
+                'default' => [
+                    'smile_elasticsuite_core_base_settings' => [
+                        'option3' => 'value3',
+                        'option4' => 'value4'
+                    ],
+                    'category' => [
+                        'option' => 'value'
+                    ],
+                    'catalog' => [
+                        'search' => [
+                            'engine' => 'elasticsearch5',
+                            'elasticsearh5_host' => 'localhost',
+                            'elasticsearh5_port' => '9200',
+                        ]
+                    ]
+                ],
+                'store1' => [
+                    'category' => [
+                        'option' => 'value'
+                    ],
+                ],
+            ]
+        ];
+
         return [
-            [
-                'is21' => false,
-                'useSharedWriter' => $this->never(),
-                'useEnvWriter' => $this->once(),
-            ],
-            [
+            'magento version 2.1 mysql config' => [
                 'is21' => true,
                 'useSharedWriter' => $this->once(),
+                'useSharedReader' => $this->once(),
                 'useEnvWriter' => $this->never(),
+                'useEnvReader' => $this->never(),
+                'searchConfig' => $mysqlSearchConfig,
+                'fileConfig' => $fileConfig,
+                'expectedConfig' => $mysqlExpectedConfig
             ],
+            'magento version > 2.1 mysql config' => [
+                'is21' => false,
+                'useSharedWriter' => $this->never(),
+                'useSharedReader' => $this->never(),
+                'useEnvWriter' => $this->once(),
+                'useEnvReader' => $this->once(),
+                'searchConfig' => $mysqlSearchConfig,
+                'fileConfig' => $fileConfig,
+                'expectedConfig' => $mysqlExpectedConfig
+            ],
+            'magento version 2.1 elasticsearch config' => [
+                'is21' => true,
+                'useSharedWriter' => $this->once(),
+                'useSharedReader' => $this->once(),
+                'useEnvWriter' => $this->never(),
+                'useEnvReader' => $this->never(),
+                'searchConfig' => $elasticSearchConfig,
+                'fileConfig' => $fileConfig,
+                'expectedConfig' => $elasticExpectedConfig
+            ],
+            'magento version > 2.1 elasticsearch config' => [
+                'is21' => false,
+                'useSharedWriter' => $this->never(),
+                'useSharedReader' => $this->never(),
+                'useEnvWriter' => $this->once(),
+                'useEnvReader' => $this->once(),
+                'searchConfig' => $elasticSearchConfig,
+                'fileConfig' => $fileConfig,
+                'expectedConfig' => $elasticExpectedConfig
+            ],
+
         ];
     }
 
@@ -189,7 +316,7 @@ class SearchEngineTest extends TestCase
             ->method('update')
             ->with($config);
         $this->envWriterMock->expects($this->once())
-            ->method('update')
+            ->method('create')
             ->with($config)
             ->willThrowException(new FileSystemException('Some error'));
 

--- a/src/Test/Unit/Process/Deploy/InstallUpdate/Update/SetAdminUrlTest.php
+++ b/src/Test/Unit/Process/Deploy/InstallUpdate/Update/SetAdminUrlTest.php
@@ -66,7 +66,7 @@ class SetAdminUrlTest extends TestCase
             ->method('getAdminUrl')
             ->willReturn($frontName);
         $this->configWriterMock->expects($this->once())
-            ->method('updateRecursive')
+            ->method('update')
             ->with(['backend' => ['frontName' => $frontName]]);
 
         $this->setAdminUrl->execute();
@@ -84,7 +84,7 @@ class SetAdminUrlTest extends TestCase
             ->method('info')
             ->with('Not updating env.php backend front name. (ADMIN_URL not set)');
         $this->configWriterMock->expects($this->never())
-            ->method('updateRecursive');
+            ->method('update');
 
         $this->setAdminUrl->execute();
     }

--- a/src/Test/Unit/Process/Deploy/SetCryptKeyTest.php
+++ b/src/Test/Unit/Process/Deploy/SetCryptKeyTest.php
@@ -71,7 +71,7 @@ class SetCryptKeyTest extends TestCase
             ->method('info')
             ->with('Setting encryption key');
         $this->configWriterMock->expects($this->once())
-            ->method('updateRecursive')
+            ->method('update')
             ->with(['crypt' => ['key' => 'TWFnZW50byBSb3g=']]);
 
         $this->process->execute();
@@ -88,7 +88,7 @@ class SetCryptKeyTest extends TestCase
         $this->loggerMock->expects($this->never())
             ->method('info');
         $this->configWriterMock->expects($this->never())
-            ->method('updateRecursive');
+            ->method('update');
 
         $this->process->execute();
     }
@@ -103,7 +103,7 @@ class SetCryptKeyTest extends TestCase
         $this->loggerMock->expects($this->never())
             ->method('info');
         $this->configWriterMock->expects($this->never())
-            ->method('updateRecursive');
+            ->method('update');
 
         $this->process->execute();
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3668

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. https://jira.corp.magento.com/browse/MC-11918 
2. app:config:dump + redeploy
3. Add and delete ElasticSearch service
    check env.php file


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
