### PR TITLE
MAGECLOUD-4355: ELASTICSUITE_CONFIGURATION is Missing _merge Parameter Syntax in .magento.env.yaml.dist

### DIFF
--- a/dist/.magento.env.yaml
+++ b/dist/.magento.env.yaml
@@ -255,6 +255,7 @@
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #
 #              QUEUE_CONFIGURATION:                                                                                   #
+#                _merge: false # if true configuration merging with default                                           #
 #                amqp:                                                                                                #
 #                  host: test.host                                                                                    #
 #                  port: 1234                                                                                         #
@@ -277,6 +278,7 @@
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #
 #              SEARCH_CONFIGURATION:                                                                                  #
+#                _merge: false # if true configuration merging with default                                           #
 #                engine: elasticsearch                                                                                #
 #                elasticsearch_server_hostname: hostname                                                              #
 #                elasticsearch_server_port: '123456'                                                                  #
@@ -301,6 +303,7 @@
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #
 #              ELASTICSUITE_CONFIGURATION:                                                                            #
+#                  _merge: false # if true configuration merging with default                                         #
 #                  es_client:                                                                                         #
 #                    servers: 'remote-host:9200'                                                                      #
 #                  indices_settings:                                                                                  #
@@ -359,6 +362,7 @@
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #
 #              CACHE_CONFIGURATION:                                                                                   #
+#                _merge: false # if true configuration merging with default                                           #
 #                frontend:                                                                                            #
 #                  default:                                                                                           #
 #                    backend: file                                                                                    #
@@ -390,6 +394,7 @@
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #
 #              SESSION_CONFIGURATION:                                                                                 #
+#                _merge: false # if true configuration merging with default                                           #
 #                redis:                                                                                               #
 #                  bot_first_lifetime: 100                                                                            #
 #                  bot_lifetime: 10001                                                                                #
@@ -453,7 +458,7 @@
 #          stage:                                                                                                     #
 #            deploy:                                                                                                  #
 #              RESOURCE_CONFIGURATION:                                                                                #
-#                _merge: false                                                                                        #
+#                _merge: false  # if true configuration merging with default                                          #
 #                default_setup:                                                                                       #
 #                  connection: default                                                                                #
 #######################################################################################################################


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Updated description for `_merge` options in the `.magento.env.yaml` file.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-4355


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
