### PR TITLE
MCLOUD-5732: Add ECE-Tools warning about MySQL search being used

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -34,6 +34,7 @@
         <service id="Magento\MagentoCloud\Scenario\Exception\ProcessorException" autowire="false" />
         <service id="Magento\MagentoCloud\Scenario\Exception\ValidationException" autowire="false" />
         <service id="Magento\MagentoCloud\Service\ServiceMismatchException" autowire="false" />
+        <service id="Magento\MagentoCloud\Config\ValidatorException" autowire="false" />
         <service id="Magento\MagentoCloud\Shell\Process" autowire="false" />
         <service id="Magento\MagentoCloud\Shell\ProcessException" autowire="false" />
         <service id="Magento\MagentoCloud\Step\Build\BackupData" autowire="false" />

--- a/scenario/deploy.xml
+++ b/scenario/deploy.xml
@@ -43,6 +43,7 @@
                     <item name="json-format-variable " xsi:type="object">Magento\MagentoCloud\Config\Validator\Deploy\JsonFormatVariable</item>
                     <item name="service-version" xsi:type="object">Magento\MagentoCloud\Config\Validator\Deploy\ServiceVersion</item>
                     <item name="service-eol-warning" xsi:type="object">ServiceEol.Warnings</item>
+                    <item name="deprecated-search-engine" xsi:type="object">Magento\MagentoCloud\Config\Validator\Deploy\DeprecatedSearchEngine</item>
                 </item>
                 <item name="notice" xsi:type="array">
                     <item name="service-eol-notice" xsi:type="object">ServiceEol.Notices</item>

--- a/src/Config/SearchEngine.php
+++ b/src/Config/SearchEngine.php
@@ -19,6 +19,8 @@ use Magento\MagentoCloud\Service\ElasticSearch;
  */
 class SearchEngine
 {
+    public const ENGINE_MYSQL = 'mysql';
+
     /**
      * @var Environment
      */

--- a/src/Config/Validator/Deploy/DeprecatedSearchEngine.php
+++ b/src/Config/Validator/Deploy/DeprecatedSearchEngine.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Config\Validator\Deploy;
+
+use Magento\MagentoCloud\Config\SearchEngine;
+use Magento\MagentoCloud\Config\Validator;
+use Magento\MagentoCloud\Config\ValidatorInterface;
+
+/**
+ * Validates if a deprecated MySQL search engine is used.
+ */
+class DeprecatedSearchEngine implements ValidatorInterface
+{
+    /**
+     * @var Validator\ResultFactory
+     */
+    private $resultFactory;
+
+    /**
+     * @var SearchEngine
+     */
+    private $searchEngine;
+
+    /**
+     * @param Validator\ResultFactory $resultFactory
+     * @param SearchEngine $searchEngine
+     */
+    public function __construct(Validator\ResultFactory $resultFactory, SearchEngine $searchEngine)
+    {
+        $this->resultFactory = $resultFactory;
+        $this->searchEngine = $searchEngine;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate(): Validator\ResultInterface
+    {
+        if (SearchEngine::ENGINE_MYSQL === $this->searchEngine->getName()) {
+            return $this->resultFactory->error(
+                '"MySQL" is configured as a search engine. ' . PHP_EOL .
+                'This option is deprecated and will be removed in one of the next versions.'
+            );
+        }
+
+        return $this->resultFactory->success();
+    }
+}

--- a/src/Config/Validator/Deploy/DeprecatedSearchEngine.php
+++ b/src/Config/Validator/Deploy/DeprecatedSearchEngine.php
@@ -43,8 +43,7 @@ class DeprecatedSearchEngine implements ValidatorInterface
     {
         if (SearchEngine::ENGINE_MYSQL === $this->searchEngine->getName()) {
             return $this->resultFactory->error(
-                '"MySQL" is configured as a search engine. ' . PHP_EOL .
-                'This option is deprecated and will be removed in one of the next versions.'
+                'The MySQL search configuration option is deprecated. Use Elasticsearch instead.'
             );
         }
 

--- a/src/Config/ValidatorException.php
+++ b/src/Config/ValidatorException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Config;
+
+use Magento\MagentoCloud\App\GenericException;
+
+/**
+ * The generic Validator exception.
+ */
+class ValidatorException extends GenericException
+{
+}

--- a/src/Config/ValidatorInterface.php
+++ b/src/Config/ValidatorInterface.php
@@ -20,6 +20,8 @@ interface ValidatorInterface
 
     /**
      * @return Validator\ResultInterface
+     *
+     * @throws ValidatorException
      */
     public function validate(): Validator\ResultInterface;
 }

--- a/src/Step/StepInterface.php
+++ b/src/Step/StepInterface.php
@@ -21,5 +21,5 @@ interface StepInterface
      * @return void
      * @throws StepException
      */
-    public function execute();
+    public function execute(); // The :void return type declaration that should be here would cause a BC issue
 }

--- a/src/Step/ValidateConfiguration.php
+++ b/src/Step/ValidateConfiguration.php
@@ -67,6 +67,7 @@ class ValidateConfiguration implements StepInterface
 
     /**
      * Returns all validation messages grouped by validation level.
+     * Converts validation level to integer value.
      *
      * @return array
      *

--- a/src/Test/Unit/Config/Validator/Deploy/DeprecatedSearchEngineTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/DeprecatedSearchEngineTest.php
@@ -60,8 +60,7 @@ class DeprecatedSearchEngineTest extends TestCase
         $this->resultFactoryMock->expects($this->once())
             ->method('error')
             ->with(
-                '"MySQL" is configured as a search engine. ' . PHP_EOL .
-                'This option is deprecated and will be removed in one of the next versions.'
+                'The MySQL search configuration option is deprecated. Use Elasticsearch instead.'
             )->willReturn(new Error('Some error'));
 
         $this->validator->validate();

--- a/src/Test/Unit/Config/Validator/Deploy/DeprecatedSearchEngineTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/DeprecatedSearchEngineTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Test\Unit\Config\Validator\Deploy;
+
+use Magento\MagentoCloud\Config\SearchEngine;
+use Magento\MagentoCloud\Config\Validator\Deploy\DeprecatedSearchEngine;
+use Magento\MagentoCloud\Config\Validator\Result\Error;
+use Magento\MagentoCloud\Config\Validator\Result\Success;
+use Magento\MagentoCloud\Config\Validator\ResultFactory;
+use Magento\MagentoCloud\Config\ValidatorException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see DeprecatedSearchEngine
+ */
+class DeprecatedSearchEngineTest extends TestCase
+{
+    /**
+     * @var DeprecatedSearchEngine
+     */
+    private $validator;
+
+    /**
+     * @var ResultFactory|MockObject
+     */
+    private $resultFactoryMock;
+
+    /**
+     * @var SearchEngine|MockObject
+     */
+    private $searchEngineMock;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->resultFactoryMock = $this->createMock(ResultFactory::class);
+        $this->searchEngineMock = $this->createMock(SearchEngine::class);
+
+        $this->validator = new DeprecatedSearchEngine(
+            $this->resultFactoryMock,
+            $this->searchEngineMock
+        );
+    }
+
+    /**
+     * @throws ValidatorException
+     */
+    public function testValidate(): void
+    {
+        $this->searchEngineMock->method('getName')
+            ->willReturn(SearchEngine::ENGINE_MYSQL);
+        $this->resultFactoryMock->expects($this->once())
+            ->method('error')
+            ->with(
+                '"MySQL" is configured as a search engine. ' . PHP_EOL .
+                'This option is deprecated and will be removed in one of the next versions.'
+            )->willReturn(new Error('Some error'));
+
+        $this->validator->validate();
+    }
+
+    /**
+     * @throws ValidatorException
+     */
+    public function testValidateWithError(): void
+    {
+        $this->searchEngineMock->method('getName')
+            ->willReturn('es');
+        $this->resultFactoryMock->expects($this->once())
+            ->method('success')
+            ->willReturn(new Success());
+
+        $this->validator->validate();
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

MySQL search is not recommended for using and will be removed in the next minor version s of Magento. The proper warning should be thrown to highlight this change.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://jira.corp.magento.com/browse/MCLOUD-5732

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Deploy Magento
2. No warning about "MySQL search engine" present
3. Force ECE-Tools to use MySQL search engine (https://devdocs.magento.com/cloud/env/variables-deploy.html#search_configuration)
4. Deploy Magento
5. Warning about "MySQL search engine being used"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
