### PR TITLE
MCLOUD-5542: Add mapping for Elastic 7 version validator in ece-tools

### DIFF
--- a/src/Config/Validator/Deploy/ElasticSearchVersion.php
+++ b/src/Config/Validator/Deploy/ElasticSearchVersion.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\MagentoCloud\Config\Validator\Deploy;
 
+use Composer\Semver\Comparator;
 use Composer\Semver\Semver;
 use Magento\MagentoCloud\Config\SearchEngine;
 use Magento\MagentoCloud\Config\Validator;
@@ -169,10 +170,15 @@ class ElasticSearchVersion implements ValidatorInterface
             $suggestion[] = '  Update the composer.json file for your Magento Cloud project to ' .
                 'require elasticsearch/elasticsearch module version ~2.0.';
         } else {
+            $mode = Comparator::greaterThan($esServiceVersion, $esPackageVersion)
+                ? 'downgrading'
+                : 'upgrading';
+
             $suggestion = [
                 sprintf(
-                    'You can fix this issue by upgrading the Elasticsearch service on your ' .
+                    'You can fix this issue by %s the Elasticsearch service on your ' .
                     'Magento Cloud infrastructure to version %s.',
+                    $mode,
                     $versionInfo['esVersionRaw']
                 )
             ];

--- a/src/Config/Validator/Deploy/ElasticSearchVersion.php
+++ b/src/Config/Validator/Deploy/ElasticSearchVersion.php
@@ -57,9 +57,9 @@ class ElasticSearchVersion implements ValidatorInterface
      */
     private static $versionsMap = [
         [
-            'packageVersion' => '~6.0',
-            'esVersion' => '~6.0',
-            'esVersionRaw' => '6.x',
+            'packageVersion' => '~2.0',
+            'esVersion' => '>= 1.0 < 3.0',
+            'esVersionRaw' => '1.x or 2.x',
         ],
         [
             'packageVersion' => '~5.0',
@@ -67,9 +67,14 @@ class ElasticSearchVersion implements ValidatorInterface
             'esVersionRaw' => '5.x',
         ],
         [
-            'packageVersion' => '~2.0',
-            'esVersion' => '>= 1.0 < 3.0',
-            'esVersionRaw' => '1.x or 2.x',
+            'packageVersion' => '~6.0',
+            'esVersion' => '~6.0',
+            'esVersionRaw' => '6.x',
+        ],
+        [
+            'packageVersion' => '~7.0',
+            'esVersion' => '~7.0',
+            'esVersionRaw' => '7.x',
         ],
     ];
 
@@ -126,7 +131,7 @@ class ElasticSearchVersion implements ValidatorInterface
                     return $this->generateError($esServiceVersion, $esPackageVersion, $versionInfo);
                 }
             }
-        } catch (\Exception $e) {
+        } catch (UndefinedPackageException $e) {
             $this->logger->warning('Can\'t validate version of elasticsearch: ' . $e->getMessage());
         }
 

--- a/src/Test/Unit/Config/Validator/Deploy/ElasticSearchVersionTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/ElasticSearchVersionTest.php
@@ -147,8 +147,6 @@ class ElasticSearchVersionTest extends TestCase
      * @param string $errorMessage
      * @param string|null $errorSuggestion
      * @dataProvider validateDataProvider
-     *
-     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function testValidate(
         string $esVersion,
@@ -189,6 +187,8 @@ class ElasticSearchVersionTest extends TestCase
 
     /**
      * @return array
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function validateDataProvider(): array
     {

--- a/src/Test/Unit/Config/Validator/Deploy/ElasticSearchVersionTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/ElasticSearchVersionTest.php
@@ -15,6 +15,7 @@ use Magento\MagentoCloud\Config\Validator\Result\Success;
 use Magento\MagentoCloud\Config\Validator\ResultFactory;
 use Magento\MagentoCloud\Package\MagentoVersion;
 use Magento\MagentoCloud\Package\Manager;
+use Magento\MagentoCloud\Package\UndefinedPackageException;
 use Magento\MagentoCloud\Service\ElasticSearch;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -63,7 +64,7 @@ class ElasticSearchVersionTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->resultFactoryMock = $this->createMock(ResultFactory::class);
         $this->managerMock = $this->createMock(Manager::class);
@@ -82,7 +83,7 @@ class ElasticSearchVersionTest extends TestCase
         );
     }
 
-    public function testValidateElasticSearchServiceNotExists()
+    public function testValidateElasticSearchServiceNotExists(): void
     {
         $this->elasticSearchMock->expects($this->once())
             ->method('getVersion')
@@ -99,7 +100,7 @@ class ElasticSearchVersionTest extends TestCase
         $this->assertInstanceOf(Success::class, $this->validator->validate());
     }
 
-    public function testValidatePackageNotExists()
+    public function testValidatePackageNotExists(): void
     {
         $this->searchEngineMock->expects($this->once())
             ->method('isESFamily')
@@ -110,7 +111,7 @@ class ElasticSearchVersionTest extends TestCase
         $this->managerMock->expects($this->once())
             ->method('get')
             ->with('elasticsearch/elasticsearch')
-            ->willThrowException(new \Exception('package doesn\'t exist'));
+            ->willThrowException(new UndefinedPackageException('package doesn\'t exist'));
         $this->loggerMock->expects($this->once())
             ->method('warning')
             ->with('Can\'t validate version of elasticsearch: package doesn\'t exist');
@@ -120,7 +121,7 @@ class ElasticSearchVersionTest extends TestCase
         $this->assertInstanceOf(Success::class, $this->validator->validate());
     }
 
-    public function testValidateElasticSearchServiceExistsAndNotConfigured()
+    public function testValidateElasticSearchServiceExistsAndNotConfigured(): void
     {
         $this->searchEngineMock->expects($this->once())
             ->method('isESFamily')
@@ -154,7 +155,7 @@ class ElasticSearchVersionTest extends TestCase
         string $magentoVersion = '2.2',
         string $errorMessage = '',
         string $errorSuggestion = ''
-    ) {
+    ): void {
         $this->magentoVersionMock->expects($this->any())
             ->method('getVersion')
             ->willReturn($magentoVersion);
@@ -202,6 +203,8 @@ class ElasticSearchVersionTest extends TestCase
             ['1.7', '2.9', Success::class],
             ['5.1', '5.0', Success::class],
             ['5.2', '5.1', Success::class],
+            ['7.0', '7.1', Success::class],
+            ['7.4', '7.2', Success::class],
             ['6.1', '2.0', Error::class],
             [
                 '6.2',
@@ -279,6 +282,16 @@ class ElasticSearchVersionTest extends TestCase
                 'elasticsearch/elasticsearch module (5.1), used by your Magento application.',
                 'You can fix this issue by upgrading the Elasticsearch service on your ' .
                 'Magento Cloud infrastructure to version 5.x.'
+            ],
+            [
+                '7.4',
+                '6.2',
+                Error::class,
+                '2.4.0',
+                'Elasticsearch service version 7.4 on infrastructure layer is not compatible with current version of ' .
+                'elasticsearch/elasticsearch module (6.2), used by your Magento application.',
+                'You can fix this issue by upgrading the Elasticsearch service on your ' .
+                'Magento Cloud infrastructure to version 6.x.'
             ],
         ];
     }

--- a/src/Test/Unit/Config/Validator/Deploy/ElasticSearchVersionTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/ElasticSearchVersionTest.php
@@ -215,7 +215,7 @@ class ElasticSearchVersionTest extends TestCase
                 '2.3.0',
                 'Elasticsearch service version 6.2 on infrastructure layer is not compatible with current version of ' .
                 'elasticsearch/elasticsearch module (5.0), used by your Magento application.',
-                'You can fix this issue by upgrading the Elasticsearch service on your ' .
+                'You can fix this issue by downgrading the Elasticsearch service on your ' .
                 'Magento Cloud infrastructure to version 5.x.'
             ],
             [
@@ -236,7 +236,7 @@ class ElasticSearchVersionTest extends TestCase
                 '2.1.4',
                 'Elasticsearch service version 5.0 on infrastructure layer is not compatible with current version of ' .
                 'elasticsearch/elasticsearch module (2.0), used by your Magento application.',
-                'You can fix this issue by upgrading the Elasticsearch service on your ' .
+                'You can fix this issue by downgrading the Elasticsearch service on your ' .
                 'Magento Cloud infrastructure to version 1.x or 2.x.'
             ],
             [
@@ -292,7 +292,7 @@ class ElasticSearchVersionTest extends TestCase
                 '2.4.0',
                 'Elasticsearch service version 7.4 on infrastructure layer is not compatible with current version of ' .
                 'elasticsearch/elasticsearch module (6.2), used by your Magento application.',
-                'You can fix this issue by upgrading the Elasticsearch service on your ' .
+                'You can fix this issue by downgrading the Elasticsearch service on your ' .
                 'Magento Cloud infrastructure to version 6.x.'
             ],
         ];

--- a/src/Test/Unit/Config/Validator/Deploy/ElasticSearchVersionTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/ElasticSearchVersionTest.php
@@ -147,6 +147,8 @@ class ElasticSearchVersionTest extends TestCase
      * @param string $errorMessage
      * @param string|null $errorSuggestion
      * @dataProvider validateDataProvider
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function testValidate(
         string $esVersion,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
ECE-Tools is throwing warnings with both module and service using version 7:

```
Elasticsearch service version 7.2.0 on infrastructure layer is not compatible with current version of elasticsearch/elasticsearch module (6.7.2.0), used by your Magento application.
```

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://jira.corp.magento.com/browse/MCLOUD-5542

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Upgrade the ES service to version 7.x
2. Deploy on Magento Cloud
3. See the warning in `var/log/cloud.log`
4. Upgrade the ES module to version 7.x 
5. Deploy on Magento Cloud
6. No warning is present in last deployment

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

releasenotes
Added support for Elasticsearch 7 to deploy validators.