### PR TITLE
MAGECLOUD-3357: [Cloud Docker] Changes in .magento.app.yaml should affect php modules

### DIFF
--- a/src/Docker/Compose/FunctionalCompose.php
+++ b/src/Docker/Compose/FunctionalCompose.php
@@ -126,6 +126,6 @@ class FunctionalCompose extends ProductionCompose
      */
     protected function getPhpExtensions(string $phpVersion): array
     {
-        return [];
+        return self::DEFAULT_PHP_EXTENSIONS;
     }
 }

--- a/src/Docker/Compose/FunctionalCompose.php
+++ b/src/Docker/Compose/FunctionalCompose.php
@@ -126,6 +126,6 @@ class FunctionalCompose extends ProductionCompose
      */
     protected function getPhpExtensions(string $phpVersion): array
     {
-        return self::DEFAULT_PHP_EXTENSIONS;
+        return PhpExtension::DEFAULT_PHP_EXTENSIONS;
     }
 }

--- a/src/Docker/Compose/FunctionalCompose.php
+++ b/src/Docker/Compose/FunctionalCompose.php
@@ -119,4 +119,13 @@ class FunctionalCompose extends ProductionCompose
     {
         return $this->fileList->getToolsDockerCompose();
     }
+
+    /**
+     * @param string $phpVersion
+     * @return array
+     */
+    protected function getPhpExtensions(string $phpVersion): array
+    {
+        return [];
+    }
 }

--- a/src/Docker/Compose/PhpExtension.php
+++ b/src/Docker/Compose/PhpExtension.php
@@ -12,7 +12,6 @@ use Composer\Semver\VersionParser;
 use Magento\MagentoCloud\Docker\Service\Config;
 use Magento\MagentoCloud\Docker\ConfigurationMismatchException;
 
-
 /**
  * Returns list of PHP extensions which will be enabled in Docker PHP container.
  */
@@ -64,6 +63,7 @@ class PhpExtension
         'mysqli' => '>=7.0.0 <7.3.0',
         'oauth' => '>=7.0.0 <7.3.0',
         'opcache' => '>=7.0.0 <7.3.0',
+        'pcntl' => '>=7.0.0 <7.3.0',
         'pdo_mysql' => '>=7.0.0 <7.3.0',
         'propro' => '>=7.0.0 <7.3.0',
         'pspell' => '>=7.0.0 <7.3.0',
@@ -84,7 +84,6 @@ class PhpExtension
         'xsl' => '>=7.0.0 <7.3.0',
         'yaml' => '>=7.0.0 <7.3.0',
         'zip' => '>=7.0.0 <7.3.0',
-        'pcntl' => '>=7.0.0 <7.3.0',
     ];
 
     /**
@@ -139,7 +138,8 @@ class PhpExtension
      * @param Config $config
      * @param VersionParser $versionParser
      */
-    public function __construct(Config $config, VersionParser $versionParser) {
+    public function __construct(Config $config, VersionParser $versionParser)
+    {
         $this->config = $config;
         $this->versionParser = $versionParser;
     }
@@ -155,7 +155,9 @@ class PhpExtension
     {
         $phpConstraint = new Constraint('==', $this->versionParser->normalize($phpVersion));
         $phpExtensions = array_diff(
-            array_merge(self::DEFAULT_PHP_EXTENSIONS, $this->config->getEnabledPhpExtensions()),
+            array_unique(
+                array_merge(self::DEFAULT_PHP_EXTENSIONS, $this->config->getEnabledPhpExtensions())
+            ),
             $this->config->getDisabledPhpExtensions(),
             self::IGNORED_EXTENSIONS
         );
@@ -176,9 +178,10 @@ class PhpExtension
                     $result[] = $phpExtName;
                     continue;
                 }
-                $messages[] = "PHP extension $phpExtName is not available for PHP version $phpVersion";
+                $messages[] = "PHP extension $phpExtName is not available for PHP version $phpVersion.";
+                continue;
             }
-            $messages[] = "PHP extension $phpExtName is not supported";
+            $messages[] = "PHP extension $phpExtName is not supported.";
         }
         if (!empty($messages)) {
             throw new ConfigurationMismatchException(implode(PHP_EOL, $messages));

--- a/src/Docker/Compose/PhpExtension.php
+++ b/src/Docker/Compose/PhpExtension.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Docker\Compose;
+
+use Composer\Semver\Constraint\Constraint;
+use Composer\Semver\VersionParser;
+use Magento\MagentoCloud\Docker\Service\Config;
+use Magento\MagentoCloud\Docker\ConfigurationMismatchException;
+
+
+/**
+ * Returns list of PHP extensions which will be enabled in Docker PHP container.
+ */
+class PhpExtension
+{
+    /**
+     * Extensions which should be installed by default
+     */
+    const DEFAULT_PHP_EXTENSIONS = [
+        'bcmath',
+        'bz2',
+        'calendar',
+        'exif',
+        'gd',
+        'gettext',
+        'intl',
+        'mysqli',
+        'pcntl',
+        'pdo_mysql',
+        'soap',
+        'sockets',
+        'sysvmsg',
+        'sysvsem',
+        'sysvshm',
+        'opcache',
+        'zip',
+    ];
+
+    /**
+     * Extensions which can be installed or uninstalled
+     */
+    const AVAILABLE_PHP_EXTENSIONS = [
+        'bcmath' => '>=7.0.0 <7.3.0',
+        'bz2' => '>=7.0.0 <7.3.0',
+        'calendar' => '>=7.0.0 <7.3.0',
+        'exif' => '>=7.0.0 <7.3.0',
+        'gd' => '>=7.0.0 <7.3.0',
+        'geoip' => '>=7.0.0 <7.3.0',
+        'gettext' => '>=7.0.0 <7.3.0',
+        'gmp' => '>=7.0.0 <7.3.0',
+        'igbinary' => '>=7.0.0 <7.3.0',
+        'imagick' => '>=7.0.0 <7.3.0',
+        'imap' => '>=7.0.0 <7.3.0',
+        'intl' => '>=7.0.0 <7.3.0',
+        'ldap' => '>=7.0.0 <7.3.0',
+        'mailparse' => '>=7.0.0 <7.3.0',
+        'mcrypt' => '>=7.0.0 <7.2.0',
+        'msgpack' => '>=7.0.0 <7.3.0',
+        'mysqli' => '>=7.0.0 <7.3.0',
+        'oauth' => '>=7.0.0 <7.3.0',
+        'opcache' => '>=7.0.0 <7.3.0',
+        'pdo_mysql' => '>=7.0.0 <7.3.0',
+        'propro' => '>=7.0.0 <7.3.0',
+        'pspell' => '>=7.0.0 <7.3.0',
+        'raphf' => '>=7.0.0 <7.3.0',
+        'recode' => '>=7.0.0 <7.3.0',
+        'redis' => '>=7.0.0 <7.3.0',
+        'shmop' => '>=7.0.0 <7.3.0',
+        'soap' => '>=7.0.0 <7.3.0',
+        'sockets' => '>=7.0.0 <7.3.0',
+        'sodium' => '>=7.0.0 <7.3.0',
+        'ssh2' => '>=7.0.0 <7.3.0',
+        'sysvmsg' => '>=7.0.0 <7.3.0',
+        'sysvsem' => '>=7.0.0 <7.3.0',
+        'sysvshm' => '>=7.0.0 <7.3.0',
+        'tidy' => '>=7.0.0 <7.3.0',
+        'xdebug' => '>=7.0.0 <7.3.0',
+        'xmlrpc' => '>=7.0.0 <7.3.0',
+        'xsl' => '>=7.0.0 <7.3.0',
+        'yaml' => '>=7.0.0 <7.3.0',
+        'zip' => '>=7.0.0 <7.3.0',
+        'pcntl' => '>=7.0.0 <7.3.0',
+    ];
+
+    /**
+     * Extensions which built-in and can't be uninstalled
+     */
+    const BUILTIN_EXTENSIONS = [
+        'ctype' => '>=7.0.0 <7.3.0',
+        'curl' => '>=7.0.0 <7.3.0',
+        'date' => '>=7.0.0 <7.3.0',
+        'dom' => '>=7.0.0 <7.3.0',
+        'fileinfo' => '>=7.0.0 <7.3.0',
+        'filter' => '>=7.0.0 <7.3.0',
+        'ftp' => '>=7.0.0 <7.3.0',
+        'hash' => '>=7.0.0 <7.3.0',
+        'iconv' => '>=7.0.0 <7.3.0',
+        'json' => '>=7.0.0 <7.3.0',
+        'mbstring' => '>=7.0.0 <7.3.0',
+        'mysqlnd' => '>=7.0.0 <7.3.0',
+        'openssl' => '>=7.0.0 <7.3.0',
+        'pcre' => '>=7.0.0 <7.3.0',
+        'pdo' => '>=7.0.0 <7.3.0',
+        'pdo_sqlite' => '>=7.0.0 <7.3.0',
+        'phar' => '>=7.0.0 <7.3.0',
+        'posix' => '>=7.0.0 <7.3.0',
+        'readline' => '>=7.0.0 <7.3.0',
+        'session' => '>=7.0.0 <7.3.0',
+        'simplexml' => '>=7.0.0 <7.3.0',
+        'sqlite3' => '>=7.0.0 <7.3.0',
+        'tokenizer' => '>=7.0.0 <7.3.0',
+        'xml' => '>=7.0.0 <7.3.0',
+        'xmlreader' => '>=7.0.0 <7.3.0',
+        'xmlwriter' => '>=7.0.0 <7.3.0',
+        'zlib' => '>=7.0.0 <7.3.0',
+    ];
+
+    /**
+     * Extensions which should be ignored
+     */
+    const IGNORED_EXTENSIONS = ['blackfire', 'newrelic'];
+
+    /**
+     * @var VersionParser
+     */
+    private $versionParser;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @param Config $config
+     * @param VersionParser $versionParser
+     */
+    public function __construct(Config $config, VersionParser $versionParser) {
+        $this->config = $config;
+        $this->versionParser = $versionParser;
+    }
+
+    /**
+     * Returns list of PHP extensions which will be enabled in Docker PHP container.
+     *
+     * @param string $phpVersion
+     * @return array
+     * @throws ConfigurationMismatchException
+     */
+    public function get(string $phpVersion): array
+    {
+        $phpConstraint = new Constraint('==', $this->versionParser->normalize($phpVersion));
+        $phpExtensions = array_diff(
+            array_merge(self::DEFAULT_PHP_EXTENSIONS, $this->config->getEnabledPhpExtensions()),
+            $this->config->getDisabledPhpExtensions(),
+            self::IGNORED_EXTENSIONS
+        );
+        $messages = [];
+        $result = [];
+        foreach ($phpExtensions as $phpExtName) {
+            if (isset(self::BUILTIN_EXTENSIONS[$phpExtName])) {
+                $phpExtConstraint = $this->versionParser->parseConstraints(self::BUILTIN_EXTENSIONS[$phpExtName]);
+                if ($phpConstraint->matches($phpExtConstraint)) {
+                    continue;
+                }
+            }
+            if (isset(self::AVAILABLE_PHP_EXTENSIONS[$phpExtName])) {
+                $phpExtConstraintAvailable = $this->versionParser->parseConstraints(
+                    self::AVAILABLE_PHP_EXTENSIONS[$phpExtName]
+                );
+                if ($phpConstraint->matches($phpExtConstraintAvailable)) {
+                    $result[] = $phpExtName;
+                    continue;
+                }
+                $messages[] = "PHP extension $phpExtName is not available for PHP version $phpVersion";
+            }
+            $messages[] = "PHP extension $phpExtName is not supported";
+        }
+        if (!empty($messages)) {
+            throw new ConfigurationMismatchException(implode(PHP_EOL, $messages));
+        }
+        return $result;
+    }
+}

--- a/src/Docker/Compose/ProductionCompose.php
+++ b/src/Docker/Compose/ProductionCompose.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace Magento\MagentoCloud\Docker\Compose;
 
+use Composer\Semver\Constraint\Constraint;
+use Composer\Semver\VersionParser;
 use Illuminate\Contracts\Config\Repository;
 use Magento\MagentoCloud\Docker\Service\Config;
 use Magento\MagentoCloud\Docker\ComposeInterface;
@@ -32,6 +34,113 @@ class ProductionCompose implements ComposeInterface
     const CRON_ENABLED = true;
 
     /**
+     * Extensions which should be installed by default
+     */
+    const DEFAULT_PHP_EXTENSIONS = [
+        'bcmath',
+        'bz2',
+        'calendar',
+        'exif',
+        'gd',
+        'gettext',
+        'intl',
+        'mysqli',
+        'pcntl',
+        'pdo_mysql',
+        'soap',
+        'sockets',
+        'sysvmsg',
+        'sysvsem',
+        'sysvshm',
+        'opcache',
+        'zip',
+    ];
+
+    /**
+     * Extensions which can be installed or uninstalled
+     */
+    const AVAILABLE_PHP_EXTENSIONS = [
+        'bcmath' => '>=7.0.0 <7.3.0',
+        'bz2' => '>=7.0.0 <7.3.0',
+        'calendar' => '>=7.0.0 <7.3.0',
+        'exif' => '>=7.0.0 <7.3.0',
+        'gd' => '>=7.0.0 <7.3.0',
+        'geoip' => '>=7.0.0 <7.3.0',
+        'gettext' => '>=7.0.0 <7.3.0',
+        'gmp' => '>=7.0.0 <7.3.0',
+        'igbinary' => '>=7.0.0 <7.3.0',
+        'imagick' => '>=7.0.0 <7.3.0',
+        'imap' => '>=7.0.0 <7.3.0',
+        'intl' => '>=7.0.0 <7.3.0',
+        'ldap' => '>=7.0.0 <7.3.0',
+        'mailparse' => '>=7.0.0 <7.3.0',
+        'mcrypt' => '>=7.0.0 <7.2.0',
+        'msgpack' => '>=7.0.0 <7.3.0',
+        'mysqli' => '>=7.0.0 <7.3.0',
+        'oauth' => '>=7.0.0 <7.3.0',
+        'opcache' => '>=7.0.0 <7.3.0',
+        'pdo_mysql' => '>=7.0.0 <7.3.0',
+        'propro' => '>=7.0.0 <7.3.0',
+        'pspell' => '>=7.0.0 <7.3.0',
+        'raphf' => '>=7.0.0 <7.3.0',
+        'recode' => '>=7.0.0 <7.3.0',
+        'redis' => '>=7.0.0 <7.3.0',
+        'shmop' => '>=7.0.0 <7.3.0',
+        'soap' => '>=7.0.0 <7.3.0',
+        'sockets' => '>=7.0.0 <7.3.0',
+        'sodium' => '>=7.0.0 <7.3.0',
+        'ssh2' => '>=7.0.0 <7.3.0',
+        'sysvmsg' => '>=7.0.0 <7.3.0',
+        'sysvsem' => '>=7.0.0 <7.3.0',
+        'sysvshm' => '>=7.0.0 <7.3.0',
+        'tidy' => '>=7.0.0 <7.3.0',
+        'xdebug' => '>=7.0.0 <7.3.0',
+        'xmlrpc' => '>=7.0.0 <7.3.0',
+        'xsl' => '>=7.0.0 <7.3.0',
+        'yaml' => '>=7.0.0 <7.3.0',
+        'zip' => '>=7.0.0 <7.3.0',
+        'pcntl' => '>=7.0.0 <7.3.0',
+    ];
+
+    /**
+     * Extensions which built-in and can't be uninstalled
+     */
+    const BUILTIN_EXTENSIONS = [
+        'ctype' => '>=7.0.0 <7.3.0',
+        'curl' => '>=7.0.0 <7.3.0',
+        'date' => '>=7.0.0 <7.3.0',
+        'dom' => '>=7.0.0 <7.3.0',
+        'fileinfo' => '>=7.0.0 <7.3.0',
+        'filter' => '>=7.0.0 <7.3.0',
+        'ftp' => '>=7.0.0 <7.3.0',
+        'hash' => '>=7.0.0 <7.3.0',
+        'iconv' => '>=7.0.0 <7.3.0',
+        'json' => '>=7.0.0 <7.3.0',
+        'mbstring' => '>=7.0.0 <7.3.0',
+        'mysqlnd' => '>=7.0.0 <7.3.0',
+        'openssl' => '>=7.0.0 <7.3.0',
+        'pcre' => '>=7.0.0 <7.3.0',
+        'pdo' => '>=7.0.0 <7.3.0',
+        'pdo_sqlite' => '>=7.0.0 <7.3.0',
+        'phar' => '>=7.0.0 <7.3.0',
+        'posix' => '>=7.0.0 <7.3.0',
+        'readline' => '>=7.0.0 <7.3.0',
+        'session' => '>=7.0.0 <7.3.0',
+        'simplexml' => '>=7.0.0 <7.3.0',
+        'sqlite3' => '>=7.0.0 <7.3.0',
+        'tokenizer' => '>=7.0.0 <7.3.0',
+        'xml' => '>=7.0.0 <7.3.0',
+        'xmlreader' => '>=7.0.0 <7.3.0',
+        'xmlwriter' => '>=7.0.0 <7.3.0',
+        'zlib' => '>=7.0.0 <7.3.0',
+    ];
+
+    /**
+     * Extensions which should be ignored
+     */
+    const IGNORED_EXTENSIONS = ['blackfire', 'newrelic'];
+
+    /**
      * @var ServiceFactory
      */
     private $serviceFactory;
@@ -52,21 +161,29 @@ class ProductionCompose implements ComposeInterface
     protected $fileList;
 
     /**
+     * @var VersionParser
+     */
+    private $versionParser;
+
+    /**
      * @param ServiceFactory $serviceFactory
      * @param FileList $fileList
      * @param Config $config
      * @param Converter $converter
+     * @param VersionParser $versionParser
      */
     public function __construct(
         ServiceFactory $serviceFactory,
         FileList $fileList,
         Config $config,
-        Converter $converter
+        Converter $converter,
+        VersionParser $versionParser
     ) {
         $this->serviceFactory = $serviceFactory;
         $this->fileList = $fileList;
         $this->config = $config;
         $this->converter = $converter;
+        $this->versionParser = $versionParser;
     }
 
     /**
@@ -190,9 +307,14 @@ class ProductionCompose implements ComposeInterface
             self::DEFAULT_TLS_VERSION,
             ['depends_on' => ['varnish']]
         );
+        $services['cron'] = $this->getCronCliService($phpVersion, true, $cliDepends, 'cron.magento2.docker');
+        $phpExtensions = $this->getPhpExtensions($phpVersion);
         $services['generic'] = [
             'image' => 'alpine',
-            'environment' => $this->converter->convert($this->getVariables()),
+            'environment' => $this->converter->convert(array_merge(
+                $this->getVariables(),
+                !empty($phpExtensions) ? ['PHP_EXTENSIONS' => implode(' ', $phpExtensions)] : []
+            )),
             'env_file' => [
                 './.docker/config.env',
             ],
@@ -387,5 +509,45 @@ class ProductionCompose implements ComposeInterface
     protected function getPhpVersion()
     {
         return $this->config->getPhpVersion();
+    }
+
+    /**
+     * @param string $phpVersion
+     * @return array
+     * @throws ConfigurationMismatchException
+     */
+    private function getPhpExtensions(string $phpVersion): array
+    {
+        $phpConstraint = new Constraint('==', $this->versionParser->normalize($phpVersion));
+        $phpExtensions = array_diff(
+            array_merge(self::DEFAULT_PHP_EXTENSIONS, $this->config->getEnabledPhpExtensions()),
+            $this->config->getDisabledPhpExtensions(),
+            self::IGNORED_EXTENSIONS
+        );
+        $messages = [];
+        $result = [];
+        foreach ($phpExtensions as $phpExtName) {
+            if (isset(self::BUILTIN_EXTENSIONS[$phpExtName])) {
+                $phpExtConstraint = $this->versionParser->parseConstraints(self::BUILTIN_EXTENSIONS[$phpExtName]);
+                if ($phpConstraint->matches($phpExtConstraint)) {
+                    continue;
+                }
+            }
+            if (isset(self::AVAILABLE_PHP_EXTENSIONS[$phpExtName])) {
+                $phpExtConstraintAvailable = $this->versionParser->parseConstraints(
+                    self::AVAILABLE_PHP_EXTENSIONS[$phpExtName]
+                );
+                if ($phpConstraint->matches($phpExtConstraintAvailable)) {
+                    $result[] = $phpExtName;
+                    continue;
+                }
+                $messages[] = "PHP extension $phpExtName is not available for PHP version $phpVersion";
+            }
+            $messages[] = "PHP extension $phpExtName is not supported";
+        }
+        if (!empty($messages)) {
+            throw new ConfigurationMismatchException(implode(PHP_EOL, $messages));
+        }
+        return $result;
     }
 }

--- a/src/Docker/Compose/ProductionCompose.php
+++ b/src/Docker/Compose/ProductionCompose.php
@@ -516,7 +516,7 @@ class ProductionCompose implements ComposeInterface
      * @return array
      * @throws ConfigurationMismatchException
      */
-    private function getPhpExtensions(string $phpVersion): array
+    protected function getPhpExtensions(string $phpVersion): array
     {
         $phpConstraint = new Constraint('==', $this->versionParser->normalize($phpVersion));
         $phpExtensions = array_diff(

--- a/src/Docker/Compose/ProductionCompose.php
+++ b/src/Docker/Compose/ProductionCompose.php
@@ -307,7 +307,6 @@ class ProductionCompose implements ComposeInterface
             self::DEFAULT_TLS_VERSION,
             ['depends_on' => ['varnish']]
         );
-        $services['cron'] = $this->getCronCliService($phpVersion, true, $cliDepends, 'cron.magento2.docker');
         $phpExtensions = $this->getPhpExtensions($phpVersion);
         $services['generic'] = [
             'image' => 'alpine',

--- a/src/Docker/Compose/ProductionCompose.php
+++ b/src/Docker/Compose/ProductionCompose.php
@@ -7,8 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\MagentoCloud\Docker\Compose;
 
-use Composer\Semver\Constraint\Constraint;
-use Composer\Semver\VersionParser;
 use Illuminate\Contracts\Config\Repository;
 use Magento\MagentoCloud\Docker\Service\Config;
 use Magento\MagentoCloud\Docker\ComposeInterface;
@@ -34,113 +32,6 @@ class ProductionCompose implements ComposeInterface
     const CRON_ENABLED = true;
 
     /**
-     * Extensions which should be installed by default
-     */
-    const DEFAULT_PHP_EXTENSIONS = [
-        'bcmath',
-        'bz2',
-        'calendar',
-        'exif',
-        'gd',
-        'gettext',
-        'intl',
-        'mysqli',
-        'pcntl',
-        'pdo_mysql',
-        'soap',
-        'sockets',
-        'sysvmsg',
-        'sysvsem',
-        'sysvshm',
-        'opcache',
-        'zip',
-    ];
-
-    /**
-     * Extensions which can be installed or uninstalled
-     */
-    const AVAILABLE_PHP_EXTENSIONS = [
-        'bcmath' => '>=7.0.0 <7.3.0',
-        'bz2' => '>=7.0.0 <7.3.0',
-        'calendar' => '>=7.0.0 <7.3.0',
-        'exif' => '>=7.0.0 <7.3.0',
-        'gd' => '>=7.0.0 <7.3.0',
-        'geoip' => '>=7.0.0 <7.3.0',
-        'gettext' => '>=7.0.0 <7.3.0',
-        'gmp' => '>=7.0.0 <7.3.0',
-        'igbinary' => '>=7.0.0 <7.3.0',
-        'imagick' => '>=7.0.0 <7.3.0',
-        'imap' => '>=7.0.0 <7.3.0',
-        'intl' => '>=7.0.0 <7.3.0',
-        'ldap' => '>=7.0.0 <7.3.0',
-        'mailparse' => '>=7.0.0 <7.3.0',
-        'mcrypt' => '>=7.0.0 <7.2.0',
-        'msgpack' => '>=7.0.0 <7.3.0',
-        'mysqli' => '>=7.0.0 <7.3.0',
-        'oauth' => '>=7.0.0 <7.3.0',
-        'opcache' => '>=7.0.0 <7.3.0',
-        'pdo_mysql' => '>=7.0.0 <7.3.0',
-        'propro' => '>=7.0.0 <7.3.0',
-        'pspell' => '>=7.0.0 <7.3.0',
-        'raphf' => '>=7.0.0 <7.3.0',
-        'recode' => '>=7.0.0 <7.3.0',
-        'redis' => '>=7.0.0 <7.3.0',
-        'shmop' => '>=7.0.0 <7.3.0',
-        'soap' => '>=7.0.0 <7.3.0',
-        'sockets' => '>=7.0.0 <7.3.0',
-        'sodium' => '>=7.0.0 <7.3.0',
-        'ssh2' => '>=7.0.0 <7.3.0',
-        'sysvmsg' => '>=7.0.0 <7.3.0',
-        'sysvsem' => '>=7.0.0 <7.3.0',
-        'sysvshm' => '>=7.0.0 <7.3.0',
-        'tidy' => '>=7.0.0 <7.3.0',
-        'xdebug' => '>=7.0.0 <7.3.0',
-        'xmlrpc' => '>=7.0.0 <7.3.0',
-        'xsl' => '>=7.0.0 <7.3.0',
-        'yaml' => '>=7.0.0 <7.3.0',
-        'zip' => '>=7.0.0 <7.3.0',
-        'pcntl' => '>=7.0.0 <7.3.0',
-    ];
-
-    /**
-     * Extensions which built-in and can't be uninstalled
-     */
-    const BUILTIN_EXTENSIONS = [
-        'ctype' => '>=7.0.0 <7.3.0',
-        'curl' => '>=7.0.0 <7.3.0',
-        'date' => '>=7.0.0 <7.3.0',
-        'dom' => '>=7.0.0 <7.3.0',
-        'fileinfo' => '>=7.0.0 <7.3.0',
-        'filter' => '>=7.0.0 <7.3.0',
-        'ftp' => '>=7.0.0 <7.3.0',
-        'hash' => '>=7.0.0 <7.3.0',
-        'iconv' => '>=7.0.0 <7.3.0',
-        'json' => '>=7.0.0 <7.3.0',
-        'mbstring' => '>=7.0.0 <7.3.0',
-        'mysqlnd' => '>=7.0.0 <7.3.0',
-        'openssl' => '>=7.0.0 <7.3.0',
-        'pcre' => '>=7.0.0 <7.3.0',
-        'pdo' => '>=7.0.0 <7.3.0',
-        'pdo_sqlite' => '>=7.0.0 <7.3.0',
-        'phar' => '>=7.0.0 <7.3.0',
-        'posix' => '>=7.0.0 <7.3.0',
-        'readline' => '>=7.0.0 <7.3.0',
-        'session' => '>=7.0.0 <7.3.0',
-        'simplexml' => '>=7.0.0 <7.3.0',
-        'sqlite3' => '>=7.0.0 <7.3.0',
-        'tokenizer' => '>=7.0.0 <7.3.0',
-        'xml' => '>=7.0.0 <7.3.0',
-        'xmlreader' => '>=7.0.0 <7.3.0',
-        'xmlwriter' => '>=7.0.0 <7.3.0',
-        'zlib' => '>=7.0.0 <7.3.0',
-    ];
-
-    /**
-     * Extensions which should be ignored
-     */
-    const IGNORED_EXTENSIONS = ['blackfire', 'newrelic'];
-
-    /**
      * @var ServiceFactory
      */
     private $serviceFactory;
@@ -161,29 +52,29 @@ class ProductionCompose implements ComposeInterface
     protected $fileList;
 
     /**
-     * @var VersionParser
+     * @var PhpExtension
      */
-    private $versionParser;
+    private $phpExtension;
 
     /**
      * @param ServiceFactory $serviceFactory
      * @param FileList $fileList
      * @param Config $config
      * @param Converter $converter
-     * @param VersionParser $versionParser
+     * @param PhpExtension $phpExtension
      */
     public function __construct(
         ServiceFactory $serviceFactory,
         FileList $fileList,
         Config $config,
         Converter $converter,
-        VersionParser $versionParser
+        PhpExtension $phpExtension
     ) {
         $this->serviceFactory = $serviceFactory;
         $this->fileList = $fileList;
         $this->config = $config;
         $this->converter = $converter;
-        $this->versionParser = $versionParser;
+        $this->phpExtension = $phpExtension;
     }
 
     /**
@@ -517,36 +408,6 @@ class ProductionCompose implements ComposeInterface
      */
     protected function getPhpExtensions(string $phpVersion): array
     {
-        $phpConstraint = new Constraint('==', $this->versionParser->normalize($phpVersion));
-        $phpExtensions = array_diff(
-            array_merge(self::DEFAULT_PHP_EXTENSIONS, $this->config->getEnabledPhpExtensions()),
-            $this->config->getDisabledPhpExtensions(),
-            self::IGNORED_EXTENSIONS
-        );
-        $messages = [];
-        $result = [];
-        foreach ($phpExtensions as $phpExtName) {
-            if (isset(self::BUILTIN_EXTENSIONS[$phpExtName])) {
-                $phpExtConstraint = $this->versionParser->parseConstraints(self::BUILTIN_EXTENSIONS[$phpExtName]);
-                if ($phpConstraint->matches($phpExtConstraint)) {
-                    continue;
-                }
-            }
-            if (isset(self::AVAILABLE_PHP_EXTENSIONS[$phpExtName])) {
-                $phpExtConstraintAvailable = $this->versionParser->parseConstraints(
-                    self::AVAILABLE_PHP_EXTENSIONS[$phpExtName]
-                );
-                if ($phpConstraint->matches($phpExtConstraintAvailable)) {
-                    $result[] = $phpExtName;
-                    continue;
-                }
-                $messages[] = "PHP extension $phpExtName is not available for PHP version $phpVersion";
-            }
-            $messages[] = "PHP extension $phpExtName is not supported";
-        }
-        if (!empty($messages)) {
-            throw new ConfigurationMismatchException(implode(PHP_EOL, $messages));
-        }
-        return $result;
+        return $this->phpExtension->get($phpVersion);
     }
 }

--- a/src/Docker/Config/Reader.php
+++ b/src/Docker/Config/Reader.php
@@ -65,7 +65,11 @@ class Reader implements ReaderInterface
         $config = [
             'type' => $appConfig['type'],
             'crons' => $appConfig['crons'] ?? [],
-            'services' => []
+            'services' => [],
+            'runtime' => [
+                'extensions' => $appConfig['runtime']['extensions'] ?? [],
+                'disabled_extensions' => $appConfig['runtime']['disabled_extensions'] ?? []
+            ]
         ];
 
         foreach ($appConfig['relationships'] as $constraint) {

--- a/src/Docker/Service/Config.php
+++ b/src/Docker/Service/Config.php
@@ -140,4 +140,30 @@ class Config
             throw new ConfigurationMismatchException($exception->getMessage(), $exception->getCode(), $exception);
         }
     }
+
+    /**
+     * @return array
+     * @throws ConfigurationMismatchException
+     */
+    public function getEnabledPhpExtensions(): array
+    {
+        try {
+            return $this->reader->read()['runtime']['extensions'];
+        } catch (FileSystemException $exception) {
+            throw new ConfigurationMismatchException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+    }
+
+    /**
+     * @return array
+     * @throws ConfigurationMismatchException
+     */
+    public function getDisabledPhpExtensions(): array
+    {
+        try {
+            return $this->reader->read()['runtime']['disabled_extensions'];
+        } catch (FileSystemException $exception) {
+            throw new ConfigurationMismatchException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+    }
 }

--- a/src/Test/Unit/Docker/Compose/PhpExtensionTest.php
+++ b/src/Test/Unit/Docker/Compose/PhpExtensionTest.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MagentoCloud\Test\Unit\Docker\Compose;
+
+use Composer\Semver\Constraint\ConstraintInterface;
+use Magento\MagentoCloud\Docker\Compose\PhpExtension;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
+use PHPUnit\Framework\TestCase;
+use Composer\Semver\VersionParser;
+use Magento\MagentoCloud\Docker\Service\Config;
+
+/**
+ * @inheritdoc
+ */
+class PhpExtensionTest extends TestCase
+{
+    /**
+     * @var PhpExtension
+     */
+    private $phpExtension;
+
+    /**
+     * @var Config|Mock
+     */
+    private $configMock;
+
+    /**
+     * @var VersionParser|Mock
+     */
+    private $versionParserMock;
+
+    protected function setUp()
+    {
+        $this->configMock = $this->createMock(Config::class);
+        $this->versionParserMock = $this->createMock(VersionParser::class);
+
+        $this->phpExtension = new PhpExtension(
+            $this->configMock,
+            $this->versionParserMock
+        );
+    }
+
+    /**
+     * @param string $phpVersion
+     * @param string $normalizePhpVersion
+     * @param array $enabledPhpExtensions
+     * @param array $disabledPhpExtensions
+     * @param array $expectedPhpExtensions
+     * @throws \Magento\MagentoCloud\Docker\ConfigurationMismatchException
+     * @dataProvider getTestDataProvider
+     */
+    public function testGet(
+        string $phpVersion,
+        string $normalizePhpVersion,
+        array $enabledPhpExtensions,
+        array $disabledPhpExtensions,
+        array $expectedPhpExtensions
+    ) {
+        $constraintMock = $this->getMockForAbstractClass(ConstraintInterface::class);
+        $this->versionParserMock->expects($this->once())
+            ->method('normalize')
+            ->with($phpVersion)
+            ->willReturn($normalizePhpVersion);
+        $this->configMock->expects($this->once())
+            ->method('getEnabledPhpExtensions')
+            ->willReturn($enabledPhpExtensions);
+        $this->configMock->expects($this->once())
+            ->method('getDisabledPhpExtensions')
+            ->willReturn($disabledPhpExtensions);
+        $this->versionParserMock->expects($this->any())
+            ->method('parseConstraints')
+            ->willReturn($constraintMock);
+        $constraintMock->expects($this->any())
+            ->method('matches')
+            ->willReturn(true);
+        $actualPhpExtensions = $this->phpExtension->get($phpVersion);
+        sort($actualPhpExtensions);
+        sort($expectedPhpExtensions);
+        $this->assertEquals($expectedPhpExtensions, $actualPhpExtensions);
+    }
+
+    /**
+     * @return array
+     */
+    public function getTestDataProvider(): array
+    {
+        return [
+            [
+                'phpVersion' => '7.0',
+                'normalizePhpVersion' => '7.0.0.0',
+                'enabledPhpExtensions' => [],
+                'disabledPhpExtensions' => [],
+                'expectedPhpExtensions' => PhpExtension::DEFAULT_PHP_EXTENSIONS
+            ],
+            [
+                'phpVersion' => '7.1',
+                'normalizePhpVersion' => '7.1.0.0',
+                'enabledPhpExtensions' => array_keys(PhpExtension::BUILTIN_EXTENSIONS),
+                'disabledPhpExtensions' => [],
+                'expectedPhpExtensions' => PhpExtension::DEFAULT_PHP_EXTENSIONS
+            ],
+            [
+                'phpVersion' => '7.2',
+                'normalizePhpVersion' => '7.2.0.0',
+                'enabledPhpExtensions' => array_keys(PhpExtension::AVAILABLE_PHP_EXTENSIONS),
+                'disabledPhpExtensions' => [],
+                'expectedPhpExtensions' => array_keys(PhpExtension::AVAILABLE_PHP_EXTENSIONS),
+            ],
+            [
+                'phpVersion' => '7.2',
+                'normalizePhpVersion' => '7.2.0.0',
+                'enabledPhpExtensions' => [],
+                'disabledPhpExtensions' => PhpExtension::DEFAULT_PHP_EXTENSIONS,
+                'expectedPhpExtensions' => []
+            ],
+            [
+                'phpVersion' => '7.0',
+                'normalizePhpVersion' => '7.0.0.0',
+                'enabledPhpExtensions' => ['redis', 'xsl', 'json', 'blackfire', 'newrelic'],
+                'disabledPhpExtensions' => [],
+                'expectedPhpExtensions' => array_merge(
+                    PhpExtension::DEFAULT_PHP_EXTENSIONS,
+                    ['redis', 'xsl']
+                )
+            ],
+            [
+                'phpVersion' => '7.1',
+                'normalizePhpVersion' => '7.1.0.0',
+                'enabledPhpExtensions' => ['redis', 'xsl', 'json', 'blackfire', 'newrelic'],
+                'disabledPhpExtensions' => ['pcntl', 'pdo_mysql', 'soap', 'sysvmsg', 'sysvsem', 'sysvshm'],
+                'expectedPhpExtensions' => [
+                    'bcmath',
+                    'bz2',
+                    'calendar',
+                    'exif',
+                    'gd',
+                    'gettext',
+                    'intl',
+                    'mysqli',
+                    'sockets',
+                    'opcache',
+                    'zip',
+                    'redis',
+                    'xsl'
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @expectedException \Magento\MagentoCloud\Docker\ConfigurationMismatchException
+     * @expectedExceptionMessage PHP extension mcrypt is not available for PHP version 7.2.
+    PHP extension fakeExt is not supported.
+     */
+    public function testGetWithException()
+    {
+        $constraintMock = $this->getMockForAbstractClass(ConstraintInterface::class);
+        $this->versionParserMock->expects($this->once())
+            ->method('normalize')
+            ->with('7.2')
+            ->willReturn('7.2.0.0');
+        $this->configMock->expects($this->once())
+            ->method('getEnabledPhpExtensions')
+            ->willReturn(['mcrypt', 'fakeExt']);
+        $this->configMock->expects($this->once())
+            ->method('getDisabledPhpExtensions')
+            ->willReturn(PhpExtension::DEFAULT_PHP_EXTENSIONS);
+        $this->versionParserMock->expects($this->any())
+            ->method('parseConstraints')
+            ->willReturn($constraintMock);
+        $constraintMock->expects($this->any())
+            ->method('matches')
+            ->willReturn(false);
+        $this->phpExtension->get('7.2');
+    }
+}

--- a/src/Test/Unit/Docker/Compose/PhpExtensionTest.php
+++ b/src/Test/Unit/Docker/Compose/PhpExtensionTest.php
@@ -153,7 +153,7 @@ class PhpExtensionTest extends TestCase
     /**
      * @expectedException \Magento\MagentoCloud\Docker\ConfigurationMismatchException
      * @expectedExceptionMessage PHP extension mcrypt is not available for PHP version 7.2.
-    PHP extension fakeExt is not supported.
+     * PHP extension fakeExt is not supported.
      */
     public function testGetWithException()
     {

--- a/src/Test/Unit/Docker/Config/ReaderTest.php
+++ b/src/Test/Unit/Docker/Config/ReaderTest.php
@@ -234,7 +234,7 @@ class ReaderTest extends TestCase
                             'redis' => 'redis:redis',
                             'elasticsearch' => 'elasticsearch:elasticsearch',
                             'mq' => 'myrabbitmq:rabbitmq'
-                        ]
+                        ],
                     ]),
                 ],
                 [
@@ -281,6 +281,10 @@ class ReaderTest extends TestCase
                     'service' => 'rabbitmq',
                     'version' => '3.5'
                 ]
+            ],
+            'runtime' => [
+                'extensions' => [],
+                'disabled_extensions' => [],
             ]
         ], $this->reader->read());
     }


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-3357

### Description
Adds support for configuring PHP modules locally via .magento.app.yaml

### Fixed Issues (if relevant)
1. magento/ece-tools#MAGECLOUD-3357: [Cloud Docker] Changes in .magento.app.yaml should affect php modules

### Related Pull Request
https://github.com/magento/magento-cloud-docker/pull/25

### Manual testing scenarios
https://jira.corp.magento.com/browse/MAGECLOUD-126

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
