### PR TITLE
MAGECLOUD-4009:  Error in UrlManager::getBaseUrl() when secured url isn't configured

### DIFF
--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -164,7 +164,9 @@ class UrlManager
                     'Instead, using the URL from the MAGENTO_CLOUD_ROUTES variable.'
                 );
                 $this->logger->debug($e->getMessage());
-                $this->baseUrl = $this->getSecureUrls()[''];
+
+                $urls = $this->getSecureUrls() ?? $this->getUnSecureUrls();
+                $this->baseUrl = $urls[''] ?? reset($urls);
             }
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Fixed an error in page warm-up when Magento_CloudComponents module disabled manually and `{default}` route not configured,

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-4009

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Magento Installed on Cloud
2. Disable cloud components in `app/etc/config.php` file
```
'modules' => [
    'Magento_CloudComponents' => 0,
]
```
3. Change `{default}` route to `{all}` in `.magento/routes.yaml` file.
4. Commit and push changes, no errors in post-deploy hook during page warm-up

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
