### PR TITLE
MAGECLOUD-5529:  ece-tools can't deploy magento if DB prefixes were enabled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,18 +8,6 @@
     "repo.magento.com": {
       "type": "composer",
       "url": "https://repo.magento.com/"
-    },
-    "mcd": {
-      "type": "git",
-      "url": "git@github.com:magento/magento-cloud-docker.git"
-    },
-    "mcc": {
-      "type": "git",
-      "url": "git@github.com:magento/magento-cloud-components.git"
-    },
-    "mcp": {
-      "type": "git",
-      "url": "git@github.com:magento/magento-cloud-patches.git"
     }
   },
   "require": {
@@ -33,9 +21,9 @@
     "graylog2/gelf-php": "^1.4.2",
     "guzzlehttp/guzzle": "^6.2",
     "illuminate/config": "^5.5",
-    "magento/magento-cloud-components": "^1.0",
-    "magento/magento-cloud-docker": "dev-develop as 1.1.99",
-    "magento/magento-cloud-patches": "1.*",
+    "magento/magento-cloud-components": "^1.0.1",
+    "magento/magento-cloud-docker": "^1.0.0",
+    "magento/magento-cloud-patches": "^1.0.0",
     "monolog/monolog": "^1.16",
     "nesbot/carbon": "^1.0||^2.0",
     "psr/container": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "guzzlehttp/guzzle": "^6.2",
     "illuminate/config": "^5.5",
     "magento/magento-cloud-components": "^1.0.1",
-    "magento/magento-cloud-docker": "^1.0.0",
     "magento/magento-cloud-patches": "^1.0.0",
     "monolog/monolog": "^1.16",
     "nesbot/carbon": "^1.0||^2.0",
@@ -84,6 +83,7 @@
     "test:integration": "phpunit --configuration tests/integration",
     "test:coverage": "phpunit --configuration tests/unit --coverage-clover tests/unit/tmp/clover.xml && php tests/unit/code-coverage.php tests/unit/tmp/clover.xml",
     "test:coverage-generate": "phpunit --configuration tests/unit --coverage-html tests/unit/tmp/coverage",
+    "add-cloud-docker": "composer config repositories.mcd git git@github.com:magento/magento-cloud-docker.git && composer require magento/magento-cloud-docker:dev-develop --no-update",
     "pre-autoload-dump": [
       "Magento\\MagentoCloud\\Composer\\ClearAutoload::preAutoloadDump"
     ]

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,18 @@
     "repo.magento.com": {
       "type": "composer",
       "url": "https://repo.magento.com/"
+    },
+    "mcd": {
+      "type": "git",
+      "url": "git@github.com:magento/magento-cloud-docker.git"
+    },
+    "mcc": {
+      "type": "git",
+      "url": "git@github.com:magento/magento-cloud-components.git"
+    },
+    "mcp": {
+      "type": "git",
+      "url": "git@github.com:magento/magento-cloud-patches.git"
     }
   },
   "require": {
@@ -21,8 +33,9 @@
     "graylog2/gelf-php": "^1.4.2",
     "guzzlehttp/guzzle": "^6.2",
     "illuminate/config": "^5.5",
-    "magento/magento-cloud-components": "^1.0.1",
-    "magento/magento-cloud-patches": "^1.0.0",
+    "magento/magento-cloud-components": "^1.0",
+    "magento/magento-cloud-docker": "dev-develop as 1.1.99",
+    "magento/magento-cloud-patches": "1.*",
     "monolog/monolog": "^1.16",
     "nesbot/carbon": "^1.0||^2.0",
     "psr/container": "^1.0",
@@ -83,7 +96,6 @@
     "test:integration": "phpunit --configuration tests/integration",
     "test:coverage": "phpunit --configuration tests/unit --coverage-clover tests/unit/tmp/clover.xml && php tests/unit/code-coverage.php tests/unit/tmp/clover.xml",
     "test:coverage-generate": "phpunit --configuration tests/unit --coverage-html tests/unit/tmp/coverage",
-    "add-cloud-docker": "composer config repositories.mcd git git@github.com:magento/magento-cloud-docker.git && composer require magento/magento-cloud-docker:dev-develop --no-update",
     "pre-autoload-dump": [
       "Magento\\MagentoCloud\\Composer\\ClearAutoload::preAutoloadDump"
     ]

--- a/src/Config/State.php
+++ b/src/Config/State.php
@@ -76,7 +76,9 @@ class State
             return false;
         }
 
-        if (!in_array('core_config_data', $output) || !in_array('setup_module', $output)) {
+        if (!in_array($this->connection->getTableName('core_config_data'), $output) ||
+            !in_array($this->connection->getTableName('setup_module'), $output)
+        ) {
             throw new GenericException('Missing either core_config_data or setup_module table');
         }
 

--- a/src/Test/Functional/Acceptance/DatabaseConfigurationCest.php
+++ b/src/Test/Functional/Acceptance/DatabaseConfigurationCest.php
@@ -78,4 +78,42 @@ class DatabaseConfigurationCest extends AbstractCest
             ],
         ];
     }
+
+    /**
+     * Check that magento can be installed and updated with configured table prefixes
+     *
+     * @param \CliTester $I
+     * @throws \Robo\Exception\TaskException
+     */
+    public function installAndRedeployWithTablePrefix(\CliTester $I)
+    {
+        $I->runEceDockerCommand(
+            sprintf(
+                'build:compose --mode=production --env-vars="%s"',
+                $this->convertEnvFromArrayToJson([
+                    'MAGENTO_CLOUD_VARIABLES' => [
+                        'DATABASE_CONFIGURATION'=>[
+                            'table_prefix' => 'ece_',
+                            '_merge' => true,
+                        ],
+                    ],
+                ])
+            )
+        );
+
+        $I->assertTrue($I->runDockerComposeCommand('run build cloud-build'));
+        $I->assertTrue($I->startEnvironment());
+        $I->assertTrue(
+            $I->runDockerComposeCommand('run deploy cloud-deploy'),
+            'Installation with table prefixes failed'
+        );
+        $I->runDockerComposeCommand('run deploy cloud-post-deploy');
+
+        $I->assertTrue($I->runDockerComposeCommand('run deploy cloud-deploy'), 'Re-deployment failed');
+        $I->runDockerComposeCommand('run deploy cloud-post-deploy');
+
+        $file = $I->grabFileContent('/app/etc/env.php');
+        $I->assertEquals($file['db']['table_prefix'], 'ece_', 'Wrong table prefix in app/etc/env.php');
+        $I->assertTrue($I->amOnPage('/'));
+    }
 }

--- a/src/Test/Functional/Acceptance/DatabaseConfigurationCest.php
+++ b/src/Test/Functional/Acceptance/DatabaseConfigurationCest.php
@@ -87,6 +87,12 @@ class DatabaseConfigurationCest extends AbstractCest
      */
     public function installAndRedeployWithTablePrefix(\CliTester $I)
     {
+        $checkResult = function (\CliTester $I) {
+            $file = $I->grabFileContent('/app/etc/env.php');
+            $I->assertEquals($file['db']['table_prefix'], 'ece_', 'Wrong table prefix in app/etc/env.php');
+            $I->assertTrue($I->amOnPage('/'));
+        };
+
         $I->runEceDockerCommand(
             sprintf(
                 'build:compose --mode=production --env-vars="%s"',
@@ -108,12 +114,10 @@ class DatabaseConfigurationCest extends AbstractCest
             'Installation with table prefixes failed'
         );
         $I->runDockerComposeCommand('run deploy cloud-post-deploy');
+        $checkResult($I);
 
         $I->assertTrue($I->runDockerComposeCommand('run deploy cloud-deploy'), 'Re-deployment failed');
         $I->runDockerComposeCommand('run deploy cloud-post-deploy');
-
-        $file = $I->grabFileContent('/app/etc/env.php');
-        $I->assertEquals($file['db']['table_prefix'], 'ece_', 'Wrong table prefix in app/etc/env.php');
-        $I->assertTrue($I->amOnPage('/'));
+        $checkResult($I);
     }
 }

--- a/src/Test/Functional/Acceptance/DatabaseConfigurationCest.php
+++ b/src/Test/Functional/Acceptance/DatabaseConfigurationCest.php
@@ -90,7 +90,9 @@ class DatabaseConfigurationCest extends AbstractCest
         $checkResult = function (\CliTester $I) {
             $file = $I->grabFileContent('/app/etc/env.php');
             $I->assertContains("'table_prefix' => 'ece_'", $file, 'Wrong table prefix in app/etc/env.php');
-            $I->assertTrue($I->amOnPage('/'));
+            $I->amOnPage('/');
+            $I->see('Home page');
+            $I->see('CMS homepage content goes here.');
         };
 
         $I->runEceDockerCommand(

--- a/src/Test/Functional/Acceptance/DatabaseConfigurationCest.php
+++ b/src/Test/Functional/Acceptance/DatabaseConfigurationCest.php
@@ -89,7 +89,7 @@ class DatabaseConfigurationCest extends AbstractCest
     {
         $checkResult = function (\CliTester $I) {
             $file = $I->grabFileContent('/app/etc/env.php');
-            $I->assertEquals($file['db']['table_prefix'], 'ece_', 'Wrong table prefix in app/etc/env.php');
+            $I->assertContains("'table_prefix' => 'ece_'", $file, 'Wrong table prefix in app/etc/env.php');
             $I->assertTrue($I->amOnPage('/'));
         };
 

--- a/src/Test/Unit/Config/StateTest.php
+++ b/src/Test/Unit/Config/StateTest.php
@@ -136,6 +136,10 @@ class StateTest extends TestCase
         $this->connectionMock->expects($this->once())
             ->method('listTables')
             ->willReturn(['core_config_data', 'setup_module']);
+        $this->connectionMock->expects($this->exactly(2))
+            ->method('getTableName')
+            ->withConsecutive(['core_config_data'], ['setup_module'])
+            ->willReturnOnConsecutiveCalls('core_config_data', 'setup_module');
         $this->readerMock->expects($this->once())
             ->method('read')
             ->willReturn([]);
@@ -165,6 +169,10 @@ class StateTest extends TestCase
         $this->connectionMock->expects($this->once())
             ->method('listTables')
             ->willReturn(['core_config_data', 'setup_module']);
+        $this->connectionMock->expects($this->exactly(2))
+            ->method('getTableName')
+            ->withConsecutive(['core_config_data'], ['setup_module'])
+            ->willReturnOnConsecutiveCalls('core_config_data', 'setup_module');
         $this->readerMock->expects($this->once())
             ->method('read')
             ->willReturn($config);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://magento2.atlassian.net/browse/MAGECLOUD-5529

### Manual testing scenarios
https://jira.corp.magento.com/browse/MAGECLOUD-119
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Install magento with DB prefix
.magento.env.yaml : 
```
stage:
    deploy:
        DATABASE_CONFIGURATION:
            table_prefix: 'ece_'
            _merge: true
```
2. Redeploy environment
3. Check that redeployment finished without errors (exception is thrown without the fix)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

releasenotes
Fixed an error that prevented redeployment of Cloud environments when Magento is configured to use DB prefixes.
