### PR TITLE
MAGECLOUD-3559: [Spike] Check how mutagen.io can improve performance of cloud docker environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,10 @@
         "docker-sync.yml"
       ],
       [
+        "dist/mutagen.sh",
+        "mutagen.sh"
+      ],
+      [
         "dist/docker/mnt",
         ".docker/mnt"
       ],

--- a/dist/mutagen.sh
+++ b/dist/mutagen.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+mutagen create \
+       --sync-mode=two-way-resolved \
+       --default-file-mode=0644 \
+       --default-directory-mode=0755 \
+       --ignore=/.idea \
+       --ignore=/.magento \
+       --ignore=/.docker \
+       --ignore=/.github \
+       --ignore-vcs \
+       --symlink-mode=posix-raw \
+       ./ docker://$(docker-compose ps -q fpm|awk '{print $1}')/app

--- a/src/Command/Docker/Build.php
+++ b/src/Command/Docker/Build.php
@@ -156,7 +156,7 @@ class Build extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 sprintf(
-                    'Sync Engine for Docker (%s)',
+                    'File sync engine. Works only with developer mode. Available: (%s)',
                     implode(', ', DeveloperCompose::SYNC_ENGINES_LIST)
                 ),
                 DeveloperCompose::SYNC_ENGINE_DOCKER_SYNC
@@ -179,6 +179,15 @@ class Build extends Command
 
         $compose = $this->composeFactory->create($type);
         $config = $this->configFactory->create();
+
+        if (ComposeFactory::COMPOSE_DEVELOPER === $type
+            && !in_array($syncEngine, DeveloperCompose::SYNC_ENGINES_LIST)) {
+            throw new ConfigurationMismatchException(sprintf(
+                "File sync engine `%s` is not supported. Available: %s",
+                $syncEngine,
+                implode(', ', DeveloperCompose::SYNC_ENGINES_LIST)
+            ));
+        }
 
         $map = [
             self::OPTION_PHP => Service::NAME_PHP,
@@ -209,17 +218,6 @@ class Build extends Command
 
         if ($errorList && !$helper->ask($input, $output, $question) && $input->isInteractive()) {
             return 1;
-        }
-
-        if (
-            ComposeFactory::COMPOSE_DEVELOPER === $type
-            && !in_array($syncEngine, DeveloperCompose::SYNC_ENGINES_LIST)
-        ) {
-            throw new ConfigurationMismatchException(sprintf(
-                "We don't support %s. We support only: %s.",
-                $syncEngine,
-                implode(', ', DeveloperCompose::SYNC_ENGINES_LIST)
-            ));
         }
 
         $config->set(DeveloperCompose::SYNC_ENGINE, $syncEngine);

--- a/src/Docker/Compose/DeveloperCompose.php
+++ b/src/Docker/Compose/DeveloperCompose.php
@@ -14,6 +14,15 @@ use Illuminate\Contracts\Config\Repository;
  */
 class DeveloperCompose extends ProductionCompose
 {
+    CONST SYNC_ENGINE_DOCKER_SYNC = 'docker-sync';
+    CONST SYNC_ENGINE_MUTAGEN = 'mutagen';
+    const SYNC_ENGINE = 'sync-engine';
+
+    CONST SYNC_ENGINES_LIST = [
+        self::SYNC_ENGINE_DOCKER_SYNC,
+        self::SYNC_ENGINE_MUTAGEN,
+    ];
+
     /**
      * @inheritDoc
      */
@@ -21,9 +30,7 @@ class DeveloperCompose extends ProductionCompose
     {
         $compose = parent::build($config);
         $compose['volumes'] = [
-            'magento-sync' => [
-                'external' => true
-            ]
+            'magento-sync' => self::SYNC_ENGINE_DOCKER_SYNC === $config[self::SYNC_ENGINE] ? ['external' => true] : []
         ];
 
         return $compose;

--- a/src/Docker/Compose/DeveloperCompose.php
+++ b/src/Docker/Compose/DeveloperCompose.php
@@ -14,11 +14,11 @@ use Illuminate\Contracts\Config\Repository;
  */
 class DeveloperCompose extends ProductionCompose
 {
-    CONST SYNC_ENGINE_DOCKER_SYNC = 'docker-sync';
-    CONST SYNC_ENGINE_MUTAGEN = 'mutagen';
+    const SYNC_ENGINE_DOCKER_SYNC = 'docker-sync';
+    const SYNC_ENGINE_MUTAGEN = 'mutagen';
     const SYNC_ENGINE = 'sync-engine';
 
-    CONST SYNC_ENGINES_LIST = [
+    const SYNC_ENGINES_LIST = [
         self::SYNC_ENGINE_DOCKER_SYNC,
         self::SYNC_ENGINE_MUTAGEN,
     ];

--- a/src/Test/Unit/Command/Docker/BuildTest.php
+++ b/src/Test/Unit/Command/Docker/BuildTest.php
@@ -13,6 +13,7 @@ use Magento\MagentoCloud\Command\Docker\Build;
 use Magento\MagentoCloud\Command\Docker\ConfigConvert;
 use Magento\MagentoCloud\Config\Environment;
 use Magento\MagentoCloud\Config\RepositoryFactory;
+use Magento\MagentoCloud\Docker\Compose\DeveloperCompose;
 use Magento\MagentoCloud\Docker\Compose\ProductionCompose;
 use Magento\MagentoCloud\Docker\ComposeFactory;
 use Magento\MagentoCloud\Docker\ConfigurationMismatchException;
@@ -128,7 +129,8 @@ class BuildTest extends TestCase
                 [Build::OPTION_REDIS, '3.2'],
                 [Build::OPTION_ES, '2.4'],
                 [Build::OPTION_RABBIT_MQ, '3.5'],
-                [Build::OPTION_MODE, ComposeFactory::COMPOSE_PRODUCTION]
+                [Build::OPTION_MODE, ComposeFactory::COMPOSE_PRODUCTION],
+                [Build::OPTION_SYNC_ENGINE, DeveloperCompose::SYNC_ENGINE_DOCKER_SYNC],
             ]);
 
         $this->builderFactoryMock->expects($this->once())
@@ -177,8 +179,9 @@ class BuildTest extends TestCase
                 [Build::OPTION_RABBIT_MQ, '3.5'],
                 [Build::OPTION_NODE, '6.0'],
                 [Build::OPTION_MODE, ComposeFactory::COMPOSE_PRODUCTION],
+                [Build::OPTION_SYNC_ENGINE, DeveloperCompose::SYNC_ENGINE_DOCKER_SYNC],
             ]);
-        $this->configMock->expects($this->exactly(7))
+        $this->configMock->expects($this->exactly(8))
             ->method('set');
         $this->writerMock->expects($this->once())
             ->method('write')


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-3559

### Description
Adds the ability to use the Mutagen to synchronize files between the local host and the Docker

### Fixed Issues (if relevant)
1. magento/ece-tools#MAGECLOUD-3559: [Spike] Check how mutagen.io can improve performance of cloud docker environment

### Manual testing scenarios
https://jira.corp.magento.com/browse/MAGECLOUD-124

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
