### PR TITLE
MAGECLOUD-3628: Change Deployment Behavior for Cases when env.php is Missing

### DIFF
--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -346,6 +346,7 @@ class Container implements ContainerInterface
             ->give(function () {
                 return $this->container->makeWith(ProcessComposite::class, [
                     'processes' => [
+                        $this->container->make(DeployProcess\PreDeploy\CheckEnvFile::class),
                         $this->container->make(DeployProcess\PreDeploy\ConfigUpdate\Cache::class),
                         $this->container->make(DeployProcess\PreDeploy\CleanStaticContent::class),
                         $this->container->make(DeployProcess\PreDeploy\CleanViewPreprocessed::class),

--- a/src/Process/Deploy/PreDeploy/CheckEnvFile.php
+++ b/src/Process/Deploy/PreDeploy/CheckEnvFile.php
@@ -105,7 +105,7 @@ class CheckEnvFile implements ProcessInterface
                 return;
             }
 
-            $this->logger->warning('Magento is installed but the  environment configuration file doesn\'t exist.');
+            $this->logger->warning('Magento is installed but the environment configuration file doesn\'t exist.');
 
             $backupFilePatch = $envFilePath . BackupList::BACKUP_SUFFIX;
             if ($this->file->isExists($backupFilePatch)) {

--- a/src/Process/Deploy/PreDeploy/CheckEnvFile.php
+++ b/src/Process/Deploy/PreDeploy/CheckEnvFile.php
@@ -99,23 +99,34 @@ class CheckEnvFile implements ProcessInterface
                 if (isset($data['install']['date'])) {
                     $this->logger->info('Magento was installed on ' . $data['install']['date']);
                 } else {
-                    $this->writer->update(['install' => ['date' => date('r')]]);
+                    $this->updateInstallDate();
                 }
 
                 return;
             }
 
-            $this->logger->warning('Magento is installed but environment configuration file doesn\'t exist.');
+            $this->logger->warning('Magento is installed but the  environment configuration file doesn\'t exist.');
 
             $backupFilePatch = $envFilePath . BackupList::BACKUP_SUFFIX;
             if ($this->file->isExists($backupFilePatch)) {
-                $this->logger->info('Restoring environment configuration file form the backup.');
+                $this->logger->info('Restoring environment configuration file from the backup.');
                 $this->file->copy($backupFilePatch, $envFilePath);
             } else {
                 $this->logger->info('Generating new environment configuration file.');
+                $this->updateInstallDate();
             }
         } catch (GenericException $e) {
             throw new ProcessException($e->getMessage(), $e->getCode(), $e);
         }
+    }
+
+    /**
+     * Update installation date in the env.php file
+     *
+     * @throws \Magento\MagentoCloud\Filesystem\FileSystemException
+     */
+    private function updateInstallDate()
+    {
+        $this->writer->update(['install' => ['date' => date('r')]]);
     }
 }

--- a/src/Process/Deploy/PreDeploy/CheckEnvFile.php
+++ b/src/Process/Deploy/PreDeploy/CheckEnvFile.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Process\Deploy\PreDeploy;
+
+use Magento\MagentoCloud\App\GenericException;
+use Magento\MagentoCloud\Config\Deploy\Reader;
+use Magento\MagentoCloud\Config\Deploy\Writer;
+use Magento\MagentoCloud\Config\State;
+use Magento\MagentoCloud\Filesystem\BackupList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Filesystem\FileList;
+use Magento\MagentoCloud\Process\ProcessException;
+use Magento\MagentoCloud\Process\ProcessInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Checks if app/etc/env.php exists and restores it if not.
+ */
+class CheckEnvFile implements ProcessInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Reader
+     */
+    private $reader;
+
+    /**
+     * @var Writer
+     */
+    private $writer;
+
+    /**
+     * @var State
+     */
+    private $state;
+
+    /**
+     * @var FileList
+     */
+    private $fileList;
+
+    /**
+     * @var File
+     */
+    private $file;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param FileList $fileList
+     * @param File $file
+     * @param Reader $reader
+     * @param Writer $writer
+     * @param State $state
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        FileList $fileList,
+        File $file,
+        Reader $reader,
+        Writer $writer,
+        State $state
+    ) {
+        $this->logger = $logger;
+        $this->reader = $reader;
+        $this->writer = $writer;
+        $this->state = $state;
+        $this->fileList = $fileList;
+        $this->file = $file;
+    }
+
+    /**
+     * Checks if app/etc/env.php exists.
+     * Writes to log magento installation date.
+     * If file doesn't exist restores it from backup.
+     * If backup doesn't exists creates new file.
+     *
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        try {
+            if (!$this->state->isInstalled()) {
+                return;
+            }
+
+            $envFilePath = $this->fileList->getEnv();
+            if ($this->file->isExists($envFilePath)) {
+                $data = $this->reader->read();
+
+                if (isset($data['install']['date'])) {
+                    $this->logger->info('Magento was installed on ' . $data['install']['date']);
+                } else {
+                    $this->writer->update(['install' => ['date' => date('r')]]);
+                }
+
+                return;
+            }
+
+            $this->logger->warning('Magento is installed but environment configuration file doesn\'t exist.');
+
+            $backupFilePatch = $envFilePath . BackupList::BACKUP_SUFFIX;
+            if ($this->file->isExists($backupFilePatch)) {
+                $this->logger->info('Restoring environment configuration file form the backup.');
+                $this->file->copy($backupFilePatch, $envFilePath);
+            } else {
+                $this->logger->info('Generating new environment configuration file.');
+            }
+        } catch (GenericException $e) {
+            throw new ProcessException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/src/Process/Deploy/PreDeploy/RestoreWritableDirectories.php
+++ b/src/Process/Deploy/PreDeploy/RestoreWritableDirectories.php
@@ -61,6 +61,8 @@ class RestoreWritableDirectories implements ProcessInterface
      */
     public function execute()
     {
+        $this->logger->notice('Starting copying recoverable directories.');
+
         foreach ($this->recoverableDirectoryList->getList() as $dirOptions) {
             $this->buildDirCopier->copy(
                 $dirOptions[RecoverableDirectoryList::OPTION_DIRECTORY],
@@ -68,7 +70,6 @@ class RestoreWritableDirectories implements ProcessInterface
             );
         }
 
-        // Restore mounted directories.
         $this->logger->notice('Recoverable directories were copied back.');
         $this->flagManager->delete(FlagManager::FLAG_REGENERATE);
     }

--- a/src/Test/Unit/Config/StateTest.php
+++ b/src/Test/Unit/Config/StateTest.php
@@ -50,18 +50,12 @@ class StateTest extends TestCase
      */
     protected function setUp()
     {
-        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
-            ->getMockForAbstractClass();
-        $this->connectionMock = $this->getMockBuilder(ConnectionInterface::class)
-            ->getMockForAbstractClass();
-        $this->readerMock = $this->createMock(Reader::class);
-        $this->writerMock = $this->createMock(Writer::class);
+        $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
+        $this->connectionMock = $this->getMockForAbstractClass(ConnectionInterface::class);
 
         $this->state = new State(
             $this->loggerMock,
-            $this->connectionMock,
-            $this->readerMock,
-            $this->writerMock
+            $this->connectionMock
         );
     }
 
@@ -77,8 +71,6 @@ class StateTest extends TestCase
         $this->connectionMock->expects($this->once())
             ->method('listTables')
             ->willReturn($tables);
-        $this->writerMock->expects($this->never())
-            ->method('update');
 
         $this->assertFalse($this->state->isInstalled());
     }
@@ -104,8 +96,6 @@ class StateTest extends TestCase
         $this->connectionMock->expects($this->once())
             ->method('listTables')
             ->willReturn($tables);
-        $this->writerMock->expects($this->never())
-            ->method('update');
 
         $this->state->isInstalled();
     }
@@ -120,54 +110,5 @@ class StateTest extends TestCase
             [['setup_module', 'some_table']],
             [['some_table', 'some_table2']],
         ];
-    }
-
-    public function testIsInstalledConfigFileIsNotExistsOrEmpty()
-    {
-        $date = 'Wed, 13 Sep 2017 13:41:32 +0000';
-        $config['install']['date'] = $date;
-
-        $this->loggerMock->expects($this->once())
-            ->method('info')
-            ->with('Checking if db exists and has tables');
-        $this->connectionMock->expects($this->once())
-            ->method('listTables')
-            ->willReturn(['core_config_data', 'setup_module']);
-        $this->readerMock->expects($this->once())
-            ->method('read')
-            ->willReturn([]);
-        $this->writerMock->expects($this->once())
-            ->method('update')
-            ->with($config);
-
-        $dateMock = $this->getFunctionMock('Magento\MagentoCloud\Config', 'date');
-        $dateMock->expects($this->once())
-            ->with('r')
-            ->willReturn($date);
-
-        $this->assertTrue($this->state->isInstalled());
-    }
-
-    public function testIsInstalledConfigFileWithDate()
-    {
-        $date = 'Wed, 12 Sep 2017 10:40:30 +0000';
-        $config = ['install' => ['date' => $date]];
-
-        $this->loggerMock->expects($this->exactly(2))
-            ->method('info')
-            ->withConsecutive(
-                ['Checking if db exists and has tables'],
-                ['Magento was installed on ' . $date]
-            );
-        $this->connectionMock->expects($this->once())
-            ->method('listTables')
-            ->willReturn(['core_config_data', 'setup_module']);
-        $this->readerMock->expects($this->once())
-            ->method('read')
-            ->willReturn($config);
-        $this->writerMock->expects($this->never())
-            ->method('update');
-
-        $this->assertTrue($this->state->isInstalled());
     }
 }

--- a/src/Test/Unit/Config/StateTest.php
+++ b/src/Test/Unit/Config/StateTest.php
@@ -31,16 +31,6 @@ class StateTest extends TestCase
     private $connectionMock;
 
     /**
-     * @var Reader|Mock
-     */
-    private $readerMock;
-
-    /**
-     * @var Writer|Mock
-     */
-    private $writerMock;
-
-    /**
      * @var State
      */
     private $state;

--- a/src/Test/Unit/Process/Deploy/PreDeploy/CheckEnvFileTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeploy/CheckEnvFileTest.php
@@ -81,7 +81,6 @@ class CheckEnvFileTest extends TestCase
         );
     }
 
-
     public function testExecuteNotInstalled()
     {
         $this->stateMock->expects($this->once())
@@ -166,7 +165,7 @@ class CheckEnvFileTest extends TestCase
             ->willReturnOnConsecutiveCalls(false, true);
         $this->loggerMock->expects($this->once())
             ->method('warning')
-            ->with('Magento is installed but environment configuration file doesn\'t exist.');
+            ->with('Magento is installed but the environment configuration file doesn\'t exist.');
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Restoring environment configuration file from the backup.');
@@ -197,7 +196,7 @@ class CheckEnvFileTest extends TestCase
             ->willReturnOnConsecutiveCalls(false, false);
         $this->loggerMock->expects($this->once())
             ->method('warning')
-            ->with('Magento is installed but environment configuration file doesn\'t exist.');
+            ->with('Magento is installed but the environment configuration file doesn\'t exist.');
         $this->loggerMock->expects($this->once())
             ->method('info')
             ->with('Generating new environment configuration file.');

--- a/src/Test/Unit/Process/Deploy/PreDeploy/CheckEnvFileTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeploy/CheckEnvFileTest.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Test\Unit\Process\Deploy\PreDeploy;
+
+use Magento\MagentoCloud\App\GenericException;
+use Magento\MagentoCloud\Config\Deploy\Reader;
+use Magento\MagentoCloud\Config\Deploy\Writer;
+use Magento\MagentoCloud\Config\State;
+use Magento\MagentoCloud\Filesystem\BackupList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Filesystem\FileList;
+use Magento\MagentoCloud\Process\Deploy\PreDeploy\CheckEnvFile;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @inheritdoc
+ */
+class CheckEnvFileTest extends TestCase
+{
+    /**
+     * @var CheckEnvFile
+     */
+    private $process;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $loggerMock;
+
+    /**
+     * @var FileList|MockObject
+     */
+    private $fileListMock;
+
+    /**
+     * @var File|MockObject
+     */
+    private $fileMock;
+
+    /**
+     * @var Reader|MockObject
+     */
+    private $readerMock;
+
+    /**
+     * @var Writer|MockObject
+     */
+    private $writerMock;
+
+    /**
+     * @var State|MockObject
+     */
+    private $stateMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
+        $this->fileListMock = $this->createMock(FileList::class);
+        $this->fileMock = $this->createMock(File::class);
+        $this->readerMock = $this->createMock(Reader::class);
+        $this->writerMock = $this->createMock(Writer::class);
+        $this->stateMock = $this->createMock(State::class);
+
+        $this->process = new CheckEnvFile(
+            $this->loggerMock,
+            $this->fileListMock,
+            $this->fileMock,
+            $this->readerMock,
+            $this->writerMock,
+            $this->stateMock
+        );
+    }
+
+
+    public function testExecuteNotInstalled()
+    {
+        $this->stateMock->expects($this->once())
+            ->method('isInstalled')
+            ->willReturn(false);
+        $this->fileListMock->expects($this->never())
+            ->method('getEnv');
+
+        $this->process->execute();
+    }
+
+    public function testExecuteEnvExistsWithInstallDate()
+    {
+        $envPath = '/path/to/env.php';
+
+        $this->stateMock->expects($this->once())
+            ->method('isInstalled')
+            ->willReturn(true);
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
+            ->willReturn($envPath);
+        $this->fileMock->expects($this->once())
+            ->method('isExists')
+            ->with($envPath)
+            ->willReturn(true);
+        $this->readerMock->expects($this->once())
+            ->method('read')
+            ->willReturn(['install' => ['date' => '01-01-2000']]);
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Magento was installed on 01-01-2000');
+        $this->loggerMock->expects($this->never())
+            ->method('warning');
+
+        $this->process->execute();
+    }
+
+    public function testExecuteEnvExistsWithoutInstallDate()
+    {
+        $envPath = '/path/to/env.php';
+
+        $this->stateMock->expects($this->once())
+            ->method('isInstalled')
+            ->willReturn(true);
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
+            ->willReturn($envPath);
+        $this->fileMock->expects($this->once())
+            ->method('isExists')
+            ->with($envPath)
+            ->willReturn(true);
+        $this->readerMock->expects($this->once())
+            ->method('read')
+            ->willReturn(['config' => ['value']]);
+        $this->writerMock->expects($this->once())
+            ->method('update');
+        $this->loggerMock->expects($this->never())
+            ->method('info');
+        $this->loggerMock->expects($this->never())
+            ->method('warning');
+
+        $this->process->execute();
+    }
+
+    public function testExecuteEnvNotExistsRestoreFromBackup()
+    {
+        $envPath = '/path/to/env.php';
+        $envPathBack = '/path/to/env.php' . BackupList::BACKUP_SUFFIX;
+
+        $this->stateMock->expects($this->once())
+            ->method('isInstalled')
+            ->willReturn(true);
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
+            ->willReturn($envPath);
+        $this->fileMock->expects($this->exactly(2))
+            ->method('isExists')
+            ->withConsecutive(
+                [$envPath],
+                [$envPathBack]
+            )
+            ->willReturnOnConsecutiveCalls(false, true);
+        $this->loggerMock->expects($this->once())
+            ->method('warning')
+            ->with('Magento is installed but environment configuration file doesn\'t exist.');
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Restoring environment configuration file from the backup.');
+        $this->fileMock->expects($this->once())
+            ->method('copy')
+            ->with($envPathBack, $envPath);
+
+        $this->process->execute();
+    }
+
+    public function testExecuteEnvAndBackupNotExists()
+    {
+        $envPath = '/path/to/env.php';
+        $envPathBack = '/path/to/env.php' . BackupList::BACKUP_SUFFIX;
+
+        $this->stateMock->expects($this->once())
+            ->method('isInstalled')
+            ->willReturn(true);
+        $this->fileListMock->expects($this->once())
+            ->method('getEnv')
+            ->willReturn($envPath);
+        $this->fileMock->expects($this->exactly(2))
+            ->method('isExists')
+            ->withConsecutive(
+                [$envPath],
+                [$envPathBack]
+            )
+            ->willReturnOnConsecutiveCalls(false, false);
+        $this->loggerMock->expects($this->once())
+            ->method('warning')
+            ->with('Magento is installed but environment configuration file doesn\'t exist.');
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Generating new environment configuration file.');
+        $this->writerMock->expects($this->once())
+            ->method('update');
+        $this->fileMock->expects($this->never())
+            ->method('copy');
+
+        $this->process->execute();
+    }
+
+    /**
+     * @expectedException \Magento\MagentoCloud\Process\ProcessException
+     * @expectedExceptionMessage some error message
+     */
+    public function testExecuteWithException()
+    {
+        $this->stateMock->expects($this->once())
+            ->method('isInstalled')
+            ->willThrowException(new GenericException('some error message'));
+        $this->fileListMock->expects($this->never())
+            ->method('getEnv');
+
+        $this->process->execute();
+    }
+}

--- a/src/Test/Unit/Process/Deploy/PreDeploy/CheckEnvFileTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeploy/CheckEnvFileTest.php
@@ -11,6 +11,8 @@ use Magento\MagentoCloud\App\GenericException;
 use Magento\MagentoCloud\Config\Deploy\Reader;
 use Magento\MagentoCloud\Config\Deploy\Writer;
 use Magento\MagentoCloud\Config\State;
+use Magento\MagentoCloud\Config\Validator\Deploy\DatabaseConfiguration;
+use Magento\MagentoCloud\Config\Validator\Result\Error;
 use Magento\MagentoCloud\Filesystem\BackupList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Filesystem\FileList;
@@ -60,6 +62,11 @@ class CheckEnvFileTest extends TestCase
     private $stateMock;
 
     /**
+     * @var DatabaseConfiguration|MockObject
+     */
+    private $databaseValidatorMock;
+
+    /**
      * @inheritdoc
      */
     protected function setUp()
@@ -70,6 +77,7 @@ class CheckEnvFileTest extends TestCase
         $this->readerMock = $this->createMock(Reader::class);
         $this->writerMock = $this->createMock(Writer::class);
         $this->stateMock = $this->createMock(State::class);
+        $this->databaseValidatorMock = $this->createMock(DatabaseConfiguration::class);
 
         $this->process = new CheckEnvFile(
             $this->loggerMock,
@@ -77,8 +85,20 @@ class CheckEnvFileTest extends TestCase
             $this->fileMock,
             $this->readerMock,
             $this->writerMock,
-            $this->stateMock
+            $this->stateMock,
+            $this->databaseValidatorMock
         );
+    }
+
+    public function testExecuteWrongDatabaseConfig()
+    {
+        $this->databaseValidatorMock->expects($this->once())
+            ->method('validate')
+            ->willReturn(new Error('some error'));
+        $this->fileListMock->expects($this->never())
+            ->method('getEnv');
+
+        $this->process->execute();
     }
 
     public function testExecuteNotInstalled()

--- a/src/Test/Unit/Process/Deploy/PreDeploy/RestoreWritableDirectoriesTest.php
+++ b/src/Test/Unit/Process/Deploy/PreDeploy/RestoreWritableDirectoriesTest.php
@@ -75,9 +75,12 @@ class RestoreWritableDirectoriesTest extends TestCase
                 ['app/etc', 'copy'],
                 ['pub/media', 'copy']
             );
-        $this->loggerMock->expects($this->once())
+        $this->loggerMock->expects($this->exactly(2))
             ->method('notice')
-            ->with('Recoverable directories were copied back.');
+            ->withConsecutive(
+                ['Starting copying recoverable directories.'],
+                ['Recoverable directories were copied back.']
+            );
         $this->flagManagerMock->expects($this->once())
             ->method('delete')
             ->with(FlagManager::FLAG_REGENERATE);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Updated logic in the case when Magento is Installed (database exists) and `app/etc/env.php` file doesn't exist. 
Shows warning message and trying to restore from backup, if the backup doesn't exist create a new file.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3628

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGECLOUD-125

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
