### PR TITLE
MAGECLOUD-3913: Deadlocks when consumers run from cron

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -111,6 +111,7 @@
       "2.2.5": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.5.patch",
       "2.2.6": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.6.patch",
       "2.2.7": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.7.patch",
+      "2.2.8 - 2.2.9": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.8.patch",
       "2.3.0": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.0.patch",
       "2.3.1 - 2.3.2": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.1.patch"
     },

--- a/patches.json
+++ b/patches.json
@@ -107,7 +107,9 @@
     },
     "Fix Problems with Consumer Runners on Cloud Clusters": {
       "2.2.0 - 2.2.3": "MAGECLOUD-2464__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.0.patch",
-      "2.2.4 - 2.2.5": "MAGECLOUD-2464__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.4.patch"
+      "2.2.4 - 2.2.5": "MAGECLOUD-2464__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.4.patch",
+      "2.3.0": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.0.patch",
+      "2.3.1 - 2.3.2": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.1.patch"
     },
     "Resolve Issues with Cron Schedule": {
       "2.1.10 - 2.1.14 || 2.2.2 - 2.2.5": "MAGECLOUD-2427__resolve_issues_with_cron_schedule.patch"

--- a/patches.json
+++ b/patches.json
@@ -110,6 +110,7 @@
       "2.2.4": "MAGECLOUD-2464__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.4.patch",
       "2.2.5": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.5.patch",
       "2.2.6": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.6.patch",
+      "2.2.7": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.7.patch",
       "2.3.0": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.0.patch",
       "2.3.1 - 2.3.2": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.1.patch"
     },

--- a/patches.json
+++ b/patches.json
@@ -107,7 +107,9 @@
     },
     "Fix Problems with Consumer Runners on Cloud Clusters": {
       "2.2.0 - 2.2.3": "MAGECLOUD-2464__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.0.patch",
-      "2.2.4 - 2.2.5": "MAGECLOUD-2464__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.4.patch",
+      "2.2.4": "MAGECLOUD-2464__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.4.patch",
+      "2.2.5": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.5.patch",
+      "2.2.6": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.6.patch",
       "2.3.0": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.0.patch",
       "2.3.1 - 2.3.2": "MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.1.patch"
     },

--- a/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.5.patch
+++ b/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.5.patch
@@ -1,0 +1,573 @@
+diff -Nuar a/vendor/magento/framework/Lock/Backend/Database.php b/vendor/magento/framework/Lock/Backend/Database.php
+--- a/vendor/magento/framework/Lock/Backend/Database.php
++++ b/vendor/magento/framework/Lock/Backend/Database.php
+@@ -3,8 +3,8 @@
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-
+ declare(strict_types=1);
++
+ namespace Magento\Framework\Lock\Backend;
+ 
+ use Magento\Framework\App\DeploymentConfig;
+@@ -14,20 +14,44 @@ use Magento\Framework\Exception\AlreadyExistsException;
+ use Magento\Framework\Exception\InputException;
+ use Magento\Framework\Phrase;
+ 
++/**
++ * Implementation of the lock manager on the basis of MySQL.
++ */
+ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ {
+-    /** @var ResourceConnection */
++    /**
++     * Max time for lock is 1 week
++     *
++     * MariaDB does not support negative timeout value to get infinite timeout,
++     * so we set 1 week for lock timeout
++     */
++    const MAX_LOCK_TIME = 604800;
++
++    /**
++     * @var ResourceConnection
++     */
+     private $resource;
+ 
+-    /** @var DeploymentConfig */
++    /**
++     * @var DeploymentConfig
++     */
+     private $deploymentConfig;
+ 
+-    /** @var string Lock prefix */
++    /**
++     * @var string Lock prefix
++     */
+     private $prefix;
+ 
+-    /** @var string|false Holds current lock name if set, otherwise false */
++    /**
++     * @var string|false Holds current lock name if set, otherwise false
++     */
+     private $currentLock = false;
+ 
++    /**
++     * @param ResourceConnection $resource
++     * @param DeploymentConfig $deploymentConfig
++     * @param string|null $prefix
++     */
+     public function __construct(
+         ResourceConnection $resource,
+         DeploymentConfig $deploymentConfig,
+@@ -46,9 +70,13 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @return bool
+      * @throws InputException
+      * @throws AlreadyExistsException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function lock(string $name, int $timeout = -1): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return true;
++        };
+         $name = $this->addPrefix($name);
+ 
+         /**
+@@ -59,7 +87,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+         if ($this->currentLock) {
+             throw new AlreadyExistsException(
+                 new Phrase(
+-                    'Current connection is already holding lock for $1, only single lock allowed',
++                    'Current connection is already holding lock for %1, only single lock allowed',
+                     [$this->currentLock]
+                 )
+             );
+@@ -67,7 +95,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ 
+         $result = (bool)$this->resource->getConnection()->query(
+             "SELECT GET_LOCK(?, ?);",
+-            [(string)$name, (int)$timeout]
++            [$name, $timeout < 0 ? self::MAX_LOCK_TIME : $timeout]
+         )->fetchColumn();
+ 
+         if ($result === true) {
+@@ -83,9 +111,14 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @param string $name lock name
+      * @return bool
+      * @throws InputException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function unlock(string $name): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return true;
++        };
++
+         $name = $this->addPrefix($name);
+ 
+         $result = (bool)$this->resource->getConnection()->query(
+@@ -106,14 +139,19 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @param string $name lock name
+      * @return bool
+      * @throws InputException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function isLocked(string $name): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return false;
++        };
++
+         $name = $this->addPrefix($name);
+ 
+         return (bool)$this->resource->getConnection()->query(
+             "SELECT IS_USED_LOCK(?);",
+-            [(string)$name]
++            [$name]
+         )->fetchColumn();
+     }
+ 
+@@ -123,7 +161,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * Limited to 64 characters in MySQL.
+      *
+      * @param string $name
+-     * @return string $name
++     * @return string
+      * @throws InputException
+      */
+     private function addPrefix(string $name): string
+diff -Nuar a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+--- a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
++++ b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
+ use Symfony\Component\Console\Input\InputOption;
+ use Symfony\Component\Console\Output\OutputInterface;
+ use Magento\Framework\MessageQueue\ConsumerFactory;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+ 
+ /**
+  * Command for starting MessageQueue consumers.
+@@ -22,6 +22,7 @@ class StartConsumerCommand extends Command
+     const OPTION_NUMBER_OF_MESSAGES = 'max-messages';
+     const OPTION_BATCH_SIZE = 'batch-size';
+     const OPTION_AREACODE = 'area-code';
++    const OPTION_SINGLE_THREAD = 'single-thread';
+     const PID_FILE_PATH = 'pid-file-path';
+     const COMMAND_QUEUE_CONSUMERS_START = 'queue:consumers:start';
+ 
+@@ -36,9 +37,9 @@ class StartConsumerCommand extends Command
+     private $appState;
+ 
+     /**
+-     * @var PidConsumerManager
++     * @var LockManagerInterface
+      */
+-    private $pidConsumerManager;
++    private $lockManager;
+ 
+     /**
+      * StartConsumerCommand constructor.
+@@ -47,23 +48,23 @@ class StartConsumerCommand extends Command
+      * @param \Magento\Framework\App\State $appState
+      * @param ConsumerFactory $consumerFactory
+      * @param string $name
+-     * @param PidConsumerManager $pidConsumerManager
++     * @param LockManagerInterface $lockManager
+      */
+     public function __construct(
+         \Magento\Framework\App\State $appState,
+         ConsumerFactory $consumerFactory,
+         $name = null,
+-        PidConsumerManager $pidConsumerManager = null
++        LockManagerInterface $lockManager = null
+     ) {
+         $this->appState = $appState;
+         $this->consumerFactory = $consumerFactory;
+-        $this->pidConsumerManager = $pidConsumerManager ?: \Magento\Framework\App\ObjectManager::getInstance()
+-            ->get(PidConsumerManager::class);
++        $this->lockManager = $lockManager ?: \Magento\Framework\App\ObjectManager::getInstance()
++            ->get(LockManagerInterface::class);
+         parent::__construct($name);
+     }
+ 
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function execute(InputInterface $input, OutputInterface $output)
+     {
+@@ -71,30 +72,36 @@ class StartConsumerCommand extends Command
+         $numberOfMessages = $input->getOption(self::OPTION_NUMBER_OF_MESSAGES);
+         $batchSize = (int)$input->getOption(self::OPTION_BATCH_SIZE);
+         $areaCode = $input->getOption(self::OPTION_AREACODE);
+-        $pidFilePath = $input->getOption(self::PID_FILE_PATH);
+ 
+-        if ($pidFilePath && $this->pidConsumerManager->isRun($pidFilePath)) {
+-            $output->writeln('<error>Consumer with the same PID is running</error>');
+-            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
++        if ($input->getOption(self::PID_FILE_PATH)) {
++            $input->setOption(self::OPTION_SINGLE_THREAD, true);
+         }
+ 
+-        if ($pidFilePath) {
+-            $this->pidConsumerManager->savePid($pidFilePath);
++        $singleThread = $input->getOption(self::OPTION_SINGLE_THREAD);
++
++        if ($singleThread && $this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
++            $output->writeln('<error>Consumer with the same name is running</error>');
++            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+         }
+ 
+-        if ($areaCode !== null) {
+-            $this->appState->setAreaCode($areaCode);
+-        } else {
+-            $this->appState->setAreaCode('global');
++        if ($singleThread) {
++            $this->lockManager->lock(md5($consumerName)); //phpcs:ignore
+         }
+ 
++        $this->appState->setAreaCode($areaCode ?? 'global');
++
+         $consumer = $this->consumerFactory->get($consumerName, $batchSize);
+         $consumer->process($numberOfMessages);
++
++        if ($singleThread) {
++            $this->lockManager->unlock(md5($consumerName)); //phpcs:ignore
++        }
++
+         return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+     }
+ 
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function configure()
+     {
+@@ -125,11 +132,17 @@ class StartConsumerCommand extends Command
+             'The preferred area (global, adminhtml, etc...) '
+             . 'default is global.'
+         );
++        $this->addOption(
++            self::OPTION_SINGLE_THREAD,
++            null,
++            InputOption::VALUE_NONE,
++            'This option prevents running multiple copies of one consumer simultaneously.'
++        );
+         $this->addOption(
+             self::PID_FILE_PATH,
+             null,
+             InputOption::VALUE_REQUIRED,
+-            'The file path for saving PID'
++            'The file path for saving PID (This option is deprecated, use --single-thread instead)'
+         );
+         $this->setHelp(
+             <<<HELP
+@@ -150,8 +163,12 @@ To specify the number of messages per batch for the batch consumer:
+ To specify the preferred area:
+ 
+     <comment>%command.full_name% someConsumer --area-code='adminhtml'</comment>
++
++To do not run multiple copies of one consumer simultaneously:
++
++    <comment>%command.full_name% someConsumer --single-thread'</comment>
+ 
+-To save PID enter path:
++To save PID enter path (This option is deprecated, use --single-thread instead):
+ 
+     <comment>%command.full_name% someConsumer --pid-file-path='/var/someConsumer.pid'</comment>
+ HELP
+diff -Nuar a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
++++ b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+@@ -5,22 +5,21 @@
+  */
+ namespace Magento\MessageQueue\Model\Cron;
+ 
++use Magento\Framework\App\ObjectManager;
++use Magento\Framework\MessageQueue\ConnectionTypeResolver;
++use Magento\Framework\MessageQueue\Consumer\Config\ConsumerConfigItemInterface;
+ use Magento\Framework\ShellInterface;
+ use Magento\Framework\MessageQueue\Consumer\ConfigInterface as ConsumerConfigInterface;
+ use Magento\Framework\App\DeploymentConfig;
++use Psr\Log\LoggerInterface;
+ use Symfony\Component\Process\PhpExecutableFinder;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+ 
+ /**
+  * Class for running consumers processes by cron
+  */
+ class ConsumersRunner
+ {
+-    /**
+-     * Extension of PID file
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+     /**
+      * Shell command line wrapper for executing command in background
+      *
+@@ -50,11 +49,21 @@ class ConsumersRunner
+     private $phpExecutableFinder;
+ 
+     /**
+-     * The class for checking status of process by PID
++     * @var ConnectionTypeResolver
++     */
++    private $mqConnectionTypeResolver;
++
++    /**
++     * @var LoggerInterface
++     */
++    private $logger;
++
++    /**
++     * Lock Manager
+      *
+-     * @var PidConsumerManager
++     * @var LockManagerInterface
+      */
+-    private $pidConsumerManager;
++    private $lockManager;
+ 
+     /**
+      * @param PhpExecutableFinder $phpExecutableFinder The executable finder specifically designed
+@@ -62,20 +71,28 @@ class ConsumersRunner
+      * @param ConsumerConfigInterface $consumerConfig The consumer config provider
+      * @param DeploymentConfig $deploymentConfig The application deployment configuration
+      * @param ShellInterface $shellBackground The shell command line wrapper for executing command in background
+-     * @param PidConsumerManager $pidConsumerManager The class for checking status of process by PID
++     * @param LockManagerInterface $lockManager The lock manager
++     * @param ConnectionTypeResolver $mqConnectionTypeResolver Consumer connection resolver
++     * @param LoggerInterface $logger Logger
+      */
+     public function __construct(
+         PhpExecutableFinder $phpExecutableFinder,
+         ConsumerConfigInterface $consumerConfig,
+         DeploymentConfig $deploymentConfig,
+         ShellInterface $shellBackground,
+-        PidConsumerManager $pidConsumerManager
++        LockManagerInterface $lockManager,
++        ConnectionTypeResolver $mqConnectionTypeResolver = null,
++        LoggerInterface $logger = null
+     ) {
+         $this->phpExecutableFinder = $phpExecutableFinder;
+         $this->consumerConfig = $consumerConfig;
+         $this->deploymentConfig = $deploymentConfig;
+         $this->shellBackground = $shellBackground;
+-        $this->pidConsumerManager = $pidConsumerManager;
++        $this->lockManager = $lockManager;
++        $this->mqConnectionTypeResolver = $mqConnectionTypeResolver
++            ?: ObjectManager::getInstance()->get(ConnectionTypeResolver::class);
++        $this->logger = $logger
++            ?: ObjectManager::getInstance()->get(LoggerInterface::class);
+     }
+ 
+     /**
+@@ -94,15 +111,13 @@ class ConsumersRunner
+         $php = $this->phpExecutableFinder->find() ?: 'php';
+ 
+         foreach ($this->consumerConfig->getConsumers() as $consumer) {
+-            $consumerName = $consumer->getName();
+-
+-            if (!$this->canBeRun($consumerName, $allowedConsumers)) {
++            if (!$this->canBeRun($consumer, $allowedConsumers)) {
+                 continue;
+             }
+ 
+             $arguments = [
+-                $consumerName,
+-                '--pid-file-path=' . $this->getPidFilePath($consumerName),
++                $consumer->getName(),
++                '--single-thread'
+             ];
+ 
+             if ($maxMessages) {
+@@ -119,26 +134,38 @@ class ConsumersRunner
+     /**
+      * Checks that the consumer can be run
+      *
+-     * @param string $consumerName The consumer name
++     * @param ConsumerConfigItemInterface $consumerConfig The consumer config
+      * @param array $allowedConsumers The list of allowed consumers
+      *        If $allowedConsumers is empty it means that all consumers are allowed
+      * @return bool Returns true if the consumer can be run
++     * @throws \Magento\Framework\Exception\FileSystemException
+      */
+-    private function canBeRun($consumerName, array $allowedConsumers = [])
++    private function canBeRun(ConsumerConfigItemInterface $consumerConfig, array $allowedConsumers = []): bool
+     {
+-        $allowed = empty($allowedConsumers) ?: in_array($consumerName, $allowedConsumers);
++        $consumerName = $consumerConfig->getName();
++        if (!empty($allowedConsumers) && !in_array($consumerName, $allowedConsumers)) {
++            return false;
++        }
+ 
+-        return $allowed && !$this->pidConsumerManager->isRun($this->getPidFilePath($consumerName));
+-    }
++        if ($this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
++            return false;
++        }
+ 
+-    /**
+-     * Returns default path to file with PID by consumers name
+-     *
+-     * @param string $consumerName The consumers name
+-     * @return string The path to file with PID
+-     */
+-    private function getPidFilePath($consumerName)
+-    {
+-        return $consumerName . static::PID_FILE_EXT;
++        $connectionName = $consumerConfig->getConnection();
++        try {
++            $this->mqConnectionTypeResolver->getConnectionType($connectionName);
++        } catch (\LogicException $e) {
++            $this->logger->info(
++                sprintf(
++                    'Consumer "%s" skipped as required connection "%s" is not configured. %s',
++                    $consumerName,
++                    $connectionName,
++                    $e->getMessage()
++                )
++            );
++            return false;
++        }
++
++        return true;
+     }
+ }
+diff -Nuar a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
+deleted file mode 100644
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
++++ /dev/null
+@@ -1,127 +0,0 @@
+-<?php
+-/**
+- * Copyright © Magento, Inc. All rights reserved.
+- * See COPYING.txt for license details.
+- */
+-namespace Magento\MessageQueue\Model\Cron\ConsumersRunner;
+-
+-use Magento\Framework\App\Filesystem\DirectoryList;
+-use Magento\Framework\Filesystem\Directory\WriteInterface;
+-use Magento\Framework\Filesystem\Directory\ReadInterface;
+-use Magento\Framework\Filesystem;
+-use Magento\Framework\Exception\FileSystemException;
+-
+-/**
+- * The class for checking status of process by PID
+- */
+-class PidConsumerManager
+-{
+-    /**
+-     * Extension of PID file
+-     * @deprecated Moved to the correct responsibility area
+-     * @see \Magento\MessageQueue\Model\Cron\ConsumersRunner::PID_FILE_EXT
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+-    /**
+-     * The class for working with FS
+-     *
+-     * @var Filesystem
+-     */
+-    private $filesystem;
+-
+-    /**
+-     * @param Filesystem $filesystem The class for working with FS
+-     */
+-    public function __construct(Filesystem $filesystem)
+-    {
+-        $this->filesystem = $filesystem;
+-    }
+-
+-    /**
+-     * Checks if consumer process is run by pid from pidFile
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return bool Returns true if consumer process is run
+-     * @throws FileSystemException
+-     */
+-    public function isRun($pidFilePath)
+-    {
+-        $pid = $this->getPid($pidFilePath);
+-        if ($pid) {
+-            if (function_exists('posix_getpgid')) {
+-                return (bool) posix_getpgid($pid);
+-            } else {
+-                return $this->checkIsProcessExists($pid);
+-            }
+-        }
+-
+-        return false;
+-    }
+-
+-    /**
+-     * Checks that process is running
+-     *
+-     * If php function exec is not available throws RuntimeException
+-     * If shell command returns non-zero code and this code is not 1 throws RuntimeException
+-     *
+-     * @param int $pid A pid of process
+-     * @return bool Returns true if consumer process is run
+-     * @throws \RuntimeException
+-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+-     */
+-    private function checkIsProcessExists($pid)
+-    {
+-        if (!function_exists('exec')) {
+-            throw new \RuntimeException('Function exec is not available');
+-        }
+-
+-        exec(escapeshellcmd('ps -p ' . $pid), $output, $code);
+-
+-        $code = (int) $code;
+-
+-        switch ($code) {
+-            case 0:
+-                return true;
+-                break;
+-            case 1:
+-                return false;
+-                break;
+-            default:
+-                throw new \RuntimeException('Exec returned non-zero code', $code);
+-                break;
+-        }
+-    }
+-
+-    /**
+-     * Returns pid by pidFile path
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return int Returns pid if pid file exists for consumer else returns 0
+-     * @throws FileSystemException
+-     */
+-    public function getPid($pidFilePath)
+-    {
+-        /** @var ReadInterface $directory */
+-        $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
+-
+-        if ($directory->isExist($pidFilePath)) {
+-            return (int) $directory->readFile($pidFilePath);
+-        }
+-
+-        return 0;
+-    }
+-
+-    /**
+-     * Saves pid of current process to file
+-     *
+-     * @param string $pidFilePath The path to file with pid
+-     * @throws FileSystemException
+-     */
+-    public function savePid($pidFilePath)
+-    {
+-        /** @var WriteInterface $directory */
+-        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+-        $directory->writeFile($pidFilePath, function_exists('posix_getpid') ? posix_getpid() : getmypid(), 'w');
+-    }
+-}

--- a/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.6.patch
+++ b/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.6.patch
@@ -1,0 +1,572 @@
+diff -Nuar a/vendor/magento/framework/Lock/Backend/Database.php b/vendor/magento/framework/Lock/Backend/Database.php
+--- a/vendor/magento/framework/Lock/Backend/Database.php
++++ b/vendor/magento/framework/Lock/Backend/Database.php
+@@ -3,8 +3,8 @@
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-
+ declare(strict_types=1);
++
+ namespace Magento\Framework\Lock\Backend;
+ 
+ use Magento\Framework\App\DeploymentConfig;
+@@ -14,23 +14,40 @@ use Magento\Framework\Exception\AlreadyExistsException;
+ use Magento\Framework\Exception\InputException;
+ use Magento\Framework\Phrase;
+ 
++/**
++ * Implementation of the lock manager on the basis of MySQL.
++ */
+ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ {
+-    /** @var ResourceConnection */
++    /**
++     * Max time for lock is 1 week
++     *
++     * MariaDB does not support negative timeout value to get infinite timeout,
++     * so we set 1 week for lock timeout
++     */
++    const MAX_LOCK_TIME = 604800;
++
++    /**
++     * @var ResourceConnection
++     */
+     private $resource;
+ 
+-    /** @var DeploymentConfig */
++    /**
++     * @var DeploymentConfig
++     */
+     private $deploymentConfig;
+ 
+-    /** @var string Lock prefix */
++    /**
++     * @var string Lock prefix
++     */
+     private $prefix;
+ 
+-    /** @var string|false Holds current lock name if set, otherwise false */
++    /**
++     * @var string|false Holds current lock name if set, otherwise false
++     */
+     private $currentLock = false;
+ 
+     /**
+-     * Database constructor.
+-     *
+      * @param ResourceConnection $resource
+      * @param DeploymentConfig $deploymentConfig
+      * @param string|null $prefix
+@@ -53,9 +70,13 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @return bool
+      * @throws InputException
+      * @throws AlreadyExistsException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function lock(string $name, int $timeout = -1): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return true;
++        };
+         $name = $this->addPrefix($name);
+ 
+         /**
+@@ -66,7 +87,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+         if ($this->currentLock) {
+             throw new AlreadyExistsException(
+                 new Phrase(
+-                    'Current connection is already holding lock for $1, only single lock allowed',
++                    'Current connection is already holding lock for %1, only single lock allowed',
+                     [$this->currentLock]
+                 )
+             );
+@@ -74,7 +95,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ 
+         $result = (bool)$this->resource->getConnection()->query(
+             "SELECT GET_LOCK(?, ?);",
+-            [(string)$name, (int)$timeout]
++            [$name, $timeout < 0 ? self::MAX_LOCK_TIME : $timeout]
+         )->fetchColumn();
+ 
+         if ($result === true) {
+@@ -90,9 +111,14 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @param string $name lock name
+      * @return bool
+      * @throws InputException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function unlock(string $name): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return true;
++        };
++
+         $name = $this->addPrefix($name);
+ 
+         $result = (bool)$this->resource->getConnection()->query(
+@@ -113,14 +139,19 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @param string $name lock name
+      * @return bool
+      * @throws InputException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function isLocked(string $name): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return false;
++        };
++
+         $name = $this->addPrefix($name);
+ 
+         return (bool)$this->resource->getConnection()->query(
+             "SELECT IS_USED_LOCK(?);",
+-            [(string)$name]
++            [$name]
+         )->fetchColumn();
+     }
+ 
+@@ -130,7 +161,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * Limited to 64 characters in MySQL.
+      *
+      * @param string $name
+-     * @return string $name
++     * @return string
+      * @throws InputException
+      */
+     private function addPrefix(string $name): string
+diff -Nuar a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+--- a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
++++ b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
+ use Symfony\Component\Console\Input\InputOption;
+ use Symfony\Component\Console\Output\OutputInterface;
+ use Magento\Framework\MessageQueue\ConsumerFactory;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+ 
+ /**
+  * Command for starting MessageQueue consumers.
+@@ -22,6 +22,7 @@ class StartConsumerCommand extends Command
+     const OPTION_NUMBER_OF_MESSAGES = 'max-messages';
+     const OPTION_BATCH_SIZE = 'batch-size';
+     const OPTION_AREACODE = 'area-code';
++    const OPTION_SINGLE_THREAD = 'single-thread';
+     const PID_FILE_PATH = 'pid-file-path';
+     const COMMAND_QUEUE_CONSUMERS_START = 'queue:consumers:start';
+ 
+@@ -36,9 +37,9 @@ class StartConsumerCommand extends Command
+     private $appState;
+ 
+     /**
+-     * @var PidConsumerManager
++     * @var LockManagerInterface
+      */
+-    private $pidConsumerManager;
++    private $lockManager;
+ 
+     /**
+      * StartConsumerCommand constructor.
+@@ -47,23 +48,23 @@ class StartConsumerCommand extends Command
+      * @param \Magento\Framework\App\State $appState
+      * @param ConsumerFactory $consumerFactory
+      * @param string $name
+-     * @param PidConsumerManager $pidConsumerManager
++     * @param LockManagerInterface $lockManager
+      */
+     public function __construct(
+         \Magento\Framework\App\State $appState,
+         ConsumerFactory $consumerFactory,
+         $name = null,
+-        PidConsumerManager $pidConsumerManager = null
++        LockManagerInterface $lockManager = null
+     ) {
+         $this->appState = $appState;
+         $this->consumerFactory = $consumerFactory;
+-        $this->pidConsumerManager = $pidConsumerManager ?: \Magento\Framework\App\ObjectManager::getInstance()
+-            ->get(PidConsumerManager::class);
++        $this->lockManager = $lockManager ?: \Magento\Framework\App\ObjectManager::getInstance()
++            ->get(LockManagerInterface::class);
+         parent::__construct($name);
+     }
+ 
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function execute(InputInterface $input, OutputInterface $output)
+     {
+@@ -71,30 +72,36 @@ class StartConsumerCommand extends Command
+         $numberOfMessages = $input->getOption(self::OPTION_NUMBER_OF_MESSAGES);
+         $batchSize = (int)$input->getOption(self::OPTION_BATCH_SIZE);
+         $areaCode = $input->getOption(self::OPTION_AREACODE);
+-        $pidFilePath = $input->getOption(self::PID_FILE_PATH);
+ 
+-        if ($pidFilePath && $this->pidConsumerManager->isRun($pidFilePath)) {
+-            $output->writeln('<error>Consumer with the same PID is running</error>');
+-            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
++        if ($input->getOption(self::PID_FILE_PATH)) {
++            $input->setOption(self::OPTION_SINGLE_THREAD, true);
+         }
+ 
+-        if ($pidFilePath) {
+-            $this->pidConsumerManager->savePid($pidFilePath);
++        $singleThread = $input->getOption(self::OPTION_SINGLE_THREAD);
++
++        if ($singleThread && $this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
++            $output->writeln('<error>Consumer with the same name is running</error>');
++            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+         }
+ 
+-        if ($areaCode !== null) {
+-            $this->appState->setAreaCode($areaCode);
+-        } else {
+-            $this->appState->setAreaCode('global');
++        if ($singleThread) {
++            $this->lockManager->lock(md5($consumerName)); //phpcs:ignore
+         }
+ 
++        $this->appState->setAreaCode($areaCode ?? 'global');
++
+         $consumer = $this->consumerFactory->get($consumerName, $batchSize);
+         $consumer->process($numberOfMessages);
++
++        if ($singleThread) {
++            $this->lockManager->unlock(md5($consumerName)); //phpcs:ignore
++        }
++
+         return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+     }
+ 
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function configure()
+     {
+@@ -125,11 +132,17 @@ class StartConsumerCommand extends Command
+             'The preferred area (global, adminhtml, etc...) '
+             . 'default is global.'
+         );
++        $this->addOption(
++            self::OPTION_SINGLE_THREAD,
++            null,
++            InputOption::VALUE_NONE,
++            'This option prevents running multiple copies of one consumer simultaneously.'
++        );
+         $this->addOption(
+             self::PID_FILE_PATH,
+             null,
+             InputOption::VALUE_REQUIRED,
+-            'The file path for saving PID'
++            'The file path for saving PID (This option is deprecated, use --single-thread instead)'
+         );
+         $this->setHelp(
+             <<<HELP
+@@ -150,8 +163,12 @@ To specify the number of messages per batch for the batch consumer:
+ To specify the preferred area:
+ 
+     <comment>%command.full_name% someConsumer --area-code='adminhtml'</comment>
++
++To do not run multiple copies of one consumer simultaneously:
++
++    <comment>%command.full_name% someConsumer --single-thread'</comment>
+ 
+-To save PID enter path:
++To save PID enter path (This option is deprecated, use --single-thread instead):
+ 
+     <comment>%command.full_name% someConsumer --pid-file-path='/var/someConsumer.pid'</comment>
+ HELP
+diff -Nuar a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
++++ b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+@@ -5,22 +5,21 @@
+  */
+ namespace Magento\MessageQueue\Model\Cron;
+ 
++use Magento\Framework\App\ObjectManager;
++use Magento\Framework\MessageQueue\ConnectionTypeResolver;
++use Magento\Framework\MessageQueue\Consumer\Config\ConsumerConfigItemInterface;
+ use Magento\Framework\ShellInterface;
+ use Magento\Framework\MessageQueue\Consumer\ConfigInterface as ConsumerConfigInterface;
+ use Magento\Framework\App\DeploymentConfig;
++use Psr\Log\LoggerInterface;
+ use Symfony\Component\Process\PhpExecutableFinder;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+ 
+ /**
+  * Class for running consumers processes by cron
+  */
+ class ConsumersRunner
+ {
+-    /**
+-     * Extension of PID file
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+     /**
+      * Shell command line wrapper for executing command in background
+      *
+@@ -50,11 +49,21 @@ class ConsumersRunner
+     private $phpExecutableFinder;
+ 
+     /**
+-     * The class for checking status of process by PID
++     * @var ConnectionTypeResolver
++     */
++    private $mqConnectionTypeResolver;
++
++    /**
++     * @var LoggerInterface
++     */
++    private $logger;
++
++    /**
++     * Lock Manager
+      *
+-     * @var PidConsumerManager
++     * @var LockManagerInterface
+      */
+-    private $pidConsumerManager;
++    private $lockManager;
+ 
+     /**
+      * @param PhpExecutableFinder $phpExecutableFinder The executable finder specifically designed
+@@ -62,20 +71,28 @@ class ConsumersRunner
+      * @param ConsumerConfigInterface $consumerConfig The consumer config provider
+      * @param DeploymentConfig $deploymentConfig The application deployment configuration
+      * @param ShellInterface $shellBackground The shell command line wrapper for executing command in background
+-     * @param PidConsumerManager $pidConsumerManager The class for checking status of process by PID
++     * @param LockManagerInterface $lockManager The lock manager
++     * @param ConnectionTypeResolver $mqConnectionTypeResolver Consumer connection resolver
++     * @param LoggerInterface $logger Logger
+      */
+     public function __construct(
+         PhpExecutableFinder $phpExecutableFinder,
+         ConsumerConfigInterface $consumerConfig,
+         DeploymentConfig $deploymentConfig,
+         ShellInterface $shellBackground,
+-        PidConsumerManager $pidConsumerManager
++        LockManagerInterface $lockManager,
++        ConnectionTypeResolver $mqConnectionTypeResolver = null,
++        LoggerInterface $logger = null
+     ) {
+         $this->phpExecutableFinder = $phpExecutableFinder;
+         $this->consumerConfig = $consumerConfig;
+         $this->deploymentConfig = $deploymentConfig;
+         $this->shellBackground = $shellBackground;
+-        $this->pidConsumerManager = $pidConsumerManager;
++        $this->lockManager = $lockManager;
++        $this->mqConnectionTypeResolver = $mqConnectionTypeResolver
++            ?: ObjectManager::getInstance()->get(ConnectionTypeResolver::class);
++        $this->logger = $logger
++            ?: ObjectManager::getInstance()->get(LoggerInterface::class);
+     }
+ 
+     /**
+@@ -94,15 +111,13 @@ class ConsumersRunner
+         $php = $this->phpExecutableFinder->find() ?: 'php';
+ 
+         foreach ($this->consumerConfig->getConsumers() as $consumer) {
+-            $consumerName = $consumer->getName();
+-
+-            if (!$this->canBeRun($consumerName, $allowedConsumers)) {
++            if (!$this->canBeRun($consumer, $allowedConsumers)) {
+                 continue;
+             }
+ 
+             $arguments = [
+-                $consumerName,
+-                '--pid-file-path=' . $this->getPidFilePath($consumerName),
++                $consumer->getName(),
++                '--single-thread'
+             ];
+ 
+             if ($maxMessages) {
+@@ -119,28 +134,38 @@ class ConsumersRunner
+     /**
+      * Checks that the consumer can be run
+      *
+-     * @param string $consumerName The consumer name
++     * @param ConsumerConfigItemInterface $consumerConfig The consumer config
+      * @param array $allowedConsumers The list of allowed consumers
+      *        If $allowedConsumers is empty it means that all consumers are allowed
+      * @return bool Returns true if the consumer can be run
++     * @throws \Magento\Framework\Exception\FileSystemException
+      */
+-    private function canBeRun($consumerName, array $allowedConsumers = [])
++    private function canBeRun(ConsumerConfigItemInterface $consumerConfig, array $allowedConsumers = []): bool
+     {
+-        $allowed = empty($allowedConsumers) ?: in_array($consumerName, $allowedConsumers);
++        $consumerName = $consumerConfig->getName();
++        if (!empty($allowedConsumers) && !in_array($consumerName, $allowedConsumers)) {
++            return false;
++        }
+ 
+-        return $allowed && !$this->pidConsumerManager->isRun($this->getPidFilePath($consumerName));
+-    }
++        if ($this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
++            return false;
++        }
+ 
+-    /**
+-     * Returns default path to file with PID by consumers name
+-     *
+-     * @param string $consumerName The consumers name
+-     * @return string The path to file with PID
+-     */
+-    private function getPidFilePath($consumerName)
+-    {
+-        $sanitizedHostname = preg_replace('/[^a-z0-9]/i', '', gethostname());
++        $connectionName = $consumerConfig->getConnection();
++        try {
++            $this->mqConnectionTypeResolver->getConnectionType($connectionName);
++        } catch (\LogicException $e) {
++            $this->logger->info(
++                sprintf(
++                    'Consumer "%s" skipped as required connection "%s" is not configured. %s',
++                    $consumerName,
++                    $connectionName,
++                    $e->getMessage()
++                )
++            );
++            return false;
++        }
+ 
+-        return $consumerName . '-' . $sanitizedHostname . static::PID_FILE_EXT;
++        return true;
+     }
+ }
+diff -Nuar a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
+deleted file mode 100644
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
++++ /dev/null
+@@ -1,127 +0,0 @@
+-<?php
+-/**
+- * Copyright © Magento, Inc. All rights reserved.
+- * See COPYING.txt for license details.
+- */
+-namespace Magento\MessageQueue\Model\Cron\ConsumersRunner;
+-
+-use Magento\Framework\App\Filesystem\DirectoryList;
+-use Magento\Framework\Filesystem\Directory\WriteInterface;
+-use Magento\Framework\Filesystem\Directory\ReadInterface;
+-use Magento\Framework\Filesystem;
+-use Magento\Framework\Exception\FileSystemException;
+-
+-/**
+- * The class for checking status of process by PID
+- */
+-class PidConsumerManager
+-{
+-    /**
+-     * Extension of PID file
+-     * @deprecated Moved to the correct responsibility area
+-     * @see \Magento\MessageQueue\Model\Cron\ConsumersRunner::PID_FILE_EXT
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+-    /**
+-     * The class for working with FS
+-     *
+-     * @var Filesystem
+-     */
+-    private $filesystem;
+-
+-    /**
+-     * @param Filesystem $filesystem The class for working with FS
+-     */
+-    public function __construct(Filesystem $filesystem)
+-    {
+-        $this->filesystem = $filesystem;
+-    }
+-
+-    /**
+-     * Checks if consumer process is run by pid from pidFile
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return bool Returns true if consumer process is run
+-     * @throws FileSystemException
+-     */
+-    public function isRun($pidFilePath)
+-    {
+-        $pid = $this->getPid($pidFilePath);
+-        if ($pid) {
+-            if (function_exists('posix_getpgid')) {
+-                return (bool) posix_getpgid($pid);
+-            } else {
+-                return $this->checkIsProcessExists($pid);
+-            }
+-        }
+-
+-        return false;
+-    }
+-
+-    /**
+-     * Checks that process is running
+-     *
+-     * If php function exec is not available throws RuntimeException
+-     * If shell command returns non-zero code and this code is not 1 throws RuntimeException
+-     *
+-     * @param int $pid A pid of process
+-     * @return bool Returns true if consumer process is run
+-     * @throws \RuntimeException
+-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+-     */
+-    private function checkIsProcessExists($pid)
+-    {
+-        if (!function_exists('exec')) {
+-            throw new \RuntimeException('Function exec is not available');
+-        }
+-
+-        exec(escapeshellcmd('ps -p ' . $pid), $output, $code);
+-
+-        $code = (int) $code;
+-
+-        switch ($code) {
+-            case 0:
+-                return true;
+-                break;
+-            case 1:
+-                return false;
+-                break;
+-            default:
+-                throw new \RuntimeException('Exec returned non-zero code', $code);
+-                break;
+-        }
+-    }
+-
+-    /**
+-     * Returns pid by pidFile path
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return int Returns pid if pid file exists for consumer else returns 0
+-     * @throws FileSystemException
+-     */
+-    public function getPid($pidFilePath)
+-    {
+-        /** @var ReadInterface $directory */
+-        $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
+-
+-        if ($directory->isExist($pidFilePath)) {
+-            return (int) $directory->readFile($pidFilePath);
+-        }
+-
+-        return 0;
+-    }
+-
+-    /**
+-     * Saves pid of current process to file
+-     *
+-     * @param string $pidFilePath The path to file with pid
+-     * @throws FileSystemException
+-     */
+-    public function savePid($pidFilePath)
+-    {
+-        /** @var WriteInterface $directory */
+-        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+-        $directory->writeFile($pidFilePath, function_exists('posix_getpid') ? posix_getpid() : getmypid(), 'w');
+-    }
+-}

--- a/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.7.patch
+++ b/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.7.patch
@@ -1,0 +1,548 @@
+diff -Nuar a/vendor/magento/framework/Lock/Backend/Database.php b/vendor/magento/framework/Lock/Backend/Database.php
+--- a/vendor/magento/framework/Lock/Backend/Database.php
++++ b/vendor/magento/framework/Lock/Backend/Database.php
+@@ -3,8 +3,8 @@
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-
+ declare(strict_types=1);
++
+ namespace Magento\Framework\Lock\Backend;
+ 
+ use Magento\Framework\App\DeploymentConfig;
+@@ -14,23 +14,40 @@ use Magento\Framework\Exception\AlreadyExistsException;
+ use Magento\Framework\Exception\InputException;
+ use Magento\Framework\Phrase;
+ 
++/**
++ * Implementation of the lock manager on the basis of MySQL.
++ */
+ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ {
+-    /** @var ResourceConnection */
++    /**
++     * Max time for lock is 1 week
++     *
++     * MariaDB does not support negative timeout value to get infinite timeout,
++     * so we set 1 week for lock timeout
++     */
++    const MAX_LOCK_TIME = 604800;
++
++    /**
++     * @var ResourceConnection
++     */
+     private $resource;
+ 
+-    /** @var DeploymentConfig */
++    /**
++     * @var DeploymentConfig
++     */
+     private $deploymentConfig;
+ 
+-    /** @var string Lock prefix */
++    /**
++     * @var string Lock prefix
++     */
+     private $prefix;
+ 
+-    /** @var string|false Holds current lock name if set, otherwise false */
++    /**
++     * @var string|false Holds current lock name if set, otherwise false
++     */
+     private $currentLock = false;
+ 
+     /**
+-     * Database constructor.
+-     *
+      * @param ResourceConnection $resource
+      * @param DeploymentConfig $deploymentConfig
+      * @param string|null $prefix
+@@ -53,9 +70,13 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @return bool
+      * @throws InputException
+      * @throws AlreadyExistsException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function lock(string $name, int $timeout = -1): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return true;
++        };
+         $name = $this->addPrefix($name);
+ 
+         /**
+@@ -66,7 +87,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+         if ($this->currentLock) {
+             throw new AlreadyExistsException(
+                 new Phrase(
+-                    'Current connection is already holding lock for $1, only single lock allowed',
++                    'Current connection is already holding lock for %1, only single lock allowed',
+                     [$this->currentLock]
+                 )
+             );
+@@ -74,7 +95,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ 
+         $result = (bool)$this->resource->getConnection()->query(
+             "SELECT GET_LOCK(?, ?);",
+-            [(string)$name, (int)$timeout]
++            [$name, $timeout < 0 ? self::MAX_LOCK_TIME : $timeout]
+         )->fetchColumn();
+ 
+         if ($result === true) {
+@@ -90,9 +111,14 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @param string $name lock name
+      * @return bool
+      * @throws InputException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function unlock(string $name): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return true;
++        };
++
+         $name = $this->addPrefix($name);
+ 
+         $result = (bool)$this->resource->getConnection()->query(
+@@ -113,14 +139,19 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @param string $name lock name
+      * @return bool
+      * @throws InputException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function isLocked(string $name): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return false;
++        };
++
+         $name = $this->addPrefix($name);
+ 
+         return (bool)$this->resource->getConnection()->query(
+             "SELECT IS_USED_LOCK(?);",
+-            [(string)$name]
++            [$name]
+         )->fetchColumn();
+     }
+ 
+@@ -130,7 +161,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * Limited to 64 characters in MySQL.
+      *
+      * @param string $name
+-     * @return string $name
++     * @return string
+      * @throws InputException
+      */
+     private function addPrefix(string $name): string
+diff -Nuar a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+--- a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
++++ b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
+ use Symfony\Component\Console\Input\InputOption;
+ use Symfony\Component\Console\Output\OutputInterface;
+ use Magento\Framework\MessageQueue\ConsumerFactory;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+ 
+ /**
+  * Command for starting MessageQueue consumers.
+@@ -22,6 +22,7 @@ class StartConsumerCommand extends Command
+     const OPTION_NUMBER_OF_MESSAGES = 'max-messages';
+     const OPTION_BATCH_SIZE = 'batch-size';
+     const OPTION_AREACODE = 'area-code';
++    const OPTION_SINGLE_THREAD = 'single-thread';
+     const PID_FILE_PATH = 'pid-file-path';
+     const COMMAND_QUEUE_CONSUMERS_START = 'queue:consumers:start';
+ 
+@@ -36,9 +37,9 @@ class StartConsumerCommand extends Command
+     private $appState;
+ 
+     /**
+-     * @var PidConsumerManager
++     * @var LockManagerInterface
+      */
+-    private $pidConsumerManager;
++    private $lockManager;
+ 
+     /**
+      * StartConsumerCommand constructor.
+@@ -47,23 +48,23 @@ class StartConsumerCommand extends Command
+      * @param \Magento\Framework\App\State $appState
+      * @param ConsumerFactory $consumerFactory
+      * @param string $name
+-     * @param PidConsumerManager $pidConsumerManager
++     * @param LockManagerInterface $lockManager
+      */
+     public function __construct(
+         \Magento\Framework\App\State $appState,
+         ConsumerFactory $consumerFactory,
+         $name = null,
+-        PidConsumerManager $pidConsumerManager = null
++        LockManagerInterface $lockManager = null
+     ) {
+         $this->appState = $appState;
+         $this->consumerFactory = $consumerFactory;
+-        $this->pidConsumerManager = $pidConsumerManager ?: \Magento\Framework\App\ObjectManager::getInstance()
+-            ->get(PidConsumerManager::class);
++        $this->lockManager = $lockManager ?: \Magento\Framework\App\ObjectManager::getInstance()
++            ->get(LockManagerInterface::class);
+         parent::__construct($name);
+     }
+ 
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function execute(InputInterface $input, OutputInterface $output)
+     {
+@@ -71,30 +72,36 @@ class StartConsumerCommand extends Command
+         $numberOfMessages = $input->getOption(self::OPTION_NUMBER_OF_MESSAGES);
+         $batchSize = (int)$input->getOption(self::OPTION_BATCH_SIZE);
+         $areaCode = $input->getOption(self::OPTION_AREACODE);
+-        $pidFilePath = $input->getOption(self::PID_FILE_PATH);
+ 
+-        if ($pidFilePath && $this->pidConsumerManager->isRun($pidFilePath)) {
+-            $output->writeln('<error>Consumer with the same PID is running</error>');
+-            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
++        if ($input->getOption(self::PID_FILE_PATH)) {
++            $input->setOption(self::OPTION_SINGLE_THREAD, true);
+         }
+ 
+-        if ($pidFilePath) {
+-            $this->pidConsumerManager->savePid($pidFilePath);
++        $singleThread = $input->getOption(self::OPTION_SINGLE_THREAD);
++
++        if ($singleThread && $this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
++            $output->writeln('<error>Consumer with the same name is running</error>');
++            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+         }
+ 
+-        if ($areaCode !== null) {
+-            $this->appState->setAreaCode($areaCode);
+-        } else {
+-            $this->appState->setAreaCode('global');
++        if ($singleThread) {
++            $this->lockManager->lock(md5($consumerName)); //phpcs:ignore
+         }
+ 
++        $this->appState->setAreaCode($areaCode ?? 'global');
++
+         $consumer = $this->consumerFactory->get($consumerName, $batchSize);
+         $consumer->process($numberOfMessages);
++
++        if ($singleThread) {
++            $this->lockManager->unlock(md5($consumerName)); //phpcs:ignore
++        }
++
+         return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+     }
+ 
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function configure()
+     {
+@@ -125,11 +132,17 @@ class StartConsumerCommand extends Command
+             'The preferred area (global, adminhtml, etc...) '
+             . 'default is global.'
+         );
++        $this->addOption(
++            self::OPTION_SINGLE_THREAD,
++            null,
++            InputOption::VALUE_NONE,
++            'This option prevents running multiple copies of one consumer simultaneously.'
++        );
+         $this->addOption(
+             self::PID_FILE_PATH,
+             null,
+             InputOption::VALUE_REQUIRED,
+-            'The file path for saving PID'
++            'The file path for saving PID (This option is deprecated, use --single-thread instead)'
+         );
+         $this->setHelp(
+             <<<HELP
+@@ -150,8 +163,12 @@ To specify the number of messages per batch for the batch consumer:
+ To specify the preferred area:
+ 
+     <comment>%command.full_name% someConsumer --area-code='adminhtml'</comment>
++
++To do not run multiple copies of one consumer simultaneously:
++
++    <comment>%command.full_name% someConsumer --single-thread'</comment>
+ 
+-To save PID enter path:
++To save PID enter path (This option is deprecated, use --single-thread instead):
+ 
+     <comment>%command.full_name% someConsumer --pid-file-path='/var/someConsumer.pid'</comment>
+ HELP
+diff -Nuar a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
++++ b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+@@ -13,18 +13,13 @@ use Magento\Framework\MessageQueue\Consumer\ConfigInterface as ConsumerConfigInt
+ use Magento\Framework\App\DeploymentConfig;
+ use Psr\Log\LoggerInterface;
+ use Symfony\Component\Process\PhpExecutableFinder;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+ 
+ /**
+  * Class for running consumers processes by cron
+  */
+ class ConsumersRunner
+ {
+-    /**
+-     * Extension of PID file
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+     /**
+      * Shell command line wrapper for executing command in background
+      *
+@@ -53,13 +48,6 @@ class ConsumersRunner
+      */
+     private $phpExecutableFinder;
+ 
+-    /**
+-     * The class for checking status of process by PID
+-     *
+-     * @var PidConsumerManager
+-     */
+-    private $pidConsumerManager;
+-
+     /**
+      * @var ConnectionTypeResolver
+      */
+@@ -70,13 +58,20 @@ class ConsumersRunner
+      */
+     private $logger;
+ 
++    /**
++     * Lock Manager
++     *
++     * @var LockManagerInterface
++     */
++    private $lockManager;
++
+     /**
+      * @param PhpExecutableFinder $phpExecutableFinder The executable finder specifically designed
+      *        for the PHP executable
+      * @param ConsumerConfigInterface $consumerConfig The consumer config provider
+      * @param DeploymentConfig $deploymentConfig The application deployment configuration
+      * @param ShellInterface $shellBackground The shell command line wrapper for executing command in background
+-     * @param PidConsumerManager $pidConsumerManager The class for checking status of process by PID
++     * @param LockManagerInterface $lockManager The lock manager
+      * @param ConnectionTypeResolver $mqConnectionTypeResolver Consumer connection resolver
+      * @param LoggerInterface $logger Logger
+      */
+@@ -85,7 +80,7 @@ class ConsumersRunner
+         ConsumerConfigInterface $consumerConfig,
+         DeploymentConfig $deploymentConfig,
+         ShellInterface $shellBackground,
+-        PidConsumerManager $pidConsumerManager,
++        LockManagerInterface $lockManager,
+         ConnectionTypeResolver $mqConnectionTypeResolver = null,
+         LoggerInterface $logger = null
+     ) {
+@@ -93,7 +88,7 @@ class ConsumersRunner
+         $this->consumerConfig = $consumerConfig;
+         $this->deploymentConfig = $deploymentConfig;
+         $this->shellBackground = $shellBackground;
+-        $this->pidConsumerManager = $pidConsumerManager;
++        $this->lockManager = $lockManager;
+         $this->mqConnectionTypeResolver = $mqConnectionTypeResolver
+             ?: ObjectManager::getInstance()->get(ConnectionTypeResolver::class);
+         $this->logger = $logger
+@@ -120,11 +115,9 @@ class ConsumersRunner
+                 continue;
+             }
+ 
+-            $consumerName = $consumer->getName();
+-
+             $arguments = [
+-                $consumerName,
+-                '--pid-file-path=' . $this->getPidFilePath($consumerName),
++                $consumer->getName(),
++                '--single-thread'
+             ];
+ 
+             if ($maxMessages) {
+@@ -154,7 +147,7 @@ class ConsumersRunner
+             return false;
+         }
+ 
+-        if ($this->pidConsumerManager->isRun($this->getPidFilePath($consumerName))) {
++        if ($this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
+             return false;
+         }
+ 
+@@ -162,28 +155,17 @@ class ConsumersRunner
+         try {
+             $this->mqConnectionTypeResolver->getConnectionType($connectionName);
+         } catch (\LogicException $e) {
+-            $this->logger->info(sprintf(
+-                'Consumer "%s" skipped as required connection "%s" is not configured. %s',
+-                $consumerName,
+-                $connectionName,
+-                $e->getMessage()
+-            ));
++            $this->logger->info(
++                sprintf(
++                    'Consumer "%s" skipped as required connection "%s" is not configured. %s',
++                    $consumerName,
++                    $connectionName,
++                    $e->getMessage()
++                )
++            );
+             return false;
+         }
+ 
+         return true;
+     }
+-
+-    /**
+-     * Returns default path to file with PID by consumers name
+-     *
+-     * @param string $consumerName The consumers name
+-     * @return string The path to file with PID
+-     */
+-    private function getPidFilePath($consumerName)
+-    {
+-        $sanitizedHostname = preg_replace('/[^a-z0-9]/i', '', gethostname());
+-
+-        return $consumerName . '-' . $sanitizedHostname . static::PID_FILE_EXT;
+-    }
+ }
+diff -Nuar a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
+deleted file mode 100644
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
++++ /dev/null
+@@ -1,127 +0,0 @@
+-<?php
+-/**
+- * Copyright © Magento, Inc. All rights reserved.
+- * See COPYING.txt for license details.
+- */
+-namespace Magento\MessageQueue\Model\Cron\ConsumersRunner;
+-
+-use Magento\Framework\App\Filesystem\DirectoryList;
+-use Magento\Framework\Filesystem\Directory\WriteInterface;
+-use Magento\Framework\Filesystem\Directory\ReadInterface;
+-use Magento\Framework\Filesystem;
+-use Magento\Framework\Exception\FileSystemException;
+-
+-/**
+- * The class for checking status of process by PID
+- */
+-class PidConsumerManager
+-{
+-    /**
+-     * Extension of PID file
+-     * @deprecated Moved to the correct responsibility area
+-     * @see \Magento\MessageQueue\Model\Cron\ConsumersRunner::PID_FILE_EXT
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+-    /**
+-     * The class for working with FS
+-     *
+-     * @var Filesystem
+-     */
+-    private $filesystem;
+-
+-    /**
+-     * @param Filesystem $filesystem The class for working with FS
+-     */
+-    public function __construct(Filesystem $filesystem)
+-    {
+-        $this->filesystem = $filesystem;
+-    }
+-
+-    /**
+-     * Checks if consumer process is run by pid from pidFile
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return bool Returns true if consumer process is run
+-     * @throws FileSystemException
+-     */
+-    public function isRun($pidFilePath)
+-    {
+-        $pid = $this->getPid($pidFilePath);
+-        if ($pid) {
+-            if (function_exists('posix_getpgid')) {
+-                return (bool) posix_getpgid($pid);
+-            } else {
+-                return $this->checkIsProcessExists($pid);
+-            }
+-        }
+-
+-        return false;
+-    }
+-
+-    /**
+-     * Checks that process is running
+-     *
+-     * If php function exec is not available throws RuntimeException
+-     * If shell command returns non-zero code and this code is not 1 throws RuntimeException
+-     *
+-     * @param int $pid A pid of process
+-     * @return bool Returns true if consumer process is run
+-     * @throws \RuntimeException
+-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+-     */
+-    private function checkIsProcessExists($pid)
+-    {
+-        if (!function_exists('exec')) {
+-            throw new \RuntimeException('Function exec is not available');
+-        }
+-
+-        exec(escapeshellcmd('ps -p ' . $pid), $output, $code);
+-
+-        $code = (int) $code;
+-
+-        switch ($code) {
+-            case 0:
+-                return true;
+-                break;
+-            case 1:
+-                return false;
+-                break;
+-            default:
+-                throw new \RuntimeException('Exec returned non-zero code', $code);
+-                break;
+-        }
+-    }
+-
+-    /**
+-     * Returns pid by pidFile path
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return int Returns pid if pid file exists for consumer else returns 0
+-     * @throws FileSystemException
+-     */
+-    public function getPid($pidFilePath)
+-    {
+-        /** @var ReadInterface $directory */
+-        $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
+-
+-        if ($directory->isExist($pidFilePath)) {
+-            return (int) $directory->readFile($pidFilePath);
+-        }
+-
+-        return 0;
+-    }
+-
+-    /**
+-     * Saves pid of current process to file
+-     *
+-     * @param string $pidFilePath The path to file with pid
+-     * @throws FileSystemException
+-     */
+-    public function savePid($pidFilePath)
+-    {
+-        /** @var WriteInterface $directory */
+-        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+-        $directory->writeFile($pidFilePath, function_exists('posix_getpid') ? posix_getpid() : getmypid(), 'w');
+-    }
+-}

--- a/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.8.patch
+++ b/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.2.8.patch
@@ -1,0 +1,496 @@
+diff -Nuar a/vendor/magento/framework/Lock/Backend/Database.php b/vendor/magento/framework/Lock/Backend/Database.php
+--- a/vendor/magento/framework/Lock/Backend/Database.php
++++ b/vendor/magento/framework/Lock/Backend/Database.php
+@@ -19,21 +19,35 @@ use Magento\Framework\Phrase;
+  */
+ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ {
+-    /** @var ResourceConnection */
++    /**
++     * Max time for lock is 1 week
++     *
++     * MariaDB does not support negative timeout value to get infinite timeout,
++     * so we set 1 week for lock timeout
++     */
++    const MAX_LOCK_TIME = 604800;
++
++    /**
++     * @var ResourceConnection
++     */
+     private $resource;
+ 
+-    /** @var DeploymentConfig */
++    /**
++     * @var DeploymentConfig
++     */
+     private $deploymentConfig;
+ 
+-    /** @var string Lock prefix */
++    /**
++     * @var string Lock prefix
++     */
+     private $prefix;
+ 
+-    /** @var string|false Holds current lock name if set, otherwise false */
++    /**
++     * @var string|false Holds current lock name if set, otherwise false
++     */
+     private $currentLock = false;
+ 
+     /**
+-     * Database constructor.
+-     *
+      * @param ResourceConnection $resource
+      * @param DeploymentConfig $deploymentConfig
+      * @param string|null $prefix
+@@ -81,7 +95,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ 
+         $result = (bool)$this->resource->getConnection()->query(
+             "SELECT GET_LOCK(?, ?);",
+-            [(string)$name, (int)$timeout]
++            [$name, $timeout < 0 ? self::MAX_LOCK_TIME : $timeout]
+         )->fetchColumn();
+ 
+         if ($result === true) {
+@@ -104,6 +118,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+         if (!$this->deploymentConfig->isDbAvailable()) {
+             return true;
+         };
++
+         $name = $this->addPrefix($name);
+ 
+         $result = (bool)$this->resource->getConnection()->query(
+@@ -131,11 +146,12 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+         if (!$this->deploymentConfig->isDbAvailable()) {
+             return false;
+         };
++
+         $name = $this->addPrefix($name);
+ 
+         return (bool)$this->resource->getConnection()->query(
+             "SELECT IS_USED_LOCK(?);",
+-            [(string)$name]
++            [$name]
+         )->fetchColumn();
+     }
+ 
+@@ -145,7 +161,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * Limited to 64 characters in MySQL.
+      *
+      * @param string $name
+-     * @return string $name
++     * @return string
+      * @throws InputException
+      */
+     private function addPrefix(string $name): string
+diff -Nuar a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+--- a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
++++ b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
+ use Symfony\Component\Console\Input\InputOption;
+ use Symfony\Component\Console\Output\OutputInterface;
+ use Magento\Framework\MessageQueue\ConsumerFactory;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+ 
+ /**
+  * Command for starting MessageQueue consumers.
+@@ -22,6 +22,7 @@ class StartConsumerCommand extends Command
+     const OPTION_NUMBER_OF_MESSAGES = 'max-messages';
+     const OPTION_BATCH_SIZE = 'batch-size';
+     const OPTION_AREACODE = 'area-code';
++    const OPTION_SINGLE_THREAD = 'single-thread';
+     const PID_FILE_PATH = 'pid-file-path';
+     const COMMAND_QUEUE_CONSUMERS_START = 'queue:consumers:start';
+ 
+@@ -36,9 +37,9 @@ class StartConsumerCommand extends Command
+     private $appState;
+ 
+     /**
+-     * @var PidConsumerManager
++     * @var LockManagerInterface
+      */
+-    private $pidConsumerManager;
++    private $lockManager;
+ 
+     /**
+      * StartConsumerCommand constructor.
+@@ -47,23 +48,23 @@ class StartConsumerCommand extends Command
+      * @param \Magento\Framework\App\State $appState
+      * @param ConsumerFactory $consumerFactory
+      * @param string $name
+-     * @param PidConsumerManager $pidConsumerManager
++     * @param LockManagerInterface $lockManager
+      */
+     public function __construct(
+         \Magento\Framework\App\State $appState,
+         ConsumerFactory $consumerFactory,
+         $name = null,
+-        PidConsumerManager $pidConsumerManager = null
++        LockManagerInterface $lockManager = null
+     ) {
+         $this->appState = $appState;
+         $this->consumerFactory = $consumerFactory;
+-        $this->pidConsumerManager = $pidConsumerManager ?: \Magento\Framework\App\ObjectManager::getInstance()
+-            ->get(PidConsumerManager::class);
++        $this->lockManager = $lockManager ?: \Magento\Framework\App\ObjectManager::getInstance()
++            ->get(LockManagerInterface::class);
+         parent::__construct($name);
+     }
+ 
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function execute(InputInterface $input, OutputInterface $output)
+     {
+@@ -71,30 +72,36 @@ class StartConsumerCommand extends Command
+         $numberOfMessages = $input->getOption(self::OPTION_NUMBER_OF_MESSAGES);
+         $batchSize = (int)$input->getOption(self::OPTION_BATCH_SIZE);
+         $areaCode = $input->getOption(self::OPTION_AREACODE);
+-        $pidFilePath = $input->getOption(self::PID_FILE_PATH);
+ 
+-        if ($pidFilePath && $this->pidConsumerManager->isRun($pidFilePath)) {
+-            $output->writeln('<error>Consumer with the same PID is running</error>');
+-            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
++        if ($input->getOption(self::PID_FILE_PATH)) {
++            $input->setOption(self::OPTION_SINGLE_THREAD, true);
+         }
+ 
+-        if ($pidFilePath) {
+-            $this->pidConsumerManager->savePid($pidFilePath);
++        $singleThread = $input->getOption(self::OPTION_SINGLE_THREAD);
++
++        if ($singleThread && $this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
++            $output->writeln('<error>Consumer with the same name is running</error>');
++            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+         }
+ 
+-        if ($areaCode !== null) {
+-            $this->appState->setAreaCode($areaCode);
+-        } else {
+-            $this->appState->setAreaCode('global');
++        if ($singleThread) {
++            $this->lockManager->lock(md5($consumerName)); //phpcs:ignore
+         }
+ 
++        $this->appState->setAreaCode($areaCode ?? 'global');
++
+         $consumer = $this->consumerFactory->get($consumerName, $batchSize);
+         $consumer->process($numberOfMessages);
++
++        if ($singleThread) {
++            $this->lockManager->unlock(md5($consumerName)); //phpcs:ignore
++        }
++
+         return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+     }
+ 
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function configure()
+     {
+@@ -125,11 +132,17 @@ class StartConsumerCommand extends Command
+             'The preferred area (global, adminhtml, etc...) '
+             . 'default is global.'
+         );
++        $this->addOption(
++            self::OPTION_SINGLE_THREAD,
++            null,
++            InputOption::VALUE_NONE,
++            'This option prevents running multiple copies of one consumer simultaneously.'
++        );
+         $this->addOption(
+             self::PID_FILE_PATH,
+             null,
+             InputOption::VALUE_REQUIRED,
+-            'The file path for saving PID'
++            'The file path for saving PID (This option is deprecated, use --single-thread instead)'
+         );
+         $this->setHelp(
+             <<<HELP
+@@ -150,8 +163,12 @@ To specify the number of messages per batch for the batch consumer:
+ To specify the preferred area:
+ 
+     <comment>%command.full_name% someConsumer --area-code='adminhtml'</comment>
++
++To do not run multiple copies of one consumer simultaneously:
++
++    <comment>%command.full_name% someConsumer --single-thread'</comment>
+ 
+-To save PID enter path:
++To save PID enter path (This option is deprecated, use --single-thread instead):
+ 
+     <comment>%command.full_name% someConsumer --pid-file-path='/var/someConsumer.pid'</comment>
+ HELP
+diff -Nuar a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
++++ b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+@@ -13,18 +13,13 @@ use Magento\Framework\MessageQueue\Consumer\ConfigInterface as ConsumerConfigInt
+ use Magento\Framework\App\DeploymentConfig;
+ use Psr\Log\LoggerInterface;
+ use Symfony\Component\Process\PhpExecutableFinder;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+ 
+ /**
+  * Class for running consumers processes by cron
+  */
+ class ConsumersRunner
+ {
+-    /**
+-     * Extension of PID file
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+     /**
+      * Shell command line wrapper for executing command in background
+      *
+@@ -53,13 +48,6 @@ class ConsumersRunner
+      */
+     private $phpExecutableFinder;
+ 
+-    /**
+-     * The class for checking status of process by PID
+-     *
+-     * @var PidConsumerManager
+-     */
+-    private $pidConsumerManager;
+-
+     /**
+      * @var ConnectionTypeResolver
+      */
+@@ -70,13 +58,20 @@ class ConsumersRunner
+      */
+     private $logger;
+ 
++    /**
++     * Lock Manager
++     *
++     * @var LockManagerInterface
++     */
++    private $lockManager;
++
+     /**
+      * @param PhpExecutableFinder $phpExecutableFinder The executable finder specifically designed
+      *        for the PHP executable
+      * @param ConsumerConfigInterface $consumerConfig The consumer config provider
+      * @param DeploymentConfig $deploymentConfig The application deployment configuration
+      * @param ShellInterface $shellBackground The shell command line wrapper for executing command in background
+-     * @param PidConsumerManager $pidConsumerManager The class for checking status of process by PID
++     * @param LockManagerInterface $lockManager The lock manager
+      * @param ConnectionTypeResolver $mqConnectionTypeResolver Consumer connection resolver
+      * @param LoggerInterface $logger Logger
+      */
+@@ -85,7 +80,7 @@ class ConsumersRunner
+         ConsumerConfigInterface $consumerConfig,
+         DeploymentConfig $deploymentConfig,
+         ShellInterface $shellBackground,
+-        PidConsumerManager $pidConsumerManager,
++        LockManagerInterface $lockManager,
+         ConnectionTypeResolver $mqConnectionTypeResolver = null,
+         LoggerInterface $logger = null
+     ) {
+@@ -93,7 +88,7 @@ class ConsumersRunner
+         $this->consumerConfig = $consumerConfig;
+         $this->deploymentConfig = $deploymentConfig;
+         $this->shellBackground = $shellBackground;
+-        $this->pidConsumerManager = $pidConsumerManager;
++        $this->lockManager = $lockManager;
+         $this->mqConnectionTypeResolver = $mqConnectionTypeResolver
+             ?: ObjectManager::getInstance()->get(ConnectionTypeResolver::class);
+         $this->logger = $logger
+@@ -120,11 +115,9 @@ class ConsumersRunner
+                 continue;
+             }
+ 
+-            $consumerName = $consumer->getName();
+-
+             $arguments = [
+-                $consumerName,
+-                '--pid-file-path=' . $this->getPidFilePath($consumerName),
++                $consumer->getName(),
++                '--single-thread'
+             ];
+ 
+             if ($maxMessages) {
+@@ -154,7 +147,7 @@ class ConsumersRunner
+             return false;
+         }
+ 
+-        if ($this->pidConsumerManager->isRun($this->getPidFilePath($consumerName))) {
++        if ($this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
+             return false;
+         }
+ 
+@@ -162,28 +155,17 @@ class ConsumersRunner
+         try {
+             $this->mqConnectionTypeResolver->getConnectionType($connectionName);
+         } catch (\LogicException $e) {
+-            $this->logger->info(sprintf(
+-                'Consumer "%s" skipped as required connection "%s" is not configured. %s',
+-                $consumerName,
+-                $connectionName,
+-                $e->getMessage()
+-            ));
++            $this->logger->info(
++                sprintf(
++                    'Consumer "%s" skipped as required connection "%s" is not configured. %s',
++                    $consumerName,
++                    $connectionName,
++                    $e->getMessage()
++                )
++            );
+             return false;
+         }
+ 
+         return true;
+     }
+-
+-    /**
+-     * Returns default path to file with PID by consumers name
+-     *
+-     * @param string $consumerName The consumers name
+-     * @return string The path to file with PID
+-     */
+-    private function getPidFilePath($consumerName)
+-    {
+-        $sanitizedHostname = preg_replace('/[^a-z0-9]/i', '', gethostname());
+-
+-        return $consumerName . '-' . $sanitizedHostname . static::PID_FILE_EXT;
+-    }
+ }
+diff -Nuar a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
+deleted file mode 100644
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
++++ /dev/null
+@@ -1,127 +0,0 @@
+-<?php
+-/**
+- * Copyright © Magento, Inc. All rights reserved.
+- * See COPYING.txt for license details.
+- */
+-namespace Magento\MessageQueue\Model\Cron\ConsumersRunner;
+-
+-use Magento\Framework\App\Filesystem\DirectoryList;
+-use Magento\Framework\Filesystem\Directory\WriteInterface;
+-use Magento\Framework\Filesystem\Directory\ReadInterface;
+-use Magento\Framework\Filesystem;
+-use Magento\Framework\Exception\FileSystemException;
+-
+-/**
+- * The class for checking status of process by PID
+- */
+-class PidConsumerManager
+-{
+-    /**
+-     * Extension of PID file
+-     * @deprecated Moved to the correct responsibility area
+-     * @see \Magento\MessageQueue\Model\Cron\ConsumersRunner::PID_FILE_EXT
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+-    /**
+-     * The class for working with FS
+-     *
+-     * @var Filesystem
+-     */
+-    private $filesystem;
+-
+-    /**
+-     * @param Filesystem $filesystem The class for working with FS
+-     */
+-    public function __construct(Filesystem $filesystem)
+-    {
+-        $this->filesystem = $filesystem;
+-    }
+-
+-    /**
+-     * Checks if consumer process is run by pid from pidFile
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return bool Returns true if consumer process is run
+-     * @throws FileSystemException
+-     */
+-    public function isRun($pidFilePath)
+-    {
+-        $pid = $this->getPid($pidFilePath);
+-        if ($pid) {
+-            if (function_exists('posix_getpgid')) {
+-                return (bool) posix_getpgid($pid);
+-            } else {
+-                return $this->checkIsProcessExists($pid);
+-            }
+-        }
+-
+-        return false;
+-    }
+-
+-    /**
+-     * Checks that process is running
+-     *
+-     * If php function exec is not available throws RuntimeException
+-     * If shell command returns non-zero code and this code is not 1 throws RuntimeException
+-     *
+-     * @param int $pid A pid of process
+-     * @return bool Returns true if consumer process is run
+-     * @throws \RuntimeException
+-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+-     */
+-    private function checkIsProcessExists($pid)
+-    {
+-        if (!function_exists('exec')) {
+-            throw new \RuntimeException('Function exec is not available');
+-        }
+-
+-        exec(escapeshellcmd('ps -p ' . $pid), $output, $code);
+-
+-        $code = (int) $code;
+-
+-        switch ($code) {
+-            case 0:
+-                return true;
+-                break;
+-            case 1:
+-                return false;
+-                break;
+-            default:
+-                throw new \RuntimeException('Exec returned non-zero code', $code);
+-                break;
+-        }
+-    }
+-
+-    /**
+-     * Returns pid by pidFile path
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return int Returns pid if pid file exists for consumer else returns 0
+-     * @throws FileSystemException
+-     */
+-    public function getPid($pidFilePath)
+-    {
+-        /** @var ReadInterface $directory */
+-        $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
+-
+-        if ($directory->isExist($pidFilePath)) {
+-            return (int) $directory->readFile($pidFilePath);
+-        }
+-
+-        return 0;
+-    }
+-
+-    /**
+-     * Saves pid of current process to file
+-     *
+-     * @param string $pidFilePath The path to file with pid
+-     * @throws FileSystemException
+-     */
+-    public function savePid($pidFilePath)
+-    {
+-        /** @var WriteInterface $directory */
+-        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+-        $directory->writeFile($pidFilePath, function_exists('posix_getpid') ? posix_getpid() : getmypid(), 'w');
+-    }
+-}

--- a/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.0.patch
+++ b/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.0.patch
@@ -1,0 +1,511 @@
+diff -Nuar a/vendor/magento/framework/Lock/Backend/Database.php b/vendor/magento/framework/Lock/Backend/Database.php
+--- a/vendor/magento/framework/Lock/Backend/Database.php
++++ b/vendor/magento/framework/Lock/Backend/Database.php
+@@ -15,10 +15,18 @@ use Magento\Framework\Exception\InputException;
+ use Magento\Framework\Phrase;
+
+ /**
+- * LockManager using the DB locks
++ * Implementation of the lock manager on the basis of MySQL.
+  */
+ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ {
++    /**
++     * Max time for lock is 1 week
++     *
++     * MariaDB does not support negative timeout value to get infinite timeout,
++     * so we set 1 week for lock timeout
++     */
++    private const MAX_LOCK_TIME = 604800;
++
+     /**
+      * @var ResourceConnection
+      */
+@@ -62,9 +70,13 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @return bool
+      * @throws InputException
+      * @throws AlreadyExistsException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function lock(string $name, int $timeout = -1): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return true;
++        };
+         $name = $this->addPrefix($name);
+
+         /**
+@@ -75,7 +87,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+         if ($this->currentLock) {
+             throw new AlreadyExistsException(
+                 new Phrase(
+-                    'Current connection is already holding lock for $1, only single lock allowed',
++                    'Current connection is already holding lock for %1, only single lock allowed',
+                     [$this->currentLock]
+                 )
+             );
+@@ -83,7 +95,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+
+         $result = (bool)$this->resource->getConnection()->query(
+             "SELECT GET_LOCK(?, ?);",
+-            [(string)$name, (int)$timeout]
++            [$name, $timeout < 0 ? self::MAX_LOCK_TIME : $timeout]
+         )->fetchColumn();
+
+         if ($result === true) {
+@@ -99,9 +111,14 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @param string $name lock name
+      * @return bool
+      * @throws InputException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function unlock(string $name): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return true;
++        };
++
+         $name = $this->addPrefix($name);
+
+         $result = (bool)$this->resource->getConnection()->query(
+@@ -122,14 +139,19 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @param string $name lock name
+      * @return bool
+      * @throws InputException
++     * @throws \Zend_Db_Statement_Exception
+      */
+     public function isLocked(string $name): bool
+     {
++        if (!$this->deploymentConfig->isDbAvailable()) {
++            return false;
++        };
++
+         $name = $this->addPrefix($name);
+
+         return (bool)$this->resource->getConnection()->query(
+             "SELECT IS_USED_LOCK(?);",
+-            [(string)$name]
++            [$name]
+         )->fetchColumn();
+     }
+
+@@ -139,7 +161,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * Limited to 64 characters in MySQL.
+      *
+      * @param string $name
+-     * @return string $name
++     * @return string
+      * @throws InputException
+      */
+     private function addPrefix(string $name): string
+diff -Nuar a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+--- a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
++++ b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
+ use Symfony\Component\Console\Input\InputOption;
+ use Symfony\Component\Console\Output\OutputInterface;
+ use Magento\Framework\MessageQueue\ConsumerFactory;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+
+ /**
+  * Command for starting MessageQueue consumers.
+@@ -22,6 +22,7 @@ class StartConsumerCommand extends Command
+     const OPTION_NUMBER_OF_MESSAGES = 'max-messages';
+     const OPTION_BATCH_SIZE = 'batch-size';
+     const OPTION_AREACODE = 'area-code';
++    const OPTION_SINGLE_THREAD = 'single-thread';
+     const PID_FILE_PATH = 'pid-file-path';
+     const COMMAND_QUEUE_CONSUMERS_START = 'queue:consumers:start';
+
+@@ -36,9 +37,9 @@ class StartConsumerCommand extends Command
+     private $appState;
+ 
+     /**
+-     * @var PidConsumerManager
++     * @var LockManagerInterface
+      */
+-    private $pidConsumerManager;
++    private $lockManager;
+
+     /**
+      * StartConsumerCommand constructor.
+@@ -47,23 +48,23 @@ class StartConsumerCommand extends Command
+      * @param \Magento\Framework\App\State $appState
+      * @param ConsumerFactory $consumerFactory
+      * @param string $name
+-     * @param PidConsumerManager $pidConsumerManager
++     * @param LockManagerInterface $lockManager
+      */
+     public function __construct(
+         \Magento\Framework\App\State $appState,
+         ConsumerFactory $consumerFactory,
+         $name = null,
+-        PidConsumerManager $pidConsumerManager = null
++        LockManagerInterface $lockManager = null
+     ) {
+         $this->appState = $appState;
+         $this->consumerFactory = $consumerFactory;
+-        $this->pidConsumerManager = $pidConsumerManager ?: \Magento\Framework\App\ObjectManager::getInstance()
+-            ->get(PidConsumerManager::class);
++        $this->lockManager = $lockManager ?: \Magento\Framework\App\ObjectManager::getInstance()
++            ->get(LockManagerInterface::class);
+         parent::__construct($name);
+     }
+
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function execute(InputInterface $input, OutputInterface $output)
+     {
+@@ -71,30 +72,36 @@ class StartConsumerCommand extends Command
+         $numberOfMessages = $input->getOption(self::OPTION_NUMBER_OF_MESSAGES);
+         $batchSize = (int)$input->getOption(self::OPTION_BATCH_SIZE);
+         $areaCode = $input->getOption(self::OPTION_AREACODE);
+-        $pidFilePath = $input->getOption(self::PID_FILE_PATH);
+ 
+-        if ($pidFilePath && $this->pidConsumerManager->isRun($pidFilePath)) {
+-            $output->writeln('<error>Consumer with the same PID is running</error>');
+-            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
++        if ($input->getOption(self::PID_FILE_PATH)) {
++            $input->setOption(self::OPTION_SINGLE_THREAD, true);
+         }
+
+-        if ($pidFilePath) {
+-            $this->pidConsumerManager->savePid($pidFilePath);
++        $singleThread = $input->getOption(self::OPTION_SINGLE_THREAD);
++
++        if ($singleThread && $this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
++            $output->writeln('<error>Consumer with the same name is running</error>');
++            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+         }
+ 
+-        if ($areaCode !== null) {
+-            $this->appState->setAreaCode($areaCode);
+-        } else {
+-            $this->appState->setAreaCode('global');
++        if ($singleThread) {
++            $this->lockManager->lock(md5($consumerName)); //phpcs:ignore
+         }
+
++        $this->appState->setAreaCode($areaCode ?? 'global');
++
+         $consumer = $this->consumerFactory->get($consumerName, $batchSize);
+         $consumer->process($numberOfMessages);
++
++        if ($singleThread) {
++            $this->lockManager->unlock(md5($consumerName)); //phpcs:ignore
++        }
++
+         return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+     }
+
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function configure()
+     {
+@@ -125,11 +132,17 @@ class StartConsumerCommand extends Command
+             'The preferred area (global, adminhtml, etc...) '
+             . 'default is global.'
+         );
++        $this->addOption(
++            self::OPTION_SINGLE_THREAD,
++            null,
++            InputOption::VALUE_NONE,
++            'This option prevents running multiple copies of one consumer simultaneously.'
++        );
+         $this->addOption(
+             self::PID_FILE_PATH,
+             null,
+             InputOption::VALUE_REQUIRED,
+-            'The file path for saving PID'
++            'The file path for saving PID (This option is deprecated, use --single-thread instead)'
+         );
+         $this->setHelp(
+             <<<HELP
+@@ -150,8 +163,12 @@ To specify the number of messages per batch for the batch consumer:
+ To specify the preferred area:
+ 
+     <comment>%command.full_name% someConsumer --area-code='adminhtml'</comment>
++
++To do not run multiple copies of one consumer simultaneously:
++
++    <comment>%command.full_name% someConsumer --single-thread'</comment>
+ 
+-To save PID enter path:
++To save PID enter path (This option is deprecated, use --single-thread instead):
+ 
+     <comment>%command.full_name% someConsumer --pid-file-path='/var/someConsumer.pid'</comment>
+ HELP
+diff -Nuar a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
++++ b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+@@ -13,18 +13,13 @@ use Magento\Framework\MessageQueue\Consumer\ConfigInterface as ConsumerConfigInt
+ use Magento\Framework\App\DeploymentConfig;
+ use Psr\Log\LoggerInterface;
+ use Symfony\Component\Process\PhpExecutableFinder;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+ 
+ /**
+  * Class for running consumers processes by cron
+  */
+ class ConsumersRunner
+ {
+-    /**
+-     * Extension of PID file
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+     /**
+      * Shell command line wrapper for executing command in background
+      *
+@@ -53,13 +48,6 @@ class ConsumersRunner
+      */
+     private $phpExecutableFinder;
+ 
+-    /**
+-     * The class for checking status of process by PID
+-     *
+-     * @var PidConsumerManager
+-     */
+-    private $pidConsumerManager;
+-
+     /**
+      * @var ConnectionTypeResolver
+      */
+@@ -70,13 +58,20 @@ class ConsumersRunner
+      */
+     private $logger;
+ 
++    /**
++     * Lock Manager
++     *
++     * @var LockManagerInterface
++     */
++    private $lockManager;
++
+     /**
+      * @param PhpExecutableFinder $phpExecutableFinder The executable finder specifically designed
+      *        for the PHP executable
+      * @param ConsumerConfigInterface $consumerConfig The consumer config provider
+      * @param DeploymentConfig $deploymentConfig The application deployment configuration
+      * @param ShellInterface $shellBackground The shell command line wrapper for executing command in background
+-     * @param PidConsumerManager $pidConsumerManager The class for checking status of process by PID
++     * @param LockManagerInterface $lockManager The lock manager
+      * @param ConnectionTypeResolver $mqConnectionTypeResolver Consumer connection resolver
+      * @param LoggerInterface $logger Logger
+      */
+@@ -85,7 +80,7 @@ class ConsumersRunner
+         ConsumerConfigInterface $consumerConfig,
+         DeploymentConfig $deploymentConfig,
+         ShellInterface $shellBackground,
+-        PidConsumerManager $pidConsumerManager,
++        LockManagerInterface $lockManager,
+         ConnectionTypeResolver $mqConnectionTypeResolver = null,
+         LoggerInterface $logger = null
+     ) {
+@@ -93,7 +88,7 @@ class ConsumersRunner
+         $this->consumerConfig = $consumerConfig;
+         $this->deploymentConfig = $deploymentConfig;
+         $this->shellBackground = $shellBackground;
+-        $this->pidConsumerManager = $pidConsumerManager;
++        $this->lockManager = $lockManager;
+         $this->mqConnectionTypeResolver = $mqConnectionTypeResolver
+             ?: ObjectManager::getInstance()->get(ConnectionTypeResolver::class);
+         $this->logger = $logger
+@@ -120,11 +115,9 @@ class ConsumersRunner
+                 continue;
+             }
+
+-            $consumerName = $consumer->getName();
+-
+             $arguments = [
+-                $consumerName,
+-                '--pid-file-path=' . $this->getPidFilePath($consumerName),
++                $consumer->getName(),
++                '--single-thread'
+             ];
+ 
+             if ($maxMessages) {
+@@ -154,7 +147,7 @@ class ConsumersRunner
+             return false;
+         }
+ 
+-        if ($this->pidConsumerManager->isRun($this->getPidFilePath($consumerName))) {
++        if ($this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
+             return false;
+         }
+ 
+@@ -162,28 +155,17 @@ class ConsumersRunner
+         try {
+             $this->mqConnectionTypeResolver->getConnectionType($connectionName);
+         } catch (\LogicException $e) {
+-            $this->logger->info(sprintf(
+-                'Consumer "%s" skipped as required connection "%s" is not configured. %s',
+-                $consumerName,
+-                $connectionName,
+-                $e->getMessage()
+-            ));
++            $this->logger->info(
++                sprintf(
++                    'Consumer "%s" skipped as required connection "%s" is not configured. %s',
++                    $consumerName,
++                    $connectionName,
++                    $e->getMessage()
++                )
++            );
+             return false;
+         }
+ 
+         return true;
+     }
+-
+-    /**
+-     * Returns default path to file with PID by consumers name
+-     *
+-     * @param string $consumerName The consumers name
+-     * @return string The path to file with PID
+-     */
+-    private function getPidFilePath($consumerName)
+-    {
+-        $sanitizedHostname = preg_replace('/[^a-z0-9]/i', '', gethostname());
+-
+-        return $consumerName . '-' . $sanitizedHostname . static::PID_FILE_EXT;
+-    }
+ }
+diff --git a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
+deleted file mode 100644
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
++++ /dev/null
+@@ -1,127 +0,0 @@
+-<?php
+-/**
+- * Copyright © Magento, Inc. All rights reserved.
+- * See COPYING.txt for license details.
+- */
+-namespace Magento\MessageQueue\Model\Cron\ConsumersRunner;
+-
+-use Magento\Framework\App\Filesystem\DirectoryList;
+-use Magento\Framework\Filesystem\Directory\WriteInterface;
+-use Magento\Framework\Filesystem\Directory\ReadInterface;
+-use Magento\Framework\Filesystem;
+-use Magento\Framework\Exception\FileSystemException;
+-
+-/**
+- * The class for checking status of process by PID
+- */
+-class PidConsumerManager
+-{
+-    /**
+-     * Extension of PID file
+-     * @deprecated Moved to the correct responsibility area
+-     * @see \Magento\MessageQueue\Model\Cron\ConsumersRunner::PID_FILE_EXT
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+-    /**
+-     * The class for working with FS
+-     *
+-     * @var Filesystem
+-     */
+-    private $filesystem;
+-
+-    /**
+-     * @param Filesystem $filesystem The class for working with FS
+-     */
+-    public function __construct(Filesystem $filesystem)
+-    {
+-        $this->filesystem = $filesystem;
+-    }
+-
+-    /**
+-     * Checks if consumer process is run by pid from pidFile
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return bool Returns true if consumer process is run
+-     * @throws FileSystemException
+-     */
+-    public function isRun($pidFilePath)
+-    {
+-        $pid = $this->getPid($pidFilePath);
+-        if ($pid) {
+-            if (function_exists('posix_getpgid')) {
+-                return (bool) posix_getpgid($pid);
+-            } else {
+-                return $this->checkIsProcessExists($pid);
+-            }
+-        }
+-
+-        return false;
+-    }
+-
+-    /**
+-     * Checks that process is running
+-     *
+-     * If php function exec is not available throws RuntimeException
+-     * If shell command returns non-zero code and this code is not 1 throws RuntimeException
+-     *
+-     * @param int $pid A pid of process
+-     * @return bool Returns true if consumer process is run
+-     * @throws \RuntimeException
+-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+-     */
+-    private function checkIsProcessExists($pid)
+-    {
+-        if (!function_exists('exec')) {
+-            throw new \RuntimeException('Function exec is not available');
+-        }
+-
+-        exec(escapeshellcmd('ps -p ' . $pid), $output, $code);
+-
+-        $code = (int) $code;
+-
+-        switch ($code) {
+-            case 0:
+-                return true;
+-                break;
+-            case 1:
+-                return false;
+-                break;
+-            default:
+-                throw new \RuntimeException('Exec returned non-zero code', $code);
+-                break;
+-        }
+-    }
+-
+-    /**
+-     * Returns pid by pidFile path
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return int Returns pid if pid file exists for consumer else returns 0
+-     * @throws FileSystemException
+-     */
+-    public function getPid($pidFilePath)
+-    {
+-        /** @var ReadInterface $directory */
+-        $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
+-
+-        if ($directory->isExist($pidFilePath)) {
+-            return (int) $directory->readFile($pidFilePath);
+-        }
+-
+-        return 0;
+-    }
+-
+-    /**
+-     * Saves pid of current process to file
+-     *
+-     * @param string $pidFilePath The path to file with pid
+-     * @throws FileSystemException
+-     */
+-    public function savePid($pidFilePath)
+-    {
+-        /** @var WriteInterface $directory */
+-        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+-        $directory->writeFile($pidFilePath, function_exists('posix_getpid') ? posix_getpid() : getmypid(), 'w');
+-    }
+-}

--- a/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.1.patch
+++ b/patches/MAGECLOUD-3913__fix_problems_with_consumer_runners_on_cloud_clusters__2.3.1.patch
@@ -1,0 +1,447 @@
+diff -Nuar a/vendor/magento/framework/Lock/Backend/Database.php b/vendor/magento/framework/Lock/Backend/Database.php
+--- a/vendor/magento/framework/Lock/Backend/Database.php
++++ b/vendor/magento/framework/Lock/Backend/Database.php
+@@ -19,6 +19,14 @@ use Magento\Framework\Phrase;
+  */
+ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ {
++    /**
++     * Max time for lock is 1 week
++     *
++     * MariaDB does not support negative timeout value to get infinite timeout,
++     * so we set 1 week for lock timeout
++     */
++    private const MAX_LOCK_TIME = 604800;
++
+     /**
+      * @var ResourceConnection
+      */
+@@ -87,7 +95,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ 
+         $result = (bool)$this->resource->getConnection()->query(
+             "SELECT GET_LOCK(?, ?);",
+-            [(string)$name, (int)$timeout]
++            [$name, $timeout < 0 ? self::MAX_LOCK_TIME : $timeout]
+         )->fetchColumn();
+ 
+         if ($result === true) {
+@@ -143,7 +151,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+ 
+         return (bool)$this->resource->getConnection()->query(
+             "SELECT IS_USED_LOCK(?);",
+-            [(string)$name]
++            [$name]
+         )->fetchColumn();
+     }
+ 
+diff -Nuar a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+--- a/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
++++ b/vendor/magento/module-message-queue/Console/StartConsumerCommand.php
+@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
+ use Symfony\Component\Console\Input\InputOption;
+ use Symfony\Component\Console\Output\OutputInterface;
+ use Magento\Framework\MessageQueue\ConsumerFactory;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+
+ /**
+  * Command for starting MessageQueue consumers.
+@@ -22,6 +22,7 @@ class StartConsumerCommand extends Command
+     const OPTION_NUMBER_OF_MESSAGES = 'max-messages';
+     const OPTION_BATCH_SIZE = 'batch-size';
+     const OPTION_AREACODE = 'area-code';
++    const OPTION_SINGLE_THREAD = 'single-thread';
+     const PID_FILE_PATH = 'pid-file-path';
+     const COMMAND_QUEUE_CONSUMERS_START = 'queue:consumers:start';
+
+@@ -36,9 +37,9 @@ class StartConsumerCommand extends Command
+     private $appState;
+
+     /**
+-     * @var PidConsumerManager
++     * @var LockManagerInterface
+      */
+-    private $pidConsumerManager;
++    private $lockManager;
+
+     /**
+      * StartConsumerCommand constructor.
+@@ -47,23 +48,23 @@ class StartConsumerCommand extends Command
+      * @param \Magento\Framework\App\State $appState
+      * @param ConsumerFactory $consumerFactory
+      * @param string $name
+-     * @param PidConsumerManager $pidConsumerManager
++     * @param LockManagerInterface $lockManager
+      */
+     public function __construct(
+         \Magento\Framework\App\State $appState,
+         ConsumerFactory $consumerFactory,
+         $name = null,
+-        PidConsumerManager $pidConsumerManager = null
++        LockManagerInterface $lockManager = null
+     ) {
+         $this->appState = $appState;
+         $this->consumerFactory = $consumerFactory;
+-        $this->pidConsumerManager = $pidConsumerManager ?: \Magento\Framework\App\ObjectManager::getInstance()
+-            ->get(PidConsumerManager::class);
++        $this->lockManager = $lockManager ?: \Magento\Framework\App\ObjectManager::getInstance()
++            ->get(LockManagerInterface::class);
+         parent::__construct($name);
+     }
+
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function execute(InputInterface $input, OutputInterface $output)
+     {
+@@ -71,30 +72,36 @@ class StartConsumerCommand extends Command
+         $numberOfMessages = $input->getOption(self::OPTION_NUMBER_OF_MESSAGES);
+         $batchSize = (int)$input->getOption(self::OPTION_BATCH_SIZE);
+         $areaCode = $input->getOption(self::OPTION_AREACODE);
+-        $pidFilePath = $input->getOption(self::PID_FILE_PATH);
+
+-        if ($pidFilePath && $this->pidConsumerManager->isRun($pidFilePath)) {
+-            $output->writeln('<error>Consumer with the same PID is running</error>');
+-            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
++        if ($input->getOption(self::PID_FILE_PATH)) {
++            $input->setOption(self::OPTION_SINGLE_THREAD, true);
+         }
+
+-        if ($pidFilePath) {
+-            $this->pidConsumerManager->savePid($pidFilePath);
++        $singleThread = $input->getOption(self::OPTION_SINGLE_THREAD);
++
++        if ($singleThread && $this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
++            $output->writeln('<error>Consumer with the same name is running</error>');
++            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+         }
+
+-        if ($areaCode !== null) {
+-            $this->appState->setAreaCode($areaCode);
+-        } else {
+-            $this->appState->setAreaCode('global');
++        if ($singleThread) {
++            $this->lockManager->lock(md5($consumerName)); //phpcs:ignore
+         }
+
++        $this->appState->setAreaCode($areaCode ?? 'global');
++
+         $consumer = $this->consumerFactory->get($consumerName, $batchSize);
+         $consumer->process($numberOfMessages);
++
++        if ($singleThread) {
++            $this->lockManager->unlock(md5($consumerName)); //phpcs:ignore
++        }
++
+         return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+     }
+
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     protected function configure()
+     {
+@@ -125,11 +132,17 @@ class StartConsumerCommand extends Command
+             'The preferred area (global, adminhtml, etc...) '
+             . 'default is global.'
+         );
++        $this->addOption(
++            self::OPTION_SINGLE_THREAD,
++            null,
++            InputOption::VALUE_NONE,
++            'This option prevents running multiple copies of one consumer simultaneously.'
++        );
+         $this->addOption(
+             self::PID_FILE_PATH,
+             null,
+             InputOption::VALUE_REQUIRED,
+-            'The file path for saving PID'
++            'The file path for saving PID (This option is deprecated, use --single-thread instead)'
+         );
+         $this->setHelp(
+             <<<HELP
+@@ -150,8 +163,12 @@ To specify the number of messages per batch for the batch consumer:
+ To specify the preferred area:
+
+     <comment>%command.full_name% someConsumer --area-code='adminhtml'</comment>
++
++To do not run multiple copies of one consumer simultaneously:
++
++    <comment>%command.full_name% someConsumer --single-thread'</comment>
+
+-To save PID enter path:
++To save PID enter path (This option is deprecated, use --single-thread instead):
+
+     <comment>%command.full_name% someConsumer --pid-file-path='/var/someConsumer.pid'</comment>
+ HELP
+diff -Nuar a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
++++ b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner.php
+@@ -13,18 +13,13 @@ use Magento\Framework\MessageQueue\Consumer\ConfigInterface as ConsumerConfigInt
+ use Magento\Framework\App\DeploymentConfig;
+ use Psr\Log\LoggerInterface;
+ use Symfony\Component\Process\PhpExecutableFinder;
+-use Magento\MessageQueue\Model\Cron\ConsumersRunner\PidConsumerManager;
++use Magento\Framework\Lock\LockManagerInterface;
+
+ /**
+  * Class for running consumers processes by cron
+  */
+ class ConsumersRunner
+ {
+-    /**
+-     * Extension of PID file
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+     /**
+      * Shell command line wrapper for executing command in background
+      *
+@@ -53,13 +48,6 @@ class ConsumersRunner
+      */
+     private $phpExecutableFinder;
+
+-    /**
+-     * The class for checking status of process by PID
+-     *
+-     * @var PidConsumerManager
+-     */
+-    private $pidConsumerManager;
+-
+     /**
+      * @var ConnectionTypeResolver
+      */
+@@ -70,13 +58,20 @@ class ConsumersRunner
+      */
+     private $logger;
+
++    /**
++     * Lock Manager
++     *
++     * @var LockManagerInterface
++     */
++    private $lockManager;
++
+     /**
+      * @param PhpExecutableFinder $phpExecutableFinder The executable finder specifically designed
+      *        for the PHP executable
+      * @param ConsumerConfigInterface $consumerConfig The consumer config provider
+      * @param DeploymentConfig $deploymentConfig The application deployment configuration
+      * @param ShellInterface $shellBackground The shell command line wrapper for executing command in background
+-     * @param PidConsumerManager $pidConsumerManager The class for checking status of process by PID
++     * @param LockManagerInterface $lockManager The lock manager
+      * @param ConnectionTypeResolver $mqConnectionTypeResolver Consumer connection resolver
+      * @param LoggerInterface $logger Logger
+      */
+@@ -85,7 +80,7 @@ class ConsumersRunner
+         ConsumerConfigInterface $consumerConfig,
+         DeploymentConfig $deploymentConfig,
+         ShellInterface $shellBackground,
+-        PidConsumerManager $pidConsumerManager,
++        LockManagerInterface $lockManager,
+         ConnectionTypeResolver $mqConnectionTypeResolver = null,
+         LoggerInterface $logger = null
+     ) {
+@@ -93,7 +88,7 @@ class ConsumersRunner
+         $this->consumerConfig = $consumerConfig;
+         $this->deploymentConfig = $deploymentConfig;
+         $this->shellBackground = $shellBackground;
+-        $this->pidConsumerManager = $pidConsumerManager;
++        $this->lockManager = $lockManager;
+         $this->mqConnectionTypeResolver = $mqConnectionTypeResolver
+             ?: ObjectManager::getInstance()->get(ConnectionTypeResolver::class);
+         $this->logger = $logger
+@@ -120,11 +115,9 @@ class ConsumersRunner
+                 continue;
+             }
+
+-            $consumerName = $consumer->getName();
+-
+             $arguments = [
+-                $consumerName,
+-                '--pid-file-path=' . $this->getPidFilePath($consumerName),
++                $consumer->getName(),
++                '--single-thread'
+             ];
+
+             if ($maxMessages) {
+@@ -154,7 +147,7 @@ class ConsumersRunner
+             return false;
+         }
+
+-        if ($this->pidConsumerManager->isRun($this->getPidFilePath($consumerName))) {
++        if ($this->lockManager->isLocked(md5($consumerName))) { //phpcs:ignore
+             return false;
+         }
+
+@@ -162,28 +155,17 @@ class ConsumersRunner
+         try {
+             $this->mqConnectionTypeResolver->getConnectionType($connectionName);
+         } catch (\LogicException $e) {
+-            $this->logger->info(sprintf(
+-                'Consumer "%s" skipped as required connection "%s" is not configured. %s',
+-                $consumerName,
+-                $connectionName,
+-                $e->getMessage()
+-            ));
++            $this->logger->info(
++                sprintf(
++                    'Consumer "%s" skipped as required connection "%s" is not configured. %s',
++                    $consumerName,
++                    $connectionName,
++                    $e->getMessage()
++                )
++            );
+             return false;
+         }
+
+         return true;
+     }
+-
+-    /**
+-     * Returns default path to file with PID by consumers name
+-     *
+-     * @param string $consumerName The consumers name
+-     * @return string The path to file with PID
+-     */
+-    private function getPidFilePath($consumerName)
+-    {
+-        $sanitizedHostname = preg_replace('/[^a-z0-9]/i', '', gethostname());
+-
+-        return $consumerName . '-' . $sanitizedHostname . static::PID_FILE_EXT;
+-    }
+ }
+diff --git a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php b/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
+deleted file mode 100644
+--- a/vendor/magento/module-message-queue/Model/Cron/ConsumersRunner/PidConsumerManager.php
++++ /dev/null
+@@ -1,127 +0,0 @@
+-<?php
+-/**
+- * Copyright © Magento, Inc. All rights reserved.
+- * See COPYING.txt for license details.
+- */
+-namespace Magento\MessageQueue\Model\Cron\ConsumersRunner;
+-
+-use Magento\Framework\App\Filesystem\DirectoryList;
+-use Magento\Framework\Filesystem\Directory\WriteInterface;
+-use Magento\Framework\Filesystem\Directory\ReadInterface;
+-use Magento\Framework\Filesystem;
+-use Magento\Framework\Exception\FileSystemException;
+-
+-/**
+- * The class for checking status of process by PID
+- */
+-class PidConsumerManager
+-{
+-    /**
+-     * Extension of PID file
+-     * @deprecated Moved to the correct responsibility area
+-     * @see \Magento\MessageQueue\Model\Cron\ConsumersRunner::PID_FILE_EXT
+-     */
+-    const PID_FILE_EXT = '.pid';
+-
+-    /**
+-     * The class for working with FS
+-     *
+-     * @var Filesystem
+-     */
+-    private $filesystem;
+-
+-    /**
+-     * @param Filesystem $filesystem The class for working with FS
+-     */
+-    public function __construct(Filesystem $filesystem)
+-    {
+-        $this->filesystem = $filesystem;
+-    }
+-
+-    /**
+-     * Checks if consumer process is run by pid from pidFile
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return bool Returns true if consumer process is run
+-     * @throws FileSystemException
+-     */
+-    public function isRun($pidFilePath)
+-    {
+-        $pid = $this->getPid($pidFilePath);
+-        if ($pid) {
+-            if (function_exists('posix_getpgid')) {
+-                return (bool) posix_getpgid($pid);
+-            } else {
+-                return $this->checkIsProcessExists($pid);
+-            }
+-        }
+-
+-        return false;
+-    }
+-
+-    /**
+-     * Checks that process is running
+-     *
+-     * If php function exec is not available throws RuntimeException
+-     * If shell command returns non-zero code and this code is not 1 throws RuntimeException
+-     *
+-     * @param int $pid A pid of process
+-     * @return bool Returns true if consumer process is run
+-     * @throws \RuntimeException
+-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+-     */
+-    private function checkIsProcessExists($pid)
+-    {
+-        if (!function_exists('exec')) {
+-            throw new \RuntimeException('Function exec is not available');
+-        }
+-
+-        exec(escapeshellcmd('ps -p ' . $pid), $output, $code);
+-
+-        $code = (int) $code;
+-
+-        switch ($code) {
+-            case 0:
+-                return true;
+-                break;
+-            case 1:
+-                return false;
+-                break;
+-            default:
+-                throw new \RuntimeException('Exec returned non-zero code', $code);
+-                break;
+-        }
+-    }
+-
+-    /**
+-     * Returns pid by pidFile path
+-     *
+-     * @param string $pidFilePath The path to file with PID
+-     * @return int Returns pid if pid file exists for consumer else returns 0
+-     * @throws FileSystemException
+-     */
+-    public function getPid($pidFilePath)
+-    {
+-        /** @var ReadInterface $directory */
+-        $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
+-
+-        if ($directory->isExist($pidFilePath)) {
+-            return (int) $directory->readFile($pidFilePath);
+-        }
+-
+-        return 0;
+-    }
+-
+-    /**
+-     * Saves pid of current process to file
+-     *
+-     * @param string $pidFilePath The path to file with pid
+-     * @throws FileSystemException
+-     */
+-    public function savePid($pidFilePath)
+-    {
+-        /** @var WriteInterface $directory */
+-        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+-        $directory->writeFile($pidFilePath, function_exists('posix_getpid') ? posix_getpid() : getmypid(), 'w');
+-    }
+-}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->
Now CronConsumerRunner uses locks instead of pid files.

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-3913

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGECLOUD-136

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
