### PR TITLE
MAGECLOUD-4979: Cleanup Composer Dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
     "nesbot/carbon": "^1.0||^2.0",
     "psr/container": "^1.0",
     "psr/log": "^1.0",
-    "symfony/config": "^3.4||^4.3",
+    "symfony/config": "^2.8||^3.4||^4.3",
     "symfony/console": "^2.3||^4.0",
-    "symfony/dependency-injection": "^3.4||^4.3",
+    "symfony/dependency-injection": "^2.8||^3.4||^4.3",
     "symfony/process": "^2.1||^4.1",
-    "symfony/serializer": "^3.3",
-    "symfony/yaml": "^3.3||^4.0"
+    "symfony/serializer": "^2.8||^3.3",
+    "symfony/yaml": "^2.8||^3.3||^4.0"
   },
   "require-dev": {
     "codeception/codeception": "^2.5.3",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "psr/log": "^1.0",
     "symfony/config": "^4.4",
     "symfony/console": "^2.8||^4.0",
-    "symfony/dependency-injection": "^2.8||^4.3",
+    "symfony/dependency-injection": "^3.3||^4.3",
     "symfony/process": "^2.1||^4.1",
     "symfony/serializer": "^2.8||^3.3",
     "symfony/yaml": "^3.3||^4.0"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "composer/semver": "^1.4",
     "graylog2/gelf-php": "^1.4.2",
     "guzzlehttp/guzzle": "^6.2",
-    "illuminate/config": "^5.6",
+    "illuminate/config": "^5.5",
     "magento/magento-cloud-components": "^1.0.1",
     "magento/magento-cloud-docker": "^1.0.0",
     "magento/magento-cloud-patches": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
     "nesbot/carbon": "^1.0||^2.0",
     "psr/container": "^1.0",
     "psr/log": "^1.0",
-    "symfony/config": "^2.8||^3.4||^4.3",
-    "symfony/console": "^2.3||^4.0",
-    "symfony/dependency-injection": "^2.8||^3.4||^4.3",
+    "symfony/config": "^4.4",
+    "symfony/console": "^2.8||^4.0",
+    "symfony/dependency-injection": "^2.8||^4.3",
     "symfony/process": "^2.1||^4.1",
     "symfony/serializer": "^2.8||^3.3",
-    "symfony/yaml": "^2.8||^3.3||^4.0"
+    "symfony/yaml": "^3.3||^4.0"
   },
   "require-dev": {
     "codeception/codeception": "^2.5.3",

--- a/config/services.xml
+++ b/config/services.xml
@@ -3,11 +3,6 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="error_level_warning">300</parameter>
-        <parameter key="error_level_notice">250</parameter>
-    </parameters>
-
     <services>
         <defaults autowire="true" autoconfigure="true" public="true" />
         <!-- ... -->
@@ -68,10 +63,14 @@
         <service id="Magento\MagentoCloud\Step\ValidateConfiguration" autowire="false" />
         <service id="Psr\Log\LoggerInterface" alias="Magento\MagentoCloud\App\Logger" />
         <service id="ServiceEol.Warnings" class="Magento\MagentoCloud\Config\Validator\Deploy\ServiceEol">
-            <argument key="$errorLevel">%error_level_warning</argument>
+            <argument key="$errorLevel" type="constant">
+                Magento\MagentoCloud\Config\ValidatorInterface::LEVEL_WARNING
+            </argument>
         </service>
         <service id="ServiceEol.Notices" class="Magento\MagentoCloud\Config\Validator\Deploy\ServiceEol">
-            <argument key="$errorLevel">%error_level_notice</argument>
+            <argument key="$errorLevel" type="constant">
+                Magento\MagentoCloud\Config\ValidatorInterface::LEVEL_NOTICE
+            </argument>
         </service>
         <service id="Symfony\Component\Serializer\Encoder\XmlEncoder"/>
     </services>

--- a/config/services.xml
+++ b/config/services.xml
@@ -3,11 +3,15 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="error_level_warning">300</parameter>
+        <parameter key="error_level_notice">250</parameter>
+    </parameters>
+
     <services>
-        <defaults autowire="true" autoconfigure="true" public="true">
-            <bind key="int $errorLevel">300</bind>
-        </defaults>
+        <defaults autowire="true" autoconfigure="true" public="true" />
         <!-- ... -->
+
         <prototype namespace="Magento\MagentoCloud\" resource="../src/*" exclude="../src/{Test}"/>
 
         <service id="Composer\Package\Version\VersionParser" autowire="false" />
@@ -38,6 +42,7 @@
         <service id="Magento\MagentoCloud\Service\ServiceMismatchException" autowire="false" />
         <service id="Magento\MagentoCloud\Shell\Process" autowire="false" />
         <service id="Magento\MagentoCloud\Shell\ProcessException" autowire="false" />
+        <service id="Magento\MagentoCloud\Config\Validator\Deploy\ServiceEol" autowire="false" />
         <service id="Magento\MagentoCloud\Filesystem\Flag\Pool">
             <argument type="collection">
                 <argument key="regenerate">var/.regenerate</argument>
@@ -45,9 +50,11 @@
                 <argument key="deploy_is_failed">var/.deploy_is_failed</argument>
             </argument>
         </service>
-        <service id="ServiceEol.Warnings" class="Magento\MagentoCloud\Config\Validator\Deploy\ServiceEol" />
+        <service id="ServiceEol.Warnings" class="Magento\MagentoCloud\Config\Validator\Deploy\ServiceEol">
+            <argument key="$errorLevel">%error_level_warning</argument>
+        </service>
         <service id="ServiceEol.Notices" class="Magento\MagentoCloud\Config\Validator\Deploy\ServiceEol">
-            <bind key="int $errorLevel">250</bind>
+            <argument key="$errorLevel">%error_level_notice</argument>
         </service>
         <service id="Composer\Package\Version\VersionParser"/>
         <service id="Composer\Semver\VersionParser"/>

--- a/config/services.xml
+++ b/config/services.xml
@@ -15,21 +15,49 @@
         <prototype namespace="Magento\MagentoCloud\" resource="../src/*" exclude="../src/{Test}"/>
 
         <service id="Composer\Package\Version\VersionParser" autowire="false" />
-        <service id="Magento\MagentoCloud\Filesystem\SystemList" autowire="false" />
-        <service id="Magento\MagentoCloud\Step\Build\DeployStaticContent" autowire="false" />
+        <service id="Composer\Semver\Comparator"/>
+        <service id="Composer\Semver\Semver"/>
+        <service id="Composer\Semver\VersionParser"/>
+        <service id="Illuminate\Config\Repository"/>
         <service id="Magento\MagentoCloud\App\Container" autowire="false" />
+        <service id="Magento\MagentoCloud\App\ContainerInterface" alias="container" />
         <service id="Magento\MagentoCloud\App\GenericException" autowire="false" />
         <service id="Magento\MagentoCloud\App\Logger\Gelf\Handler" autowire="false" />
-        <service id="Magento\MagentoCloud\App\Container" autowire="false" />
+        <service id="Magento\MagentoCloud\Config\AdminDataInterface" alias="Magento\MagentoCloud\Config\AdminData" />
+        <service id="Magento\MagentoCloud\Config\EnvironmentDataInterface" alias="Magento\MagentoCloud\Config\EnvironmentData" />
+        <service id="Magento\MagentoCloud\Config\Environment\ReaderInterface" alias="Magento\MagentoCloud\Config\Environment\Reader" />
+        <service id="Magento\MagentoCloud\Config\Magento\Env\ReaderInterface" alias="Magento\MagentoCloud\Config\Magento\Env\Reader" />
+        <service id="Magento\MagentoCloud\Config\Magento\Env\WriterInterface" alias="Magento\MagentoCloud\Config\Magento\Env\Writer" />
+        <service id="Magento\MagentoCloud\Config\Magento\Shared\ReaderInterface" alias="Magento\MagentoCloud\Config\Magento\Shared\Reader" />
+        <service id="Magento\MagentoCloud\Config\Magento\Shared\WriterInterface" alias="Magento\MagentoCloud\Config\Magento\Shared\Writer" />
+        <service id="Magento\MagentoCloud\Config\Stage\BuildInterface" alias="Magento\MagentoCloud\Config\Stage\Build" />
+        <service id="Magento\MagentoCloud\Config\Stage\DeployInterface" alias="Magento\MagentoCloud\Config\Stage\Deploy" />
+        <service id="Magento\MagentoCloud\Config\Stage\PostDeployInterface" alias="Magento\MagentoCloud\Config\Stage\PostDeploy" />
+        <service id="Magento\MagentoCloud\Config\Validator\Deploy\ServiceEol" autowire="false" />
         <service id="Magento\MagentoCloud\Config\Validator\Result\Error" autowire="false" />
         <service id="Magento\MagentoCloud\DB\Data\Connection" autowire="false" />
         <service id="Magento\MagentoCloud\DB\Data\RelationshipConnection" autowire="false" />
         <service id="Magento\MagentoCloud\DB\PDOException" autowire="false" />
+        <service id="Magento\MagentoCloud\Filesystem\FileSystemException" autowire="false" />
         <service id="Magento\MagentoCloud\Filesystem\Flag\ConfigurationMismatchException" autowire="false" />
+        <service id="Magento\MagentoCloud\Filesystem\Flag\Pool">
+            <argument type="collection">
+                <argument key="regenerate">var/.regenerate</argument>
+                <argument key="scd_in_build">.static_content_deploy</argument>
+                <argument key="deploy_is_failed">var/.deploy_is_failed</argument>
+            </argument>
+        </service>
+        <service id="Magento\MagentoCloud\Filesystem\SystemList" autowire="false" />
+        <service id="Magento\MagentoCloud\Package\UndefinedPackageException" autowire="false" />
+        <service id="Magento\MagentoCloud\PlatformVariable\DecoderInterface" alias="Magento\MagentoCloud\PlatformVariable\Decoder" />
         <service id="Magento\MagentoCloud\Scenario\Exception\ProcessorException" autowire="false" />
         <service id="Magento\MagentoCloud\Scenario\Exception\ValidationException" autowire="false" />
-        <service id="Magento\MagentoCloud\Filesystem\FileSystemException" autowire="false" />
-        <service id="Magento\MagentoCloud\Package\UndefinedPackageException" autowire="false" />
+        <service id="Magento\MagentoCloud\Service\ServiceMismatchException" autowire="false" />
+        <service id="Magento\MagentoCloud\Shell\Process" autowire="false" />
+        <service id="Magento\MagentoCloud\Shell\ProcessException" autowire="false" />
+        <service id="Magento\MagentoCloud\Shell\ShellInterface" alias="Magento\MagentoCloud\Shell\Shell" />
+        <service id="Magento\MagentoCloud\Step\Build\BackupData" autowire="false" />
+        <service id="Magento\MagentoCloud\Step\Build\DeployStaticContent" autowire="false" />
         <service id="Magento\MagentoCloud\Step\Deploy\DeployCompletion" autowire="false" />
         <service id="Magento\MagentoCloud\Step\Deploy\DeployStaticContent" autowire="false" />
         <service id="Magento\MagentoCloud\Step\Deploy\InstallUpdate" autowire="false" />
@@ -38,43 +66,13 @@
         <service id="Magento\MagentoCloud\Step\SkipStep" autowire="false" />
         <service id="Magento\MagentoCloud\Step\StepException" autowire="false" />
         <service id="Magento\MagentoCloud\Step\ValidateConfiguration" autowire="false" />
-        <service id="Magento\MagentoCloud\Step\Build\BackupData" autowire="false" />
-        <service id="Magento\MagentoCloud\Service\ServiceMismatchException" autowire="false" />
-        <service id="Magento\MagentoCloud\Shell\Process" autowire="false" />
-        <service id="Magento\MagentoCloud\Shell\ProcessException" autowire="false" />
-        <service id="Magento\MagentoCloud\Config\Validator\Deploy\ServiceEol" autowire="false" />
-        <service id="Magento\MagentoCloud\Filesystem\Flag\Pool">
-            <argument type="collection">
-                <argument key="regenerate">var/.regenerate</argument>
-                <argument key="scd_in_build">.static_content_deploy</argument>
-                <argument key="deploy_is_failed">var/.deploy_is_failed</argument>
-            </argument>
-        </service>
+        <service id="Psr\Log\LoggerInterface" alias="Magento\MagentoCloud\App\Logger" />
         <service id="ServiceEol.Warnings" class="Magento\MagentoCloud\Config\Validator\Deploy\ServiceEol">
             <argument key="$errorLevel">%error_level_warning</argument>
         </service>
         <service id="ServiceEol.Notices" class="Magento\MagentoCloud\Config\Validator\Deploy\ServiceEol">
             <argument key="$errorLevel">%error_level_notice</argument>
         </service>
-        <service id="Composer\Package\Version\VersionParser"/>
-        <service id="Composer\Semver\VersionParser"/>
-        <service id="Composer\Semver\Semver"/>
-        <service id="Composer\Semver\Comparator"/>
-        <service id="Illuminate\Config\Repository"/>
         <service id="Symfony\Component\Serializer\Encoder\XmlEncoder"/>
-        <service id="Psr\Log\LoggerInterface" alias="Magento\MagentoCloud\App\Logger" />
-        <service id="Magento\MagentoCloud\App\ContainerInterface" alias="container" />
-        <service id="Magento\MagentoCloud\Shell\ShellInterface" alias="Magento\MagentoCloud\Shell\Shell" />
-        <service id="Magento\MagentoCloud\Config\Stage\DeployInterface" alias="Magento\MagentoCloud\Config\Stage\Deploy" />
-        <service id="Magento\MagentoCloud\Config\Stage\BuildInterface" alias="Magento\MagentoCloud\Config\Stage\Build" />
-        <service id="Magento\MagentoCloud\Config\Stage\PostDeployInterface" alias="Magento\MagentoCloud\Config\Stage\PostDeploy" />
-        <service id="Magento\MagentoCloud\Config\EnvironmentDataInterface" alias="Magento\MagentoCloud\Config\EnvironmentData" />
-        <service id="Magento\MagentoCloud\Config\AdminDataInterface" alias="Magento\MagentoCloud\Config\AdminData" />
-        <service id="Magento\MagentoCloud\PlatformVariable\DecoderInterface" alias="Magento\MagentoCloud\PlatformVariable\Decoder" />
-        <service id="Magento\MagentoCloud\Config\Environment\ReaderInterface" alias="Magento\MagentoCloud\Config\Environment\Reader" />
-        <service id="Magento\MagentoCloud\Config\Magento\Env\ReaderInterface" alias="Magento\MagentoCloud\Config\Magento\Env\Reader" />
-        <service id="Magento\MagentoCloud\Config\Magento\Env\WriterInterface" alias="Magento\MagentoCloud\Config\Magento\Env\Writer" />
-        <service id="Magento\MagentoCloud\Config\Magento\Shared\ReaderInterface" alias="Magento\MagentoCloud\Config\Magento\Shared\Reader" />
-        <service id="Magento\MagentoCloud\Config\Magento\Shared\WriterInterface" alias="Magento\MagentoCloud\Config\Magento\Shared\Writer" />
     </services>
 </container>

--- a/src/App/Container.php
+++ b/src/App/Container.php
@@ -39,7 +39,7 @@ class Container implements ContainerInterface
     public function __construct(string $toolsBasePath, string $magentoBasePath)
     {
         $containerBuilder = new ContainerBuilder();
-        $containerBuilder->set('container', $containerBuilder);
+        $containerBuilder->set('container', $this);
         $containerBuilder->setDefinition('container', new Definition(Container::class))
             ->setArguments([$toolsBasePath, $magentoBasePath]);
 


### PR DESCRIPTION
### Description

- Lower the minimum version of a couple of packages to support M 2.1 & PHP 7.1.
- Narrowed the set of installable versions where no conflict should exist with Magento or other modules
- Made the version constraints consistent across Magento Cloud packages

### Fixed Issues (if relevant)

[MAGECLOUD-4979](https://magento2.atlassian.net/browse/MAGECLOUD-4979)

### Manual testing scenarios

None, dependencies should be installable.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
