### PR TITLE
MAGECLOUD-3940: Use more OS agnostic form to find number of processors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ matrix:
       env: TEST_SUITE=functional
 
 install:
-  - if [ $TRAVIS_SECURE_ENV_VARS == "false" ]; then composer remove magento/magento-cloud-components --no-update; fi;
-  - composer config http-basic.repo.magento.com ${REPO_USERNAME} ${REPO_PASSWORD}
+  - if [ $TRAVIS_SECURE_ENV_VARS != "true" ]; then composer remove magento/magento-cloud-components --no-update; fi;
+  - if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then composer config http-basic.repo.magento.com ${REPO_USERNAME} ${REPO_PASSWORD}; fi;
   - composer update -n --no-suggest
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
 
 install:
   - if [ $TRAVIS_SECURE_ENV_VARS != "true" ]; then composer remove magento/magento-cloud-components --no-update; fi;
-  - if [ $TRAVIS_SECURE_ENV_VARS != "true" ]; then composer config --unset repositories.repo.magento.com fi;
+  - if [ $TRAVIS_SECURE_ENV_VARS != "true" ]; then composer config --unset repositories.repo.magento.com; fi;
   - if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then composer config http-basic.repo.magento.com ${REPO_USERNAME} ${REPO_PASSWORD}; fi;
   - composer update -n --no-suggest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
       env: TEST_SUITE=functional
 
 install:
+  - if [ $TRAVIS_SECURE_ENV_VARS == "false" ]; then composer remove magento/magento-cloud-components --no-update; fi;
   - composer config http-basic.repo.magento.com ${REPO_USERNAME} ${REPO_PASSWORD}
   - composer update -n --no-suggest
 
@@ -62,7 +63,7 @@ before_script:
 
 script:
   - if [ $TEST_SUITE == "static-unit" ]; then ./tests/travis/static-unit.sh; fi
-  - if [ $TRAVIS_SECURE_ENV_VARS == "true" ] && [ $TEST_SUITE == "integration" ]; then ./tests/travis/integration.sh; fi
-  - if [ $TRAVIS_SECURE_ENV_VARS == "true" ] && [ $TEST_SUITE == "functional" ]; then ./tests/travis/functional.sh; fi
+  - if [ $TRAVIS_SECURE_ENV_VARS == "true" ] && [ $TEST_SUITE == "integration" ]; then ./tests/travis/integration.sh; fi;
+  - if [ $TRAVIS_SECURE_ENV_VARS == "true" ] && [ $TEST_SUITE == "functional" ]; then ./tests/travis/functional.sh; fi;
 
 after_failure: docker ps -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ matrix:
 
 install:
   - if [ $TRAVIS_SECURE_ENV_VARS != "true" ]; then composer remove magento/magento-cloud-components --no-update; fi;
+  - if [ $TRAVIS_SECURE_ENV_VARS != "true" ]; then composer config --unset repositories.repo.magento.com fi;
   - if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then composer config http-basic.repo.magento.com ${REPO_USERNAME} ${REPO_PASSWORD}; fi;
   - composer update -n --no-suggest
 

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
   "type": "magento2-component",
   "version": "2002.0.20",
   "license": "OSL-3.0",
-  "repositories": [
-    {
+  "repositories": {
+    "repo.magento.com": {
       "type": "composer",
       "url": "https://repo.magento.com/"
     }
-  ],
+  },
   "require": {
     "php": "^7.0",
     "ext-PDO": "*",

--- a/src/Test/Unit/Util/CpuTest.php
+++ b/src/Test/Unit/Util/CpuTest.php
@@ -51,7 +51,7 @@ class CpuTest extends TestCase
             ->willReturn('8');
         $this->shellMock->expects($this->once())
             ->method('execute')
-            ->with('grep -c processor /proc/cpuinfo')
+            ->with('nproc')
             ->willReturn($processMock);
 
         $this->assertEquals(8, $this->cpu->getThreadsCount());

--- a/src/Util/Cpu.php
+++ b/src/Util/Cpu.php
@@ -45,7 +45,7 @@ class Cpu
     public function getThreadsCount(): int
     {
         try {
-            $result = $this->shell->execute('grep -c processor /proc/cpuinfo');
+            $result = $this->shell->execute('nproc');
             $threadCount = (int)$result->getOutput() ?? 1;
         } catch (ShellException $e) {
             $this->logger->error('Can\'t get system processor count: ' . $e->getMessage());


### PR DESCRIPTION
nproc is the better, more common way to find the number of processors (CPUs). It exists for linux and OSX. This change helps developers run "ece-tools deploy" on OSX faster while preparing their code for cloud.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. on OSX, ece-tools does not properly detect # of CPUs

### Manual testing scenarios
1. run `nproc` on cloud; 
2. see that the result matches `grep -c processor /proc/cpuinfo`

* https://jira.corp.magento.com/browse/MAGECLOUD-44
* https://jira.corp.magento.com/browse/MAGECLOUD-53

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
