### PR TITLE
MCLOUD-6045: Throw exception if removing directories was failed in backgroundClearDirectory() method

### DIFF
--- a/src/Filesystem/Driver/File.php
+++ b/src/Filesystem/Driver/File.php
@@ -371,7 +371,18 @@ class File
             }
             $this->rename($src, $dst);
         }
-        shell_exec('nohup rm -rf ' . escapeshellarg($tempDir) . ' 1>/dev/null 2>&1 &');
+        exec(
+            'nohup rm -rf ' . escapeshellarg($tempDir) ,
+            $output,
+            $status
+        );
+
+        if ($status !== 0) {
+            $this->fileSystemException(
+                'Error occurred during removing "%1" directory. %2',
+                [$tempDir, $output]
+            );
+        }
     }
 
     /**

--- a/src/Filesystem/Driver/File.php
+++ b/src/Filesystem/Driver/File.php
@@ -372,7 +372,7 @@ class File
             $this->rename($src, $dst);
         }
         exec(
-            'nohup rm -rf ' . escapeshellarg($tempDir) ,
+            'nohup rm -rf ' . escapeshellarg($tempDir),
             $output,
             $status
         );


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Method Magento\MagentoCloud\Filesystem\Driver\File::backgroundClearDirectory() does not provide any information if removing directories was fails as a result cloud.log does not have warning about the problem with not removed directories.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://jira.corp.magento.com/browse/MCLOUD-6045

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
