### PR TITLE
Reduce log level of shell output

### DIFF
--- a/src/Shell/Shell.php
+++ b/src/Shell/Shell.php
@@ -79,7 +79,7 @@ class Shell implements ShellInterface
                 'timeout' => null
             ]);
 
-            $this->logger->info($process->getCommandLine());
+            $this->logger->debug($process->getCommandLine());
 
             $process->execute();
         } catch (ProcessException $e) {

--- a/src/Test/Unit/Shell/ShellTest.php
+++ b/src/Test/Unit/Shell/ShellTest.php
@@ -95,17 +95,16 @@ class ShellTest extends TestCase
         $this->systemListMock->expects($this->once())
             ->method('getMagentoRoot')
             ->willReturn($magentoRoot);
-        $this->loggerMock->expects($this->once())
-            ->method('info')
-            ->with($commandWithArgs);
+
+        $logExpects = [[$commandWithArgs]];
+        if ($processOutput) {
+            $logExpects[] = [$processOutput];
+        }
+        $this->loggerMock->expects($this->exactly(count($logExpects)))
+            ->method('debug')
+            ->withConsecutive(...$logExpects);
         $this->sanitizerMock->expects($this->never())
             ->method('sanitize');
-
-        if ($processOutput) {
-            $this->loggerMock->expects($this->once())
-                ->method('debug')
-                ->with($processOutput);
-        }
 
         $this->shell->execute($command, $args);
     }
@@ -188,10 +187,10 @@ class ShellTest extends TestCase
             ->method('sanitize')
             ->with($this->stringContains('ls -al --password="123"'))
             ->willReturn('Command ls -al --password="***" failed');
-        $this->loggerMock->expects($this->once())
+        $this->loggerMock->expects($this->never())
             ->method('info')
             ->with($command);
-        $this->loggerMock->expects($this->never())
+        $this->loggerMock->expects($this->once())
             ->method('debug');
 
         $this->shell->execute($command);
@@ -219,7 +218,7 @@ class ShellTest extends TestCase
             ->method('getMagentoRoot')
             ->willReturn($magentoRoot);
         $this->loggerMock->expects($this->once())
-            ->method('info')
+            ->method('debug')
             ->with("ls -al 'arg1' 'arg2'");
 
         $this->shell->execute($command, ['arg1', 'arg2']);


### PR DESCRIPTION
Reduce log level of shell output

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
This pull request reduces the log level of shell output from INFO to DEBUG. The corresponding unit tests are also modified to match.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/ece-tools/issues/467

### Manual testing scenarios
1. Deploy to a remote integration environment.
2. See that the deploy log is less noisy.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
