### PR TITLE
MAGECLOUD-4887: Implement wizard for split Db  'wizard:split-db-state'

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -68,6 +68,7 @@ class Application extends \Symfony\Component\Console\Application
             $this->container->create(Command\ModuleRefresh::class),
             $this->container->create(Command\Wizard\IdealState::class),
             $this->container->create(Command\Wizard\MasterSlave::class),
+            $this->container->create(Command\Wizard\SplitDbState::class),
             $this->container->create(Command\CronDisable::class),
             $this->container->create(Command\CronEnable::class),
             $this->container->create(Command\CronKill::class),

--- a/src/Command/Wizard/SplitDbState.php
+++ b/src/Command/Wizard/SplitDbState.php
@@ -24,14 +24,21 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class SplitDbState extends Command
 {
+    /**
+     * Command name
+     */
     const NAME = 'wizard:split-db-state';
 
     /**
+     * Console output formatter
+     *
      * @var OutputFormatter
      */
     private $outputFormatter;
 
     /**
+     * Reader of Magento environment configuration file
+     *
      * @var ConfigReader
      */
     private $configReader;
@@ -44,7 +51,6 @@ class SplitDbState extends Command
     private $connectionDataFactory;
 
     /**
-     * SplitDb constructor.
      * @param OutputFormatter $outputFormatter
      * @param ConfigReader $configReader
      * @param RelationshipConnectionFactory $connectionDataFactory

--- a/src/Command/Wizard/SplitDbState.php
+++ b/src/Command/Wizard/SplitDbState.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Command\Wizard;
+
+use Magento\MagentoCloud\Command\Wizard\Util\OutputFormatter;
+use Magento\MagentoCloud\Config\Database\DbConfig;
+use Magento\MagentoCloud\Config\Magento\Env\ReaderInterface as ConfigReader;
+use Magento\MagentoCloud\Config\Stage\DeployInterface;
+use Magento\MagentoCloud\Step\Deploy\SplitDbConnection;
+use Magento\MagentoCloud\DB\Data\RelationshipConnectionFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Verifies whether DB was split or not
+ *
+ * @api
+ */
+class SplitDbState extends Command
+{
+    const NAME = 'wizard:split-db-state';
+
+    /**
+     * @var OutputFormatter
+     */
+    private $outputFormatter;
+
+    /**
+     * @var ConfigReader
+     */
+    private $configReader;
+
+    /**
+     * Factory for creation database configurations
+     *
+     * @var RelationshipConnectionFactory
+     */
+    private $connectionDataFactory;
+
+    /**
+     * SplitDb constructor.
+     * @param OutputFormatter $outputFormatter
+     * @param ConfigReader $configReader
+     * @param RelationshipConnectionFactory $connectionDataFactory
+     */
+    public function __construct(
+        OutputFormatter $outputFormatter,
+        ConfigReader $configReader,
+        RelationshipConnectionFactory $connectionDataFactory
+    ) {
+        $this->outputFormatter = $outputFormatter;
+        $this->configReader = $configReader;
+        $this->connectionDataFactory = $connectionDataFactory;
+
+        parent::__construct();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this->setName(self::NAME)
+            ->setDescription('Verifies ability to split DB and whether DB was already split or not.');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $info = [];
+        $mageConfig = $this->configReader->read();
+        $envDBConfig = [];
+        $existedSplits = [];
+
+        foreach (DbConfig::SPLIT_CONNECTIONS as $mageConnectionName) {
+            if (isset($mageConfig[DbConfig::KEY_DB][DbConfig::KEY_CONNECTION][$mageConnectionName])) {
+                $existedSplits[] = SplitDbConnection::SPLIT_CONNECTION_MAP[$mageConnectionName];
+            }
+            $connection = $this->connectionDataFactory->create(DbConfig::MAIN_CONNECTION_MAP[$mageConnectionName]);
+            if ($connection->getHost()) {
+                $envDBConfig[$mageConnectionName] = $connection;
+            }
+        }
+
+        if (!$existedSplits) {
+            if ($envDBConfig) {
+                $info[] = sprintf(
+                    'You may split DB using %s variable in .magento.env.yaml file',
+                    DeployInterface::VAR_SPLIT_DB
+                );
+            } else {
+                $info[] = 'DB cannot be split on this environment';
+            }
+        }
+
+        $message = $existedSplits
+            ? sprintf('DB is already split with type(s): %s', implode(', ', $existedSplits))
+            : 'DB is not split:';
+
+        $this->outputFormatter->writeResult($output, true, $message);
+
+        foreach ($info as $msg) {
+            $this->outputFormatter->writeItem($output, $msg);
+        }
+    }
+}

--- a/src/Test/Unit/ApplicationTest.php
+++ b/src/Test/Unit/ApplicationTest.php
@@ -74,6 +74,7 @@ class ApplicationTest extends TestCase
         Command\ModuleRefresh::NAME => Command\ModuleRefresh::class,
         Command\Wizard\IdealState::NAME => Command\Wizard\IdealState::class,
         Command\Wizard\MasterSlave::NAME => Command\Wizard\MasterSlave::class,
+        Command\Wizard\SplitDbState::NAME => Command\Wizard\SplitDbState::class,
         Command\CronKill::NAME => Command\CronKill::class,
         Command\CronEnable::NAME => Command\CronEnable::class,
         Command\CronDisable::NAME => Command\CronDisable::class,

--- a/src/Test/Unit/Command/Wizard/SplitDbStateTest.php
+++ b/src/Test/Unit/Command/Wizard/SplitDbStateTest.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Test\Unit\Command\Wizard;
+
+use Magento\MagentoCloud\Command\Wizard\SplitDbState;
+use Magento\MagentoCloud\Command\Wizard\Util\OutputFormatter;
+use Magento\MagentoCloud\Config\Magento\Env\ReaderInterface;
+use Magento\MagentoCloud\DB\Data\RelationshipConnection;
+use Magento\MagentoCloud\DB\Data\RelationshipConnectionFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @inheritdoc
+ */
+class SplitDbStateTest extends TestCase
+{
+    /**
+     * @var SplitDbState
+     */
+    private $command;
+
+    /**
+     * @var OutputFormatter|MockObject
+     */
+    private $outputFormatterMock;
+
+    /**
+     * @var ReaderInterface|MockObject
+     */
+    private $configReaderMock;
+
+    /**
+     * @var RelationshipConnectionFactory|MockObject
+     */
+    private $connectionDataFactoryMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->outputFormatterMock = $this->createMock(OutputFormatter::class);
+        $this->configReaderMock = $this->getMockForAbstractClass(ReaderInterface::class);
+        $this->connectionDataFactoryMock = $this->createMock(RelationshipConnectionFactory::class);
+
+        $this->command = new SplitDbState(
+            $this->outputFormatterMock,
+            $this->configReaderMock,
+            $this->connectionDataFactoryMock
+        );
+    }
+
+    /**
+     * @param $mageConf
+     * @param $message
+     *
+     * @dataProvider executeWithSplitDataProvider
+     */
+    public function testExecuteWithSplit($mageConf, $message)
+    {
+        $inputMock = $this->getMockForAbstractClass(InputInterface::class);
+        $outputMock = $this->getMockForAbstractClass(OutputInterface::class);
+
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn($mageConf);
+
+        $this->connectionDataFactoryMock->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnMap(
+                [
+                    [RelationshipConnectionFactory::CONNECTION_QUOTE_MAIN, new RelationshipConnection([])],
+                    [RelationshipConnectionFactory::CONNECTION_SALES_MAIN, new RelationshipConnection([])],
+                ]
+            );
+
+        $this->outputFormatterMock->expects($this->never())
+           ->method('writeItem');
+        $this->outputFormatterMock->expects($this->once())
+            ->method('writeResult')
+            ->with($outputMock, true, $message);
+
+        $this->command->execute($inputMock, $outputMock);
+    }
+
+    /**
+     * @param $quoteConnection
+     * @param $salesConnection
+     * @param $message
+     *
+     * @dataProvider executeNoSplitDataProvider
+     */
+    public function testExecuteNoSplit($quoteConnection, $salesConnection, $message)
+    {
+        $inputMock = $this->getMockForAbstractClass(InputInterface::class);
+        $outputMock = $this->getMockForAbstractClass(OutputInterface::class);
+
+        $mageConf = [
+            'db' => [
+                'connection' => [
+                    'main' => ['host' => 'localhost'],
+                ]
+            ]
+        ];
+        $this->configReaderMock->expects($this->once())
+            ->method('read')
+            ->willReturn($mageConf);
+
+        $this->connectionDataFactoryMock->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnMap([
+                [RelationshipConnectionFactory::CONNECTION_QUOTE_MAIN, new RelationshipConnection($quoteConnection)],
+                [RelationshipConnectionFactory::CONNECTION_SALES_MAIN, new RelationshipConnection($salesConnection)],
+            ]);
+
+        $this->outputFormatterMock->expects($this->any())
+            ->method('writeItem')
+            ->with($outputMock, $message);
+        $this->outputFormatterMock->expects($this->once())
+            ->method('writeResult')
+            ->with($outputMock, true, 'DB is not split');
+
+        $this->command->execute($inputMock, $outputMock);
+    }
+
+    /**
+     * Data provider for executeWithSplit
+     * @return array
+     */
+    public function executeWithSplitDataProvider(): array
+    {
+        $mageConfQuote = [
+            'db' => [
+                'connection' => [
+                    'main' => ['host' => 'localhost'],
+                    'checkout' => ['host' => 'localhost'],
+                ]
+            ]
+        ];
+        $mageConfSales = [
+            'db' => [
+                'connection' => [
+                    'sale' => ['host' => 'localhost'],
+                ]
+            ]
+        ];
+        $mageConfSalesQuote = array_merge_recursive($mageConfQuote, $mageConfSales);
+
+        return [
+            [$mageConfQuote, 'DB is already split with type(s): quote'],
+            [$mageConfSales, 'DB is already split with type(s): sales'],
+            [$mageConfSalesQuote, 'DB is already split with type(s): quote, sales'],
+        ];
+    }
+
+    /**
+     * Data provider for testExecuteNoSplit
+     * @return array
+     */
+    public function executeNoSplitDataProvider(): array
+    {
+        $connection = [
+            'host' => '120.0.0.1',
+            'dbname' => 'dbname'
+        ];
+
+        return [
+            [[], [], 'DB cannot be split on this environment'],
+            [$connection, [], 'You may split DB using SPLIT_DB variable in .magento.env.yaml file'],
+            [[], $connection, 'You may split DB using SPLIT_DB variable in .magento.env.yaml file'],
+            [$connection, $connection, 'You may split DB using SPLIT_DB variable in .magento.env.yaml file'],
+        ];
+    }
+}


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-4887

### Description
Implement CLI command which provides info about ability to split DB and whether DB was already split or not.
### Manual testing scenarios
Run command `wizard:split-db-state` on next cloud environments:
**1.** On any env, which does not support split DB. 
  Result: 
```
DB is not split:
- DB cannot be split on this environment
```
**2.** On env which support split DB.
  Result: 
```
DB is not split:
- You may split DB using SPLIT_DB variable in .magento.env.yaml file
```
**3.** On env which support split DB. And quote type was already split
  Result: 
```
DB is already split with type(s): quote
```
**4.** On env which support split DB. And quote and sales types were already split
  Result: 
```
DB is already split with type(s): quote, sales
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
