### PR TITLE
MAGECLOUD-4474: ECE-Tools is showing wrong ES configuration on multiple config entities

### DIFF
--- a/src/Service/ElasticSearch.php
+++ b/src/Service/ElasticSearch.php
@@ -123,7 +123,7 @@ class ElasticSearch implements ServiceInterface
 
         try {
             $templates = $this->call(sprintf(
-                '%s:%s/_template',
+                '%s:%s/_template/platformsh_index_settings',
                 $config['host'],
                 $config['port']
             ));

--- a/src/Test/Unit/Service/ElasticSearchTest.php
+++ b/src/Test/Unit/Service/ElasticSearchTest.php
@@ -206,7 +206,7 @@ class ElasticSearchTest extends TestCase
         );
         $clientMock->expects($this->once())
             ->method('get')
-            ->with('127.0.0.1:1234/_template')
+            ->with('127.0.0.1:1234/_template/platformsh_index_settings')
             ->willReturn($responseMock);
         $responseMock->expects($this->once())
             ->method('getBody')
@@ -255,16 +255,11 @@ class ElasticSearchTest extends TestCase
                 ]
             );
         $clientMock = $this->createPartialMock(Client::class, ['get']);
-        $responseMock = $this->createMock(Response::class);
 
         $clientMock->expects($this->once())
             ->method('get')
-            ->with('127.0.0.1:1234/_template')
+            ->with('127.0.0.1:1234/_template/platformsh_index_settings')
             ->willThrowException(new \Exception('Some error'));
-        $clientMock->expects($this->once())
-            ->method('get')
-            ->with('127.0.0.1:1234/_template')
-            ->willReturn($responseMock);
         $this->clientFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($clientMock);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Changed curl query in ECE-Tools to retrieve ES config from http://localhost:9200/_template/platformsh_index_settings
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-4474

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
https://jira.corp.magento.com/browse/MAGECLOUD-110

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
