### PR TITLE
MAGECLOUD-3850: [CLOUD Docker] Disabled extensions are still displayed in php container

### DIFF
--- a/src/Docker/Compose/ProductionCompose.php
+++ b/src/Docker/Compose/ProductionCompose.php
@@ -203,7 +203,7 @@ class ProductionCompose implements ComposeInterface
             'image' => 'alpine',
             'environment' => $this->converter->convert(array_merge(
                 $this->getVariables(),
-                !empty($phpExtensions) ? ['PHP_EXTENSIONS' => implode(' ', $phpExtensions)] : []
+                ['PHP_EXTENSIONS' => implode(' ', $phpExtensions)]
             )),
             'env_file' => [
                 './.docker/config.env',


### PR DESCRIPTION
### Description
https://magento2.atlassian.net/browse/MAGECLOUD-3850
### Fixed Issues (if relevant)

1. magento/ece-tools#MAGECLOUD-3850: [CLOUD Docker] Disabled extensions are still displayed in php container

### Manual testing scenarios
https://jira.corp.magento.com/browse/MAGECLOUD-126

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
