### PR TITLE
MAGECLOUD-4982: De-composed magento-cloud-patches fail to apply locally

### DIFF
--- a/dist/front-static.php.dist
+++ b/dist/front-static.php.dist
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Entry point for static resources (JS, CSS, etc.)
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+$_GET['resource'] = preg_replace('/^(\/static\/)(version(\d+)?\/)?|(\?.*)/', '', $_SERVER['REQUEST_URI'] ?: '');
+require realpath(__DIR__) . '/../app/bootstrap.php';
+$bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
+/** @var \Magento\Framework\App\StaticResource $app */
+$app = $bootstrap->createApplication(\Magento\Framework\App\StaticResource::class);
+$bootstrap->run($app);

--- a/src/Filesystem/FileList.php
+++ b/src/Filesystem/FileList.php
@@ -119,8 +119,16 @@ class FileList extends ConfigFileList
      *
      * @return string
      */
-    public function getServiceEolsConfig() : string
+    public function getServiceEolsConfig(): string
     {
         return $this->directoryList->getRoot() . '/config/eol.yaml';
+    }
+
+    /**
+     * @return string
+     */
+    public function getFrontStaticDist(): string
+    {
+        return $this->directoryList->getRoot() . '/dist/front-static.php.dist';
     }
 }

--- a/src/Step/Build/CopyPubStatic.php
+++ b/src/Step/Build/CopyPubStatic.php
@@ -54,16 +54,14 @@ class CopyPubStatic implements StepInterface
     {
         $magentoRoot = $this->directoryList->getMagentoRoot();
 
-        if (!$this->file->isExists($magentoRoot . '/pub/static.php')) {
-            $this->logger->notice('File "static.php" was not found');
-
-            return;
+        if (!$this->file->isExists($magentoRoot . '/pub/front-static.php')) {
+            $this->file->deleteFile($magentoRoot . '/pub/front-static.php');
         }
 
         $this->file->copy(
-            $magentoRoot . '/pub/static.php',
+            $magentoRoot . '/dist/front-static.php.dist',
             $magentoRoot . '/pub/front-static.php'
         );
-        $this->logger->info('File "static.php" was copied');
+        $this->logger->info('File "front-static.php" was copied');
     }
 }

--- a/src/Step/Build/CopyPubStatic.php
+++ b/src/Step/Build/CopyPubStatic.php
@@ -63,10 +63,6 @@ class CopyPubStatic implements StepInterface
     {
         $magentoRoot = $this->directoryList->getMagentoRoot();
 
-        if ($this->file->isExists($magentoRoot . '/pub/front-static.php')) {
-            $this->file->deleteFile($magentoRoot . '/pub/front-static.php');
-        }
-
         $this->file->copy(
             $this->fileList->getFrontStaticDist(),
             $magentoRoot . '/pub/front-static.php'

--- a/src/Step/Build/CopyPubStatic.php
+++ b/src/Step/Build/CopyPubStatic.php
@@ -9,6 +9,7 @@ namespace Magento\MagentoCloud\Step\Build;
 
 use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Step\StepInterface;
 use Psr\Log\LoggerInterface;
 
@@ -33,18 +34,26 @@ class CopyPubStatic implements StepInterface
     private $directoryList;
 
     /**
+     * @var FileList
+     */
+    private $fileList;
+
+    /**
      * @param LoggerInterface $logger
      * @param File $file
      * @param DirectoryList $directoryList
+     * @param FileList $fileList
      */
     public function __construct(
         LoggerInterface $logger,
         File $file,
-        DirectoryList $directoryList
+        DirectoryList $directoryList,
+        FileList $fileList
     ) {
         $this->logger = $logger;
         $this->file = $file;
         $this->directoryList = $directoryList;
+        $this->fileList = $fileList;
     }
 
     /**
@@ -54,12 +63,12 @@ class CopyPubStatic implements StepInterface
     {
         $magentoRoot = $this->directoryList->getMagentoRoot();
 
-        if (!$this->file->isExists($magentoRoot . '/pub/front-static.php')) {
+        if ($this->file->isExists($magentoRoot . '/pub/front-static.php')) {
             $this->file->deleteFile($magentoRoot . '/pub/front-static.php');
         }
 
         $this->file->copy(
-            $magentoRoot . '/dist/front-static.php.dist',
+            $this->fileList->getFrontStaticDist(),
             $magentoRoot . '/pub/front-static.php'
         );
         $this->logger->info('File "front-static.php" was copied');

--- a/src/Test/Unit/Step/Build/CopyPubStaticTest.php
+++ b/src/Test/Unit/Step/Build/CopyPubStaticTest.php
@@ -76,13 +76,6 @@ class CopyPubStaticTest extends TestCase
         $this->directoryListMock->expects($this->once())
             ->method('getMagentoRoot')
             ->willReturn('magento_root');
-        $this->fileMock->expects($this->once())
-            ->method('isExists')
-            ->with('magento_root/pub/front-static.php')
-            ->willReturn(true);
-        $this->fileMock->expects($this->once())
-            ->method('deleteFile')
-            ->with('magento_root/pub/front-static.php');
         $this->fileListMock->expects($this->once())
             ->method('getFrontStaticDist')
             ->willReturn($frontStaticDistPath);
@@ -107,12 +100,6 @@ class CopyPubStaticTest extends TestCase
         $this->directoryListMock->expects($this->once())
             ->method('getMagentoRoot')
             ->willReturn('magento_root');
-        $this->fileMock->expects($this->once())
-            ->method('isExists')
-            ->with('magento_root/pub/front-static.php')
-            ->willReturn(false);
-        $this->fileMock->expects($this->never())
-            ->method('deleteFile');
         $this->fileListMock->expects($this->once())
             ->method('getFrontStaticDist')
             ->willReturn($frontStaticDistPath);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Magento-Cloud-Patches fails to run when missing cloud specific files.  Moved file generation to ece-tools
see PR: https://github.com/magento/magento-cloud-patches/pull/15
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. MAGECLOUD-4982

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Deploy to cloud, confirm pub/front-static.php is there and correct
2. Run ece-tools patch locally, confirm works
3. Run ece-patch apply locally, confrim works
4. Confirm SCD on demand continues to work on Cloud (reference MAGECLOUD-1601)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
