### PR TITLE
MAGECLOUD-4284: Command "docker cp" sets wrong file owner and permissions

### DIFF
--- a/src/Test/Functional/Acceptance/AcceptanceCest.php
+++ b/src/Test/Functional/Acceptance/AcceptanceCest.php
@@ -261,12 +261,10 @@ class AcceptanceCest extends AbstractCest
 
     /**
      * @param \CliTester $I
-     * @param \Codeception\Scenario $scenario
      * @throws \Robo\Exception\TaskException
      */
-    public function testDeployInBuild(\CliTester $I, \Codeception\Scenario $scenario)
+    public function testDeployInBuild(\CliTester $I)
     {
-        $scenario->skip('Test skipped... See MAGECLOUD-4284');
         $tmpConfig = sys_get_temp_dir() . '/app/etc/config.php';
         $I->startEnvironment();
         $I->assertTrue($I->runEceToolsCommand('build', Docker::BUILD_CONTAINER));

--- a/tests/functional/Robo/Tasks/CopyToDocker.php
+++ b/tests/functional/Robo/Tasks/CopyToDocker.php
@@ -79,11 +79,15 @@ class CopyToDocker extends BaseTask implements CommandInterface
      */
     public function getCommand(): string
     {
-        return sprintf(
-            'docker cp %s "$(docker-compose ps -q %s)":%s',
-            $this->source,
-            $this->container,
-            $this->destination
+        $command = 'docker cp [source] "$(docker-compose ps -q [container])":[destination]'
+            . ' && docker-compose run -uroot [container] bash -c "chown -R www:www [destination]"';
+        return strtr(
+            $command,
+            [
+                '[source]' => $this->source,
+                '[container]' => $this->container,
+                '[destination]' => $this->destination
+            ]
         );
     }
 


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-4284

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
This PR does not require manual testing because it contains the FT fix.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
