### PR TITLE
MAGECLOUD-3997: Fix autoload error in ece-tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,10 @@
     "phpmd": "phpmd src xml tests/static/phpmd-ruleset.xml",
     "phpunit": "phpunit --configuration tests/unit",
     "coverage": "phpunit --configuration tests/unit --coverage-clover tests/unit/tmp/clover.xml && php tests/unit/code-coverage.php tests/unit/tmp/clover.xml",
-    "coverage-generate": "phpunit --configuration tests/unit --coverage-html tests/unit/tmp/coverage"
+    "coverage-generate": "phpunit --configuration tests/unit --coverage-html tests/unit/tmp/coverage",
+    "pre-autoload-dump": [
+      "Magento\\MagentoCloud\\Composer\\ClearAutoload::preAutoloadDump"
+    ]
   },
   "config": {
     "sort-packages": true

--- a/src/Composer/ClearAutoload.php
+++ b/src/Composer/ClearAutoload.php
@@ -13,6 +13,8 @@ use Composer\Script\Event;
 
 /**
  * Clears registration.php file of magento/magento-cloud-components package from composer autoload
+ *
+ * @codeCoverageIgnore
  */
 class ClearAutoload
 {

--- a/src/Composer/ClearAutoload.php
+++ b/src/Composer/ClearAutoload.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Composer;
+
+use Composer\Package\Package;
+use Composer\Package\PackageInterface;
+use Composer\Script\Event;
+
+/**
+ * Clears registration.php file of magento/magento-cloud-components package from composer autoload
+ */
+class ClearAutoload
+{
+    /**
+     * @param Event $event
+     */
+    public static function preAutoloadDump(Event $event)
+    {
+        $composer = $event->getComposer();
+
+        $generator  = $composer->getAutoloadGenerator();
+        $packages   = $composer->getRepositoryManager()->getLocalRepository()->getCanonicalPackages();
+        $packageMap = $generator->buildPackageMap(
+            $composer->getInstallationManager(),
+            $composer->getPackage(),
+            $packages
+        );
+
+        foreach ($packageMap as $item) {
+            /** @var Package $package */
+            $package = reset($item);
+
+            if (!$package instanceof PackageInterface ||
+                $package->getName() !== 'magento/magento-cloud-components'
+            ) {
+                continue;
+            }
+
+            $autoload = $package->getAutoload();
+
+            if (!isset($autoload['files'])) {
+                continue;
+            }
+
+            foreach ($autoload['files'] as $index => $fileName) {
+                if ($fileName === 'registration.php') {
+                    unset($autoload['files'][$index]);
+                }
+            }
+
+            $package->setAutoload($autoload);
+        }
+    }
+}

--- a/tests/static/phpstan.neon
+++ b/tests/static/phpstan.neon
@@ -5,5 +5,7 @@ parameters:
     excludes_analyse:
         - %currentWorkingDirectory%/src/Test/*
     ignoreErrors:
+        - message: "#.*ComponentRegistrar.*#"
+          path: %currentWorkingDirectory%/src/StaticContent/ThemeResolver.php
         - message: "#Strict comparison using === between bool and null will always evaluate to false.#"
           path: %currentWorkingDirectory%/src/Filesystem/Driver/File.php

--- a/tests/static/phpstan7.0.neon
+++ b/tests/static/phpstan7.0.neon
@@ -1,3 +1,5 @@
 parameters:
     excludes_analyse:
         - %currentWorkingDirectory%/src/Test/*
+    ignoreErrors:
+        - "#.*ComponentRegistrar not found.#"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed ece-tools autoloader
```
PHP Fatal error:  Uncaught Error: Class 'Magento\Framework\Component\ComponentRegistrar' not found in /u02/cloud/ece-tools/vendor/magento/magento-cloud-components/registration.php:9
```

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3997

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. clone ece-tools
2. run `composer update`
3. Check that `php bin/ece-tools` don't trow an Exception

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
