### PR TITLE
MAGECLOUD-4849:  Not full error log on failed execution of shell command

### DIFF
--- a/src/Shell/Process.php
+++ b/src/Shell/Process.php
@@ -38,7 +38,7 @@ class Process extends \Symfony\Component\Process\Process implements ProcessInter
             $error = sprintf(
                 'The command "%s" failed. %s',
                 $process->getCommandLine(),
-                trim($process->getErrorOutput(), "\n")
+                trim($process->getErrorOutput() ?: $process->getOutput(), "\n")
             );
 
             throw new ProcessException($error, $process->getExitCode());

--- a/src/Step/PostDeploy/TimeToFirstByte.php
+++ b/src/Step/PostDeploy/TimeToFirstByte.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\MagentoCloud\Step\PostDeploy;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\RequestOptions;
 use Magento\MagentoCloud\Config\Stage\PostDeployInterface;
 use Magento\MagentoCloud\Http\PoolFactory;
@@ -82,7 +83,9 @@ class TimeToFirstByte implements StepInterface
                 'concurrency' => 1,
             ]);
 
-            $pool->promise()->wait();
+            /** @var PromiseInterface $promise */
+            $promise = $pool->promise();
+            $promise->wait();
         } catch (\Throwable $exception) {
             throw new StepException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/src/Step/PostDeploy/WarmUp.php
+++ b/src/Step/PostDeploy/WarmUp.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\MagentoCloud\Step\PostDeploy;
 
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\PromiseInterface;
 use Magento\MagentoCloud\Http\PoolFactory;
 use Magento\MagentoCloud\WarmUp\Urls;
 use Magento\MagentoCloud\Step\StepException;
@@ -85,7 +86,9 @@ class WarmUp implements StepInterface
         try {
             $pool = $this->poolFactory->create($urls, compact('fulfilled', 'rejected'));
 
-            $pool->promise()->wait();
+            /** @var PromiseInterface $promise */
+            $promise = $pool->promise();
+            $promise->wait();
         } catch (\Throwable $exception) {
             throw new StepException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/src/Test/Functional/Acceptance/ErrorMessageCest.php
+++ b/src/Test/Functional/Acceptance/ErrorMessageCest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Test\Functional\Acceptance;
+
+use CliTester;
+use Magento\MagentoCloud\Test\Functional\Codeception\Docker;
+
+/**
+ * This test runs on the latest version of PHP
+ */
+class ErrorMessageCest extends AbstractCest
+{
+    /**
+     * @param CliTester $I
+     * @throws \Robo\Exception\TaskException
+     */
+    public function _before(CliTester $I)
+    {
+        parent::_before($I);
+        $I->cloneTemplate();
+        $I->addEceComposerRepo();
+    }
+
+    /**
+     * @param CliTester $I
+     * @throws \Robo\Exception\TaskException
+     */
+    public function testShellErrorMessage(CliTester $I)
+    {
+        $I->cleanDirectories(['/bin/*']);
+        $I->assertFalse($I->runEceToolsCommand('build', Docker::BUILD_CONTAINER));
+        $I->seeInOutput('Could not open input file: ./bin/magento');
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If some Shell command writes error output into `stdout` instead of `stderr` `ece-tools` don't write that error into a log as it expected to be in `stderr`.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-4849

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Emulate missing `bin/magento` file. Update .magento.app.yaml
```
build: |
        set -e
        rm ./bin/magento
        ....
```
2. push changes
3. Log must contain `Could not open input file: ./bin/magento`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
