### PR TITLE
MAGECLOUD-3957: Error with static content deploy because of empty locale for admin user in config.php in case of dump after installation

### DIFF
--- a/src/Test/Unit/Util/ArrayManagerTest.php
+++ b/src/Test/Unit/Util/ArrayManagerTest.php
@@ -116,6 +116,14 @@ class ArrayManagerTest extends TestCase
             ],
             [
                 [
+                    'admin_user/locale/code' => [],
+                ],
+                'admin_user/locale/code',
+                false,
+                [],
+            ],
+            [
+                [
                     'admin_user/locale/code' => 'en_US',
                 ],
                 'admin_user/locale/code',

--- a/src/Util/ArrayManager.php
+++ b/src/Util/ArrayManager.php
@@ -55,7 +55,7 @@ class ArrayManager
             }
         }
 
-        return array_unique(array_values($filteredResult));
+        return array_unique(array_filter(array_values($filteredResult)));
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Fixed an issue when `admin_user` locales are empty after `ece-tools config:dump` command

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3957

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Install magento on cloud
2. Remove all admin_users if they exist
3. Make ece-tools dump
4. Copy config.php to local machine
5. Commit and push 
6. No Error during build static content generation

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
