### PR TITLE
Fix typo in default subject line

### DIFF
--- a/src/App/Logger/HandlerFactory.php
+++ b/src/App/Logger/HandlerFactory.php
@@ -105,7 +105,7 @@ class HandlerFactory
             case static::HANDLER_EMAIL:
                 $handlerInstance = new NativeMailerHandler(
                     $configuration->get('to'),
-                    $configuration->get('subject', 'Log form Magento Cloud'),
+                    $configuration->get('subject', 'Log from Magento Cloud'),
                     $configuration->get('from'),
                     $minLevel
                 );


### PR DESCRIPTION
### Description

Noticed a quick typo in the default subject line

### Manual testing scenarios

1. Configure an email log handler using the default value for `subject`
1. Email subject should be "Log from Magento Cloud"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
