### PR TITLE
MCLOUD-6375: MC-34668: Introduce environment variable to store a list of quality p…

### DIFF
--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -643,6 +643,20 @@ variables:
       - stage:
           global:
             X_FRAME_CONFIGURATION: SAMEORIGIN
+  QUALITY_PATCHES:
+    description: Specify a list of Magento quality patches that will be applied during deployment.
+    type: array
+    stages:
+      - build
+    default:
+      build: []
+    examples:
+      - stage:
+          build:
+            QUALITY_PATCHES:
+              - MC-31387
+              - MDVA-4567
+              - MC-45634
 
   # Environment variables
   ENV_RELATIONSHIPS:

--- a/scenario/deploy.xml
+++ b/scenario/deploy.xml
@@ -5,6 +5,7 @@
         <arguments>
             <argument name="logger" xsi:type="object">Psr\Log\LoggerInterface</argument>
             <argument name="steps" xsi:type="array">
+                <item name="restore-patch-log" xsi:type="object" priority="25">Magento\MagentoCloud\Step\Deploy\PreDeploy\RestorePatchLog</item>
                 <item name="check-state" xsi:type="object" priority="50">Magento\MagentoCloud\Step\Deploy\PreDeploy\CheckState</item>
                 <item name="cache" xsi:type="object" priority="100">Magento\MagentoCloud\Step\Deploy\PreDeploy\ConfigUpdate\Cache</item>
                 <item name="clean-static-content" xsi:type="object" priority="200">Magento\MagentoCloud\Step\Deploy\PreDeploy\CleanStaticContent</item>

--- a/src/Config/Stage/BuildInterface.php
+++ b/src/Config/Stage/BuildInterface.php
@@ -22,7 +22,12 @@ interface BuildInterface extends StageConfigInterface
     public const VAR_ERROR_REPORT_DIR_NESTING_LEVEL = 'ERROR_REPORT_DIR_NESTING_LEVEL';
 
     /**
-     * Perfom Baler JS bundling
+     * Perform Baler JS bundling
      */
     public const VAR_SCD_USE_BALER = 'SCD_USE_BALER';
+
+    /**
+     * Magento quality patches list
+     */
+    public const VAR_QUALITY_PATCHES = 'QUALITY_PATCHES';
 }

--- a/src/Filesystem/FileList.php
+++ b/src/Filesystem/FileList.php
@@ -179,4 +179,22 @@ class FileList extends ConfigFileList
     {
         return $this->directoryList->getRoot() . '/config/schema.error.yaml';
     }
+
+    /**
+     * @return string
+     * @throws UndefinedPackageException
+     */
+    public function getPatchLog(): string
+    {
+        return $this->directoryList->getLog() . '/patch.log';
+    }
+
+    /**
+     * @return string
+     * @throws UndefinedPackageException
+     */
+    public function getInitPatchLog(): string
+    {
+        return $this->directoryList->getInit() . '/var/log/patch.log';
+    }
 }

--- a/src/Patch/Manager.php
+++ b/src/Patch/Manager.php
@@ -51,18 +51,25 @@ class Manager
     /**
      * Applies all needed patches.
      *
+     * @param array $qualityPatches
      * @throws ShellException
      * @throws ConfigException
      */
-    public function apply(): void
+    public function apply(array $qualityPatches = []): void
     {
         $this->logger->notice('Applying patches');
 
         $command = 'php ./vendor/bin/ece-patches apply';
 
+        if ($qualityPatches) {
+            $command .= sprintf(" '%s'", implode("' '", $qualityPatches));
+        }
+
         if ($this->globalSection->get(GlobalSection::VAR_DEPLOYED_MAGENTO_VERSION_FROM_GIT)) {
             $command .= ' --git-installation 1';
         }
+
+        $command .= ' --no-interaction';
 
         try {
             $this->shell->execute($command);

--- a/src/Step/Build/ApplyPatches.php
+++ b/src/Step/Build/ApplyPatches.php
@@ -9,6 +9,7 @@ namespace Magento\MagentoCloud\Step\Build;
 
 use Magento\MagentoCloud\App\Error;
 use Magento\MagentoCloud\Config\ConfigException;
+use Magento\MagentoCloud\Config\Stage\BuildInterface;
 use Magento\MagentoCloud\Patch\Manager;
 use Magento\MagentoCloud\Shell\ShellException;
 use Magento\MagentoCloud\Step\StepException;
@@ -25,11 +26,20 @@ class ApplyPatches implements StepInterface
     private $manager;
 
     /**
-     * @param Manager $manager
+     * @var BuildInterface
      */
-    public function __construct(Manager $manager)
-    {
+    private $stageConfig;
+
+    /**
+     * @param Manager $manager
+     * @param BuildInterface $stageConfig
+     */
+    public function __construct(
+        Manager $manager,
+        BuildInterface $stageConfig
+    ) {
         $this->manager = $manager;
+        $this->stageConfig = $stageConfig;
     }
 
     /**
@@ -38,7 +48,8 @@ class ApplyPatches implements StepInterface
     public function execute(): void
     {
         try {
-            $this->manager->apply();
+            $qualityPatches = $this->stageConfig->get(BuildInterface::VAR_QUALITY_PATCHES);
+            $this->manager->apply($qualityPatches);
         } catch (ConfigException $e) {
             throw new StepException($e->getMessage(), $e->getCode(), $e);
         } catch (ShellException $e) {

--- a/src/Step/Deploy/PreDeploy/RestorePatchLog.php
+++ b/src/Step/Deploy/PreDeploy/RestorePatchLog.php
@@ -67,7 +67,7 @@ class RestorePatchLog implements StepInterface
      */
     public function execute()
     {
-        try{
+        try {
             $buildPhaseLogPath = $this->fileList->getInitPatchLog();
             if ($this->file->isExists($buildPhaseLogPath)) {
                 $this->logger->info('Restoring patch log file');

--- a/src/Step/Deploy/PreDeploy/RestorePatchLog.php
+++ b/src/Step/Deploy/PreDeploy/RestorePatchLog.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Step\Deploy\PreDeploy;
+
+use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Filesystem\FileList;
+use Magento\MagentoCloud\Filesystem\FileSystemException;
+use Magento\MagentoCloud\Package\UndefinedPackageException;
+use Magento\MagentoCloud\Step\StepException;
+use Magento\MagentoCloud\Step\StepInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Restores patch log file.
+ */
+class RestorePatchLog implements StepInterface
+{
+    /**
+     * @var DirectoryList
+     */
+    private $directoryList;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var File
+     */
+    private $file;
+
+    /**
+     * @var FileList
+     */
+    private $fileList;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param DirectoryList $directoryList
+     * @param File $file
+     * @param FileList $fileList
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        DirectoryList $directoryList,
+        File $file,
+        FileList $fileList
+    ) {
+        $this->logger = $logger;
+        $this->directoryList = $directoryList;
+        $this->file = $file;
+        $this->fileList = $fileList;
+    }
+
+    /**
+     * Restores patch log file from build phase if needed.
+     *
+     * @return void
+     * @throws StepException
+     */
+    public function execute()
+    {
+        try{
+            $buildPhaseLogPath = $this->fileList->getInitPatchLog();
+            if ($this->file->isExists($buildPhaseLogPath)) {
+                $this->logger->info('Restoring patch log file');
+                $this->file->createDirectory($this->directoryList->getLog());
+                $buildPhaseLogContent = $this->file->fileGetContents($buildPhaseLogPath);
+                $this->file->filePutContents(
+                    $this->fileList->getPatchLog(),
+                    $buildPhaseLogContent,
+                    FILE_APPEND
+                );
+            }
+        } catch (FileSystemException | UndefinedPackageException $exception) {
+            throw new StepException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+    }
+}

--- a/src/Test/Unit/Config/SchemaTest.php
+++ b/src/Test/Unit/Config/SchemaTest.php
@@ -77,6 +77,7 @@ class SchemaTest extends TestCase
                 BuildInterface::VAR_SCD_MAX_EXEC_TIME => null,
                 BuildInterface::VAR_ERROR_REPORT_DIR_NESTING_LEVEL => 1,
                 BuildInterface::VAR_SCD_USE_BALER => false,
+                BuildInterface::VAR_QUALITY_PATCHES => []
             ],
             $this->schema->getDefaults(StageConfigInterface::STAGE_BUILD)
         );

--- a/src/Test/Unit/Step/Deploy/PreDeploy/RestorePatchLogTest.php
+++ b/src/Test/Unit/Step/Deploy/PreDeploy/RestorePatchLogTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Test\Unit\Step\Deploy\PreDeploy;
+
+use Magento\MagentoCloud\Filesystem\DirectoryList;
+use Magento\MagentoCloud\Filesystem\Driver\File;
+use Magento\MagentoCloud\Filesystem\FileList;
+use Magento\MagentoCloud\Filesystem\FileSystemException;
+use Magento\MagentoCloud\Package\UndefinedPackageException;
+use Magento\MagentoCloud\Step\Deploy\PreDeploy\RestorePatchLog;
+use Magento\MagentoCloud\Step\StepException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @inheritdoc
+ */
+class RestorePatchLogTest extends TestCase
+{
+    const PATCH_LOG_PATH = 'path/patch.log';
+
+    const INIT_PATCH_LOG_PATH = 'init/path/patch.log';
+
+    /**
+     * @var RestorePatchLog
+     */
+    private $step;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $loggerMock;
+
+    /**
+     * @var File|MockObject
+     */
+    private $fileMock;
+
+    /**
+     * @var DirectoryList|MockObject
+     */
+    private $directoryListMock;
+
+    /**
+     * @var FileList|MockObject
+     */
+    private $fileListMock;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->getMockForAbstractClass();
+        $this->fileMock = $this->createMock(File::class);
+        $this->directoryListMock = $this->createMock(DirectoryList::class);
+        $this->fileListMock = $this->createMock(FileList::class);
+
+        $this->step = new RestorePatchLog(
+            $this->loggerMock,
+            $this->directoryListMock,
+            $this->fileMock,
+            $this->fileListMock
+        );
+    }
+
+    public function testExecute(): void
+    {
+        $this->fileListMock->expects($this->once())
+            ->method('getInitPatchLog')
+            ->willReturn(self::INIT_PATCH_LOG_PATH);
+        $this->fileListMock->expects($this->once())
+            ->method('getPatchLog')
+            ->willReturn(self::PATCH_LOG_PATH);
+        $this->fileMock->expects($this->once())
+            ->method('isExists')
+            ->with(self::INIT_PATCH_LOG_PATH)
+            ->willReturn(true);
+        $this->loggerMock->expects($this->once())
+            ->method('info')
+            ->with('Restoring patch log file');
+        $this->directoryListMock->expects($this->once())
+            ->method('getLog')
+            ->willReturn('/path/to/dir/log');
+        $this->fileMock->expects($this->once())
+            ->method('createDirectory')
+            ->with('/path/to/dir/log');
+        $this->fileMock->expects($this->once())
+            ->method('fileGetContents')
+            ->with(self::INIT_PATCH_LOG_PATH)
+            ->willReturn('content');
+        $this->fileMock->expects($this->once())
+            ->method('filePutContents')
+            ->with(self::PATCH_LOG_PATH, 'content');
+
+        $this->step->execute();
+    }
+
+    public function testExecutePatchLogFileNotExist(): void
+    {
+        $this->fileListMock->expects($this->once())
+            ->method('getInitPatchLog')
+            ->willReturn(self::INIT_PATCH_LOG_PATH);
+        $this->fileMock->expects($this->once())
+            ->method('isExists')
+            ->with(self::INIT_PATCH_LOG_PATH)
+            ->willReturn(false);
+        $this->fileMock->expects($this->never())
+            ->method('fileGetContents');
+        $this->fileMock->expects($this->never())
+            ->method('createDirectory');
+        $this->fileMock->expects($this->never())
+            ->method('filePutContents');
+
+        $this->step->execute();
+    }
+
+    public function testExecuteWithUndefinedPackageException(): void
+    {
+        $this->fileListMock->expects($this->once())
+            ->method('getInitPatchLog')
+            ->willThrowException(new UndefinedPackageException(''));
+        $this->fileMock->expects($this->never())
+            ->method('isExists');
+
+        $this->expectException(StepException::class);
+        $this->step->execute();
+    }
+
+    public function testExecuteWithFilesystemException(): void
+    {
+        $this->fileListMock->expects($this->once())
+            ->method('getInitPatchLog')
+            ->willReturn(self::INIT_PATCH_LOG_PATH);
+        $this->fileMock->expects($this->once())
+            ->method('isExists')
+            ->with(self::INIT_PATCH_LOG_PATH)
+            ->willReturn(true);
+        $this->fileMock->expects($this->once())
+            ->method('fileGetContents')
+            ->willThrowException(new FileSystemException(''));
+
+        $this->expectException(StepException::class);
+        $this->step->execute();
+    }
+}


### PR DESCRIPTION
https://jira.corp.magento.com/browse/MCLOUD-6375: 

In scope of the story [Magento Quality Patches](https://jira.corp.magento.com/browse/MC-34580) added environment variable QUALITY_PATCHES. By default, it's empty and doesn't affect the deployment process. We need it in develop branch to proceed with [adopting CI builds](https://jira.corp.magento.com/browse/MC-34666) for Magento Quality Patches 

### Description
- Added environment variable QUALITY_PATCHES
- Updated patch manager to use QUALITY_PATCHES variable
- Implemented copying patch.log file from build phase to {magento_root}/var/log directory

### Testing scenario
- Check if your GitHub token has access to https://github.com/magento-mpi/magento-cloud-patches.git, https://github.com/magento/quality-patches.git, https://github.com/magento-mpi/ece-tools.git
- Add to composer.json 

```
 "repositories": {
        "repo": {
            "type": "composer",
            "url": "https://repo.magento.com"
        },
        "mcp": {
            "type": "vcs",
            "url": "https://github.com/magento-mpi/magento-cloud-patches.git"
        },
        "mqp": {
            "type": "vcs",
            "url": "https://github.com/magento/quality-patches.git"
        },
        "ece": {
            "type": "vcs",
            "url": "https://github.com/magento-mpi/ece-tools.git"
        }
    },
    "require": {
        "magento/magento-cloud-patches": "dev-MC-34580 as 1.0.99",
        "magento/quality-patches": "dev-master as 1.0.999",
        "magento/ece-tools": "dev-MC-34668 as 2002.1.99"
    },
```

- Add to .magento.env.yaml
```
 stage:
    build:
        QUALITY_PATCHES:
            - MCTEST-1001
```

- Install Magento
- Check /var/log/patch.log file contains 
```
INFO: Patch MCTEST-1001 has been applied {"file":"/app/vendor/magento/quality-patches/src/../patches/MCTEST-1001__TEST_changes__2.3.5_ce.patch"}
INFO: Patch MCTEST-1001 has been applied {"file":"/app/vendor/magento/quality-patches/src/../patches/MCTEST-1001__TEST_changes__2.3.5_ee.patch"}
```
- Verify that patches https://github.com/magento/quality-patches/blob/master/patches/MCTEST-1001__TEST_changes__2.3.5_ce.patch and https://github.com/magento/quality-patches/blob/master/patches/MCTEST-1001__TEST_changes__2.3.5_ee.patch were applied (check sources in vendor folder) 

### Release notes

Added the `QUALITY_PATCHES` environment variable to specify one or more patches to apply during the deployment process. Currently, this variable is for Magento internal use only.

### Associated documentation updates



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful updates for any required release notes and documentation changes
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
