### PR TITLE
MCLOUD-5883: UrlManager must respect routes with the attribute primary=true

### DIFF
--- a/src/Test/Unit/Util/UrlManagerTest.php
+++ b/src/Test/Unit/Util/UrlManagerTest.php
@@ -383,6 +383,66 @@ class UrlManagerTest extends TestCase
                     ],
                 ],
             ],
+            'with primary option' => [
+                'routes' => [
+                    'http://example.com/' => [
+                        'original_url' => 'http://{default}/',
+                        'type' => 'upstream',
+                        'primary' => false,
+                    ],
+                    'http://www.custom.example.com/' => [
+                        'original_url' => 'http://{all}/',
+                        'type' => 'upstream',
+                        'primary' => false,
+                    ],
+                    'http://custom.example.com/' => [
+                        'original_url' => 'http://{default}/',
+                        'type' => 'upstream',
+                        'primary' => true,
+                    ],
+                    'https://french.example.com/' => [
+                        'original_url' => 'https://french.{default}/',
+                        'type' => 'upstream',
+                        'primary' => false,
+                    ],
+                ],
+                'expectedResult' => [
+                    'secure' => [
+                        '' => 'https://custom.example.com/',
+                    ],
+                    'unsecure' => [
+                        '' => 'http://custom.example.com/',
+                    ],
+                ],
+            ],
+            'all primary false and one secure' => [
+                'routes' => [
+                    'http://example.com/' => [
+                        'original_url' => 'http://{default}/',
+                        'type' => 'upstream',
+                        'primary' => false,
+                    ],
+                    'http://www.example.com/' => [
+                        'original_url' => 'http://{all}/',
+                        'type' => 'upstream',
+                        'primary' => false,
+                    ],
+                    'https://www.example.com/' => [
+                        'original_url' => 'http://{all}/',
+                        'type' => 'upstream',
+                        'primary' => false,
+                    ],
+                ],
+                'expectedResult' => [
+                    'secure' => [
+                        '{all}' => 'https://www.example.com/',
+                    ],
+                    'unsecure' => [
+                        '' => 'http://example.com/',
+                        '{all}' => 'http://www.example.com/',
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/src/Test/Unit/Util/UrlManagerTest.php
+++ b/src/Test/Unit/Util/UrlManagerTest.php
@@ -164,6 +164,20 @@ class UrlManagerTest extends TestCase
         $this->assertEquals($expectedResult, $this->manager->getUrls());
     }
 
+    /**
+     * @param array $routes
+     * @param array $expectedResult
+     * @dataProvider getPrimaryUrlsDataProvider
+     */
+    public function testGetPrimaryUrls(array $routes, array $expectedResult): void
+    {
+        $this->environmentMock->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($routes);
+
+        $this->assertEquals($expectedResult, $this->manager->getUrls());
+    }
+
     public function testGetUrlsException(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -295,6 +309,10 @@ class UrlManagerTest extends TestCase
         ];
     }
 
+    /**
+     * DataProvider for testGetUrls
+     * @return array
+     */
     public function getUrlsDataProvider(): array
     {
         return [
@@ -383,7 +401,17 @@ class UrlManagerTest extends TestCase
                     ],
                 ],
             ],
-            'with primary option' => [
+        ];
+    }
+
+    /**
+     * DataProvider for testGetPrimaryUrls
+     * @return array
+     */
+    public function getPrimaryUrlsDataProvider(): array
+    {
+        return [
+            'with unsecure primary' => [
                 'routes' => [
                     'http://example.com/' => [
                         'original_url' => 'http://{default}/',
@@ -412,6 +440,33 @@ class UrlManagerTest extends TestCase
                     ],
                     'unsecure' => [
                         '' => 'http://custom.example.com/',
+                    ],
+                ],
+            ],
+            'secure primary' => [
+                'routes' => [
+                    'http://example.com/' => [
+                        'original_url' => 'http://{default}/',
+                        'type' => 'upstream',
+                        'primary' => false,
+                    ],
+                    'http://www.example.com/' => [
+                        'original_url' => 'http://{all}/',
+                        'type' => 'upstream',
+                        'primary' => false,
+                    ],
+                    'https://custom.example.com/' => [
+                        'original_url' => 'http://{default}/',
+                        'type' => 'upstream',
+                        'primary' => true,
+                    ],
+                ],
+                'expectedResult' => [
+                    'secure' => [
+                        '' => 'https://custom.example.com/',
+                    ],
+                    'unsecure' => [
+                        '' => 'https://custom.example.com/',
                     ],
                 ],
             ],

--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -77,6 +77,7 @@ class UrlManager
     private function parseRoutes(array $routes): array
     {
         $urls = ['secure' => [], 'unsecure' => []];
+        $primaryUrls = [];
 
         foreach ($routes as $key => $val) {
             if ($val['type'] !== 'upstream') {
@@ -89,16 +90,22 @@ class UrlManager
 
             if (strpos($key, self::PREFIX_UNSECURE) === 0) {
                 $urls['unsecure'][$originalUrl] = $key;
+                if (!empty($val['primary'])) {
+                    $primaryUrls['unsecure'][$originalUrl] = $key;
+                }
                 continue;
             }
 
             if (strpos($key, self::PREFIX_SECURE) === 0) {
                 $urls['secure'][$originalUrl] = $key;
+                if (!empty($val['primary'])) {
+                    $primaryUrls['secure'][$originalUrl] = $key;
+                }
                 continue;
             }
         }
 
-        return $urls;
+        return $primaryUrls ?: $urls;
     }
 
     /**

--- a/src/Util/UrlManager.php
+++ b/src/Util/UrlManager.php
@@ -123,14 +123,14 @@ class UrlManager
 
         $urls = $this->parseRoutes($this->environment->getRoutes());
 
-        if (0 === count($urls['unsecure']) && 0 === count($urls['secure'])) {
+        if (empty($urls['unsecure']) && empty($urls['secure'])) {
             throw new \RuntimeException('Expected at least one valid unsecure or secure route. None found.');
         }
-        if (0 === count($urls['unsecure'])) {
+        if (empty($urls['unsecure'])) {
             $urls['unsecure'] = $urls['secure'];
         }
 
-        if (0 === count($urls['secure'])) {
+        if (empty($urls['secure'])) {
             $urls['secure'] = substr_replace($urls['unsecure'], self::PREFIX_SECURE, 0, strlen(self::PREFIX_UNSECURE));
         }
 


### PR DESCRIPTION
### Description
UrlManager prefers that route which is marked as "primary".

### Implemented Story 
https://jira.corp.magento.com/browse/MCLOUD-5883

### Manual testing scenarios
check on environments which have several routes with `"original_url" : "http://{default}/"`.
if one of those routes has `"primary" : true` then only that URL should be set after deployment. 
Otherwise, the last one with `"original_url" : "http://{default}/"`which displayed in the list will be set:
for 

> {
>    "http://stg-1q2w3e4r5t.dummycachetest.com/" : {
>       "upstream" : "mymagento:http",
>       "type" : "upstream",
>       "primary" : true,
>       "id" : null,
>       "attributes" : {},
>       "original_url" : "http://{default}/"
>    },
>    "http://srg-1q2w3e4r5t.dummycachetest.com.c.1q2w3e4r5t.dev.ent.magento.cloud/" : {
>       "original_url" : "http://{default}/",
>       "attributes" : {},
>       "id" : null,
>       "primary" : false,
>       "type" : "upstream",
>       "upstream" : "mymagento:http"
>    }
> }

URL will be `http://stg-1q2w3e4r5t.dummycachetest.com/`
**Note**: to update URLs on Pro Staging or Starter, need to use configuration FORCE_UPDATE_URLS

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
