### PR TITLE
MAGECLOUD-3704: Magento cloud 2.1.x and 2.2.x installations are failing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "version": "2002.0.19",
   "license": "OSL-3.0",
   "require": {
-    "php": "^7.1",
+    "php": "^7.0",
     "ext-PDO": "*",
     "ext-json": "*",
     "composer/composer": "@stable",
@@ -19,7 +19,7 @@
     "psr/container": "^1.0",
     "psr/log": "^1.0",
     "symfony/console": "^2.6||^4.0",
-    "symfony/yaml": "^4.0",
+    "symfony/yaml": "^3.3||^4.0",
     "symfony/process": "~2.1||~4.1.0",
     "twig/twig": "^1.0||^2.0"
   },
@@ -28,9 +28,12 @@
     "phpmd/phpmd": "@stable",
     "phpunit/php-code-coverage": "^5.2",
     "phpunit/phpunit": "^6.2",
-    "squizlabs/php_codesniffer": " ^3.0",
+    "squizlabs/php_codesniffer": "^3.0",
     "codeception/codeception": "^2.5.3",
     "consolidation/robo": "^1.2"
+  },
+  "conflict": {
+    "nesbot/carbon": ">=1.38 <2.0"
   },
   "replace": {
     "magento/ece-patches": "*",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "version": "2002.0.19",
   "license": "OSL-3.0",
   "require": {
-    "php": "^7.0",
+    "php": "^7.1",
     "ext-PDO": "*",
     "ext-json": "*",
     "composer/composer": "@stable",
@@ -19,7 +19,7 @@
     "psr/container": "^1.0",
     "psr/log": "^1.0",
     "symfony/console": "^2.6||^4.0",
-    "symfony/yaml": "^3.3",
+    "symfony/yaml": "^4.0",
     "symfony/process": "~2.1||~4.1.0",
     "twig/twig": "^1.0||^2.0"
   },

--- a/tests/functional/Codeception/Docker.php
+++ b/tests/functional/Codeception/Docker.php
@@ -151,13 +151,27 @@ class Docker extends Module implements BuilderAwareInterface, ContainerAwareInte
             ->workingDir($this->_getConfig('system_magento_dir'))
             ->noInteraction()
             ->option('--no-update');
+        /**
+         * This is temporary fix for MAGECLOUD-3714
+         */
+        $composerRequireCarbonTask = $this->taskComposerRequire('composer')
+            ->dependency('nesbot/carbon', '<1.38||^2.0')
+            ->workingDir($this->_getConfig('system_magento_dir'))
+            ->noInteraction()
+            ->option('--no-update');
         $composerUpdateTask = $this->taskComposerUpdate('composer');
+
+        $tasks = [
+            $composerRequireTask->getCommand(),
+            $composerRequireCarbonTask->getCommand(),
+            $composerUpdateTask->getCommand()
+        ];
 
         /** @var Result $result */
         $result = $this->taskBash(self::BUILD_CONTAINER)
             ->printOutput($this->_getConfig('printOutput'))
             ->interactive(false)
-            ->exec($composerRequireTask->getCommand() . ' && ' . $composerUpdateTask->getCommand())
+            ->exec(implode(' && ', $tasks))
             ->run();
 
         $this->output = $result->getMessage();

--- a/tests/functional/Robo/Tasks/DockerCompose/Run.php
+++ b/tests/functional/Robo/Tasks/DockerCompose/Run.php
@@ -56,7 +56,7 @@ class Run extends BaseTask implements CommandInterface
     public function getCommand()
     {
         return trim(sprintf(
-            'docker-compose run %s %s ' . $this->runWrapper,
+            'docker-compose run -w "/var/www/magento" %s %s ' . $this->runWrapper,
             $this->arguments,
             $this->container,
             $this->run


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://magento2.atlassian.net/browse/MAGECLOUD-3704

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run `composer update` on a cloned version

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
