### PR TITLE
MAGECLOUD-3653: Change description for killing cron processes

### DIFF
--- a/src/Process/Deploy/CronProcessKill.php
+++ b/src/Process/Deploy/CronProcessKill.php
@@ -74,7 +74,8 @@ class CronProcessKill implements ProcessInterface
         try {
             $this->shell->execute("kill $pid");
         } catch (\RuntimeException $e) {
-            $this->logger->info('There is an error during killing the cron processes: ' . $e->getMessage());
+            $this->logger->info(sprintf('Couldn\'t kill process #%d it may be already finished', $pid));
+            $this->logger->debug($e->getMessage());
         }
     }
 }

--- a/src/Shell/Process.php
+++ b/src/Shell/Process.php
@@ -33,7 +33,15 @@ class Process extends \Symfony\Component\Process\Process implements ProcessInter
         try {
             parent::mustRun();
         } catch (ProcessFailedException $e) {
-            throw new ProcessException($e->getMessage(), $e->getProcess()->getExitCode());
+            $process = $e->getProcess();
+
+            $error = sprintf(
+                'The command "%s" failed. %s',
+                $process->getCommandLine(),
+                trim($process->getErrorOutput(), "\n")
+            );
+
+            throw new ProcessException($error, $process->getExitCode());
         }
     }
 }

--- a/src/Test/Unit/Process/Deploy/CronProcessKillTest.php
+++ b/src/Test/Unit/Process/Deploy/CronProcessKillTest.php
@@ -124,15 +124,18 @@ class CronProcessKillTest extends TestCase
             ->method('info')
             ->withConsecutive(
                 ['Trying to kill running cron jobs'],
-                ['There is an error during killing the cron processes: some error']
+                ['Couldn\'t kill process #111 it may be already finished']
             );
+        $this->loggerMock->expects($this->once())
+            ->method('debug')
+            ->with('some error');
         $this->shellMock->expects($this->at(0))
             ->method('execute')
             ->with('pgrep -U "$(id -u)" -f "bin/magento cron:run"')
             ->willReturn($processMock);
         $this->shellMock->expects($this->at(1))
             ->method('execute')
-            ->with("kill 111")
+            ->with('kill 111')
             ->willThrowException(new \RuntimeException('some error', 1));
         $this->process->execute();
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Changed log message when failed to kill the cron process. Detailed message moved to debug level.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3653

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Redeploy project on cloud environment
2. Check that next message was moved to `debug` level .  (For this set MIN_LOGGING_LEVEL: debug in .magento.env.yaml)
```
DEBUG: The command "kill 169" failed. sh: 1: kill: No such process
```
3. And in cloud.log you should also see following meesage
```INFO: Couldn't kill process #169 it may be already finished```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
