### PR TITLE
MCLOUD-5939: Failed deploy with missed env.php

### DIFF
--- a/src/Step/Deploy/InstallUpdate/ConfigUpdate/DbConnection.php
+++ b/src/Step/Deploy/InstallUpdate/ConfigUpdate/DbConnection.php
@@ -382,9 +382,14 @@ class DbConnection implements StepInterface
      */
     private function getMageSplitConnectionsConfig(): array
     {
-        return array_intersect_key(
-            $this->getMageConfigData()[DbConfig::KEY_DB][DbConfig::KEY_CONNECTION],
-            array_flip(DbConfig::SPLIT_CONNECTIONS)
-        );
+        $existedSplitConnections = [];
+        $mageConfig = $this->getMageConfigData();
+        if (isset($mageConfig[DbConfig::KEY_DB][DbConfig::KEY_CONNECTION])) {
+            $existedSplitConnections = array_intersect_key(
+                $mageConfig[DbConfig::KEY_DB][DbConfig::KEY_CONNECTION],
+                array_flip(DbConfig::SPLIT_CONNECTIONS)
+            );
+        }
+        return $existedSplitConnections;
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
**Steps to reproduce:**
- Install Magento on cloud
- remove app/etc/env.php
- run redeployment

**Actual result**: 
deployment is failed with error:
```
Unhandled error: Notice: Undefined index: db in /app/vendor/magento/ece-too
        W:   ls/src/Step/Deploy/InstallUpdate/ConfigUpdate/DbConnection.php on line 386

```
**Expected Result**: 
deployment finished without errors

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. [Failed deploy with missed env.php](https://jira.corp.magento.com/browse/MCLOUD-5939) 


### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Described in description

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
