### PR TITLE
MCLOUD-6137: Remove error log at the beginning of deploy phase

### DIFF
--- a/src/Step/Deploy/RemoveDeployFailedFlag.php
+++ b/src/Step/Deploy/RemoveDeployFailedFlag.php
@@ -7,7 +7,10 @@ declare(strict_types=1);
 
 namespace Magento\MagentoCloud\Step\Deploy;
 
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Filesystem\FileList;
 use Magento\MagentoCloud\Filesystem\Flag\Manager;
+use Magento\MagentoCloud\Step\StepException;
 use Magento\MagentoCloud\Step\StepInterface;
 
 /**
@@ -21,11 +24,29 @@ class RemoveDeployFailedFlag implements StepInterface
     private $manager;
 
     /**
-     * @param Manager $manager
+     * @var File
      */
-    public function __construct(Manager $manager)
-    {
+    private $fileDriver;
+
+    /**
+     * @var FileList
+     */
+    private $fileList;
+
+    /**
+     * @param Manager $manager
+     * @param File $fileDriver
+     * @param FileList $fileList
+     */
+    public function __construct(
+        Manager $manager,
+        File $fileDriver,
+        FileList $fileList
+    ) {
+
         $this->manager = $manager;
+        $this->fileDriver = $fileDriver;
+        $this->fileList = $fileList;
     }
 
     /**
@@ -33,8 +54,13 @@ class RemoveDeployFailedFlag implements StepInterface
      */
     public function execute()
     {
-        $this->manager->delete(Manager::FLAG_DEPLOY_HOOK_IS_FAILED);
-        $this->manager->delete(Manager::FLAG_IGNORE_SPLIT_DB);
-        $this->manager->delete(Manager::FLAG_ENV_FILE_ABSENCE);
+        try {
+            $this->manager->delete(Manager::FLAG_DEPLOY_HOOK_IS_FAILED);
+            $this->manager->delete(Manager::FLAG_IGNORE_SPLIT_DB);
+            $this->manager->delete(Manager::FLAG_ENV_FILE_ABSENCE);
+            $this->fileDriver->deleteFile($this->fileList->getCloudErrorLog());
+        } catch (\Exception $e) {
+            throw new StepException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 }

--- a/src/Step/Deploy/RemoveDeployFailedFlag.php
+++ b/src/Step/Deploy/RemoveDeployFailedFlag.php
@@ -14,7 +14,7 @@ use Magento\MagentoCloud\Step\StepException;
 use Magento\MagentoCloud\Step\StepInterface;
 
 /**
- * Removes flags which set during the deploy phase.
+ * Removes flags and files which could be set during the previous deploy phase.
  */
 class RemoveDeployFailedFlag implements StepInterface
 {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
var/log/cloud.error.log file should be removed at the beginning of deploy phase 
This file was implemented as part of story https://jira.corp.magento.com/browse/MCLOUD-5531
PR https://github.com/magento/ece-tools/pull/726

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://jira.corp.magento.com/browse/MCLOUD-6137

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run deployment with some wrong configurations which will be log as warnings or critical errors (but build phase should not be failed). As a result var/log/cloud.error.log file was created and has these error messages.
Then fix those configurations and run redeployment.
**Expected result:** var/log/cloud.error.log files does not exist or does not have data from previous deployment


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
