### PR TITLE
MAGECLOUD-4146: Cache warm-up script

### DIFF
--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -590,6 +590,17 @@ WARM_UP_PAGES:
             - "index.php"
             - "index.php/customer/account/create"
             - "https://example.com/catalog/some-category"
+WARM_UP_CONCURRENCY:
+  description: Specify the number of requests for warm-up which will be sent concurrently.
+  type: integer
+  stages:
+    - post-deploy
+  default:
+    post-deploy: 0
+  examples:
+    - stage:
+        post-deploy:
+          WARM_UP_CONCURRENCY: 4
 TTFB_TESTED_PAGES:
   description: List pages you wish to perform time to first byte (TTFB) testing on
   type: array

--- a/src/Config/Stage/PostDeployInterface.php
+++ b/src/Config/Stage/PostDeployInterface.php
@@ -17,5 +17,6 @@ use Magento\MagentoCloud\Config\StageConfigInterface;
 interface PostDeployInterface extends StageConfigInterface
 {
     const VAR_WARM_UP_PAGES = 'WARM_UP_PAGES';
+    const VAR_WARM_UP_CONCURRENCY = 'WARM_UP_CONCURRENCY';
     const VAR_TTFB_TESTED_PAGES = 'TTFB_TESTED_PAGES';
 }

--- a/src/Test/Unit/Config/SchemaTest.php
+++ b/src/Test/Unit/Config/SchemaTest.php
@@ -136,6 +136,7 @@ class SchemaTest extends TestCase
                 PostDeployInterface::VAR_WARM_UP_PAGES => [
                     '',
                 ],
+                PostDeployInterface::VAR_WARM_UP_CONCURRENCY => 0,
                 PostDeployInterface::VAR_TTFB_TESTED_PAGES => [],
                 PostDeployInterface::VAR_VERBOSE_COMMANDS => '',
             ],

--- a/src/Test/Unit/Config/SchemaTest.php
+++ b/src/Test/Unit/Config/SchemaTest.php
@@ -124,6 +124,7 @@ class SchemaTest extends TestCase
                 PostDeployInterface::VAR_WARM_UP_PAGES => [
                     '',
                 ],
+                PostDeployInterface::VAR_WARM_UP_CONCURRENCY => 0,
                 PostDeployInterface::VAR_TTFB_TESTED_PAGES => [],
                 PostDeployInterface::VAR_VERBOSE_COMMANDS => '',
             ],


### PR DESCRIPTION
### Description
At the end of post-deploy phase the cache warm up script sends requests at a high rate such that weaker instances, like the 4-cpu ones, cannot cope. There nginx exhausts the number of workers, and this is without php-fpm, mysql or reds involvement.

This pull request adds the ability to specify the number of requests for warm-up which will be sent concurrently.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-4146

### Manual testing scenarios
1. Specify a big list of pages to warm-up and the number of concurrent requests for warm-up.
In .magento.env.yaml add:
```
stage:
    post-deploy:
        WARM_UP_PAGES:
            - "index.php"
            ...
stage:
    post-deploy:
        WARM_UP_CONCURRENCY: 2
```
2. Deploy environment
3. Check the number of concurrent requests that are sending.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

releasenotes
Added the  [WARM_UP_CONCURRENCY post-deploy variable](https://devdocs.magento.com/cloud/env/variables-post-deploy.html) to specify the number of warm-up requests that the cache warm up script can send concurrently. Setting this option can help manage load on the Magento Cloud infrastructure.
