### PR TITLE
MCLOUD-6708: Add warning if MAGE_MODE was set as not production

### DIFF
--- a/config/schema.error.yaml
+++ b/config/schema.error.yaml
@@ -578,9 +578,9 @@
     step: 'pre-deploy:restore-writable-dirs'
     type: warning
 !php/const Magento\MagentoCloud\App\Error::WARN_NOT_SUPPORTED_MAGE_MODE:
-    title: 'Mode value for MAGE_MODE environment variable not supported '
+    title: 'Environment variable MAGE_MODE was found and the value differs from "production"'
     stage: deploy
-    suggestion: 'Remove MAGE_MODE environment variable, or change its value to "production". Magento Cloud supports only "production" mode.'
+    suggestion: 'Magento Cloud does not support Magento modes other than "production". Remove this variable, or change the value to "production", the only supported mode on Cloud projects'
     step: 'validate-config:mage-mode-variable'
     type: warning
 !php/const Magento\MagentoCloud\App\Error::WARN_DEBUG_LOG_ENABLED:

--- a/config/schema.error.yaml
+++ b/config/schema.error.yaml
@@ -580,7 +580,7 @@
 !php/const Magento\MagentoCloud\App\Error::WARN_NOT_SUPPORTED_MAGE_MODE:
     title: 'Environment variable MAGE_MODE has value with not supported mode '
     stage: deploy
-    suggestion: 'Remove MAGE_MODE environment variable or change its value to "production". Magento Cloud supports only "production" mode.'
+    suggestion: 'Remove MAGE_MODE environment variable, or change its value to "production". Magento Cloud supports only "production" mode.'
     step: 'validate-config:mage-mode-variable'
     type: warning
 !php/const Magento\MagentoCloud\App\Error::WARN_DEBUG_LOG_ENABLED:

--- a/config/schema.error.yaml
+++ b/config/schema.error.yaml
@@ -578,9 +578,9 @@
     step: 'pre-deploy:restore-writable-dirs'
     type: warning
 !php/const Magento\MagentoCloud\App\Error::WARN_NOT_SUPPORTED_MAGE_MODE:
-    title: 'Environment variable MAGE_MODE was found and the value differs from "production"'
+    title: 'Mode value for MAGE_MODE environment variable not supported'
     stage: deploy
-    suggestion: 'Magento Cloud does not support Magento modes other than "production". Remove this variable, or change the value to "production", the only supported mode on Cloud projects'
+    suggestion: 'Remove MAGE_MODE environment variable, or change its value to "production". Magento Cloud supports only "production" mode.'
     step: 'validate-config:mage-mode-variable'
     type: warning
 !php/const Magento\MagentoCloud\App\Error::WARN_DEBUG_LOG_ENABLED:

--- a/config/schema.error.yaml
+++ b/config/schema.error.yaml
@@ -578,7 +578,7 @@
     step: 'pre-deploy:restore-writable-dirs'
     type: warning
 !php/const Magento\MagentoCloud\App\Error::WARN_NOT_SUPPORTED_MAGE_MODE:
-    title: 'Environment variable MAGE_MODE has value with not supported mode '
+    title: 'Mode value for MAGE_MODE environment variable not supported '
     stage: deploy
     suggestion: 'Remove MAGE_MODE environment variable, or change its value to "production". Magento Cloud supports only "production" mode.'
     step: 'validate-config:mage-mode-variable'

--- a/config/schema.error.yaml
+++ b/config/schema.error.yaml
@@ -577,6 +577,12 @@
     suggestion: 'Check the `cloud.log` for more information.'
     step: 'pre-deploy:restore-writable-dirs'
     type: warning
+!php/const Magento\MagentoCloud\App\Error::WARN_NOT_SUPPORTED_MAGE_MODE:
+    title: 'Environment variable MAGE_MODE has value with not supported mode '
+    stage: deploy
+    suggestion: 'Remove MAGE_MODE environment variable or change its value to "production". Magento Cloud supports only "production" mode.'
+    step: 'validate-config:mage-mode-variable'
+    type: warning
 !php/const Magento\MagentoCloud\App\Error::WARN_DEBUG_LOG_ENABLED:
     title: 'Debug logging is enabled in Magento'
     suggestion: 'To save disk space, do not enable debug logging for your production environments.'

--- a/dist/error-codes.md
+++ b/dist/error-codes.md
@@ -147,7 +147,8 @@ Warning errors indicate a problem with the Magento Commerce Cloud project config
 | 2023 | install-update:split-db | Enabling a split database will be skipped. |  |
 | 2024 | install-update:split-db | The SPLIT_DB variable is missing the configuration for split connection types. |  |
 | 2025 | install-update:split-db | Slave connection not set. |  |
-| 2026 | pre-deploy:restore-writable-dirs | Failed to restore some data generated data during the build phase to the mounted directories. | Check the `cloud.log` for more information. |
+| 2026 | pre-deploy:restore-writable-dirs | Failed to restore some data generated during the build phase to the mounted directories | Check the `cloud.log` for more information. |
+| 2027 | validate-config:mage-mode-variable | Environment variable MAGE_MODE has value with not supported mode  | Remove MAGE_MODE environment variable or change its value to "production". Magento Cloud supports only "production" mode. |
 
 ### Post-deploy stage
 

--- a/dist/error-codes.md
+++ b/dist/error-codes.md
@@ -148,7 +148,7 @@ Warning errors indicate a problem with the Magento Commerce Cloud project config
 | 2024 | install-update:split-db | The SPLIT_DB variable is missing the configuration for split connection types. |  |
 | 2025 | install-update:split-db | Slave connection not set. |  |
 | 2026 | pre-deploy:restore-writable-dirs | Failed to restore some data generated during the build phase to the mounted directories | Check the `cloud.log` for more information. |
-| 2027 | validate-config:mage-mode-variable | Environment variable MAGE_MODE has value with not supported mode  | Remove MAGE_MODE environment variable or change its value to "production". Magento Cloud supports only "production" mode. |
+| 2027 | validate-config:mage-mode-variable | Mode value for MAGE_MODE environment variable not supported | Remove MAGE_MODE environment variable, or change its value to "production". Magento Cloud supports only "production" mode. |
 
 ### Post-deploy stage
 

--- a/scenario/deploy.xml
+++ b/scenario/deploy.xml
@@ -33,6 +33,7 @@
                     <item name="elasticsuite-integrity" xsi:type="object">Magento\MagentoCloud\Config\Validator\Deploy\ElasticSuiteIntegrity</item>
                 </item>
                 <item name="warning" xsi:type="array">
+                    <item name="mage-mode-variable" xsi:type="object">Magento\MagentoCloud\Config\Validator\Deploy\MageModeVariable</item>
                     <item name="database-split-connection" xsi:type="object">Magento\MagentoCloud\Config\Validator\Deploy\DatabaseSplitConnection</item>
                     <item name="report-dir-nesting-level" xsi:type="object">Magento\MagentoCloud\Config\Validator\Deploy\ReportDirNestingLevel</item>
                     <item name="admin-data" xsi:type="object">Magento\MagentoCloud\Config\Validator\Deploy\AdminData</item>

--- a/src/App/Error.php
+++ b/src/App/Error.php
@@ -130,6 +130,7 @@ class Error
     public const WARN_NOT_ENOUGH_DATA_SPLIT_DB_VAR = 2024;
     public const WARN_SLAVE_CONNECTION_NOT_SET = 2025;
     public const WARN_COPY_MOUNTED_DIRS_FAILED = 2026;
+    public const WARN_NOT_SUPPORTED_MAGE_MODE = 2027;
 
     /**
      * Post-deploy

--- a/src/Config/EnvironmentData.php
+++ b/src/Config/EnvironmentData.php
@@ -162,4 +162,18 @@ class EnvironmentData implements EnvironmentDataInterface
 
         return $this->getEnv($envVarName) ? (string) $this->getEnv($envVarName) : '';
     }
+
+    /**
+     * Returns MAGE_MODE environment variable
+     *
+     * @return string|null
+     */
+    public function getMageMode(): ?string
+    {
+        if (isset($this->data['mage-mode'])) {
+            return $this->data['mage-mode'];
+        }
+
+        return $this->data['mage-mode'] = $this->getEnv('MAGE_MODE') ?: null;
+    }
 }

--- a/src/Config/EnvironmentData.php
+++ b/src/Config/EnvironmentData.php
@@ -164,9 +164,7 @@ class EnvironmentData implements EnvironmentDataInterface
     }
 
     /**
-     * Returns MAGE_MODE environment variable
-     *
-     * @return string|null
+     * @inheritDoc
      */
     public function getMageMode(): ?string
     {

--- a/src/Config/EnvironmentDataInterface.php
+++ b/src/Config/EnvironmentDataInterface.php
@@ -56,4 +56,11 @@ interface EnvironmentDataInterface
      * @return string
      */
     public function getBranchName(): string;
+
+    /**
+     * Returns MAGE_MODE environment variable
+     *
+     * @return string|null
+     */
+    public function getMageMode(): ?string;
 }

--- a/src/Config/Validator/Deploy/MageModeVariable.php
+++ b/src/Config/Validator/Deploy/MageModeVariable.php
@@ -15,7 +15,7 @@ use Magento\MagentoCloud\Config\ValidatorInterface;
 
 /**
  * Validates value of MAGE_MODE variable.
-*/
+ */
 class MageModeVariable implements ValidatorInterface
 {
     public const PRODUCTION_MODE = 'production';

--- a/src/Config/Validator/Deploy/MageModeVariable.php
+++ b/src/Config/Validator/Deploy/MageModeVariable.php
@@ -59,7 +59,7 @@ class MageModeVariable implements ValidatorInterface
             ),
             sprintf(
                 'Magento Cloud does not support Magento modes other than "%s". '
-                . 'You should remove this variable or change the value to supported mode.',
+                . 'Remove this variable, or change the value to "%s", the only supported mode on Cloud projects.',
                 self::PRODUCTION_MODE
             ),
             Error::WARN_NOT_SUPPORTED_MAGE_MODE

--- a/src/Config/Validator/Deploy/MageModeVariable.php
+++ b/src/Config/Validator/Deploy/MageModeVariable.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Config\Validator\Deploy;
+
+use Magento\MagentoCloud\App\Error;
+use Magento\MagentoCloud\Config\EnvironmentDataInterface;
+use Magento\MagentoCloud\Config\Validator;
+use Magento\MagentoCloud\Config\Validator\ResultFactory;
+use Magento\MagentoCloud\Config\ValidatorInterface;
+
+/**
+ * Validates existence the split database connections in DATABASE CONFIGURATION variable
+ */
+class MageModeVariable implements ValidatorInterface
+{
+    public const PRODUCTION_MODE = 'production';
+
+    /**
+     * @var EnvironmentDataInterface
+     */
+    private $envData;
+
+    /**
+     * @var ResultFactory
+     */
+    private $resultFactory;
+
+    /**
+     * MageModeVariable constructor.
+     * @param EnvironmentDataInterface $envData
+     * @param ResultFactory $resultFactory
+     */
+    public function __construct(
+        EnvironmentDataInterface $envData,
+        ResultFactory $resultFactory
+    ) {
+        $this->envData = $envData;
+        $this->resultFactory = $resultFactory;
+    }
+
+    /**
+     * @return Validator\ResultInterface
+     */
+    public function validate(): Validator\ResultInterface
+    {
+        $mageMode = $this->envData->getMageMode();
+        if (!$mageMode || $mageMode == self::PRODUCTION_MODE) {
+            return $this->resultFactory->success();
+        }
+
+        return $this->resultFactory->error(
+            sprintf(
+                'Environment variable MAGE_MODE was found and the value is differ than "%s".',
+                self::PRODUCTION_MODE
+            ),
+            sprintf(
+                'Magento Cloud does not support Magento modes other than "%s". '
+                . 'You should remove this variable or change the value to supported mode.',
+                self::PRODUCTION_MODE
+            ),
+            Error::WARN_NOT_SUPPORTED_MAGE_MODE
+        );
+    }
+}

--- a/src/Config/Validator/Deploy/MageModeVariable.php
+++ b/src/Config/Validator/Deploy/MageModeVariable.php
@@ -14,8 +14,8 @@ use Magento\MagentoCloud\Config\Validator\ResultFactory;
 use Magento\MagentoCloud\Config\ValidatorInterface;
 
 /**
- * Validates existence the split database connections in DATABASE CONFIGURATION variable
- */
+ * Validates value of MAGE_MODE variable.
+*/
 class MageModeVariable implements ValidatorInterface
 {
     public const PRODUCTION_MODE = 'production';
@@ -31,7 +31,6 @@ class MageModeVariable implements ValidatorInterface
     private $resultFactory;
 
     /**
-     * MageModeVariable constructor.
      * @param EnvironmentDataInterface $envData
      * @param ResultFactory $resultFactory
      */

--- a/src/Config/Validator/Deploy/MageModeVariable.php
+++ b/src/Config/Validator/Deploy/MageModeVariable.php
@@ -58,8 +58,8 @@ class MageModeVariable implements ValidatorInterface
                 self::PRODUCTION_MODE
             ),
             sprintf(
-                'Magento Cloud does not support Magento modes other than "%s". '
-                . 'Remove this variable, or change the value to "%s", the only supported mode on Cloud projects.',
+                'Magento Cloud does not support Magento modes other than "%1$s". '
+                . 'Remove this variable, or change the value to "%1$s", the only supported mode on Cloud projects.',
                 self::PRODUCTION_MODE
             ),
             Error::WARN_NOT_SUPPORTED_MAGE_MODE

--- a/src/Config/Validator/Deploy/MageModeVariable.php
+++ b/src/Config/Validator/Deploy/MageModeVariable.php
@@ -12,6 +12,7 @@ use Magento\MagentoCloud\Config\EnvironmentDataInterface;
 use Magento\MagentoCloud\Config\Validator;
 use Magento\MagentoCloud\Config\Validator\ResultFactory;
 use Magento\MagentoCloud\Config\ValidatorInterface;
+use Magento\MagentoCloud\Filesystem\FileSystemException;
 
 /**
  * Validates value of MAGE_MODE variable.
@@ -45,6 +46,11 @@ class MageModeVariable implements ValidatorInterface
     /**
      * @return Validator\ResultInterface
      */
+
+    /**
+     * @return Validator\ResultInterface
+     * @throws FileSystemException
+     */
     public function validate(): Validator\ResultInterface
     {
         $mageMode = $this->envData->getMageMode();
@@ -52,17 +58,6 @@ class MageModeVariable implements ValidatorInterface
             return $this->resultFactory->success();
         }
 
-        return $this->resultFactory->error(
-            sprintf(
-                'Environment variable MAGE_MODE was found and the value differs from "%s".',
-                self::PRODUCTION_MODE
-            ),
-            sprintf(
-                'Magento Cloud does not support Magento modes other than "%1$s". '
-                . 'Remove this variable, or change the value to "%1$s", the only supported mode on Cloud projects.',
-                self::PRODUCTION_MODE
-            ),
-            Error::WARN_NOT_SUPPORTED_MAGE_MODE
-        );
+        return $this->resultFactory->errorByCode(Error::WARN_NOT_SUPPORTED_MAGE_MODE);
     }
 }

--- a/src/Config/Validator/Deploy/MageModeVariable.php
+++ b/src/Config/Validator/Deploy/MageModeVariable.php
@@ -45,10 +45,6 @@ class MageModeVariable implements ValidatorInterface
 
     /**
      * @return Validator\ResultInterface
-     */
-
-    /**
-     * @return Validator\ResultInterface
      * @throws FileSystemException
      */
     public function validate(): Validator\ResultInterface

--- a/src/Config/Validator/Deploy/MageModeVariable.php
+++ b/src/Config/Validator/Deploy/MageModeVariable.php
@@ -54,7 +54,7 @@ class MageModeVariable implements ValidatorInterface
 
         return $this->resultFactory->error(
             sprintf(
-                'Environment variable MAGE_MODE was found and the value is differ than "%s".',
+                'Environment variable MAGE_MODE was found and the value differs from "%s".',
                 self::PRODUCTION_MODE
             ),
             sprintf(

--- a/src/Test/Unit/Config/EnvironmentDataTest.php
+++ b/src/Test/Unit/Config/EnvironmentDataTest.php
@@ -171,4 +171,17 @@ class EnvironmentDataTest extends TestCase
 
         $this->assertEquals([], $this->environmentData->getApplication());
     }
+
+    public function testGetMageMode(): void
+    {
+        $this->assertNull($this->environmentData->getMageMode());
+
+        $mode = 'some_mode';
+        $_ENV['MAGE_MODE'] = $mode;
+        $this->assertEquals($mode, $this->environmentData->getMageMode());
+
+        //check that value was taken from cache
+        $_ENV['MAGE_MODE'] = 'new value';
+        $this->assertEquals($mode, $this->environmentData->getMageMode());
+    }
 }

--- a/src/Test/Unit/Config/Validator/Deploy/MageModeVariableTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/MageModeVariableTest.php
@@ -94,7 +94,7 @@ class MageModeVariableTest extends TestCase
             ->with(
                 'Environment variable MAGE_MODE was found and the value is differ than "production".',
                 'Magento Cloud does not support Magento modes other than "production". '
-                    . 'You should remove this variable or change the value to supported mode.',
+                . 'Remove this variable, or change the value to "%s", the only supported mode on Cloud projects.',
                 Error::WARN_NOT_SUPPORTED_MAGE_MODE
             );
 

--- a/src/Test/Unit/Config/Validator/Deploy/MageModeVariableTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/MageModeVariableTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MagentoCloud\Test\Unit\Config\Validator\Deploy;
+
+use Magento\MagentoCloud\App\Error;
+use Magento\MagentoCloud\Config\EnvironmentDataInterface;
+use Magento\MagentoCloud\Config\Validator\Deploy\MageModeVariable;
+use Magento\MagentoCloud\Config\Validator\ResultFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @inheritdoc
+ */
+class MageModeVariableTest extends TestCase
+{
+    /**
+     * @var ResultFactory|MockObject
+     */
+    private $resultFactoryMock;
+
+    /**
+     * @var EnvironmentDataInterface|MockObject
+     */
+    private $envDataMock;
+
+    /**
+     * @var MageModeVariable
+     */
+    private $validator;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->envDataMock = $this->createMock(EnvironmentDataInterface::class);
+        $this->resultFactoryMock = $this->createMock(ResultFactory::class);
+
+        $this->validator = new MageModeVariable(
+            $this->envDataMock,
+            $this->resultFactoryMock
+        );
+    }
+
+    /**
+     * @param $mageMode string|null
+     * @dataProvider validateSuccessDataProvider
+     */
+    public function testValidateSuccess($mageMode)
+    {
+        $this->envDataMock->expects($this->once())
+            ->method('getMageMode')
+            ->willReturn($mageMode);
+        $this->resultFactoryMock->expects($this->once())
+            ->method('success');
+        $this->resultFactoryMock->expects($this->never())
+            ->method('error');
+
+        $this->validator->validate();
+    }
+
+    /**
+     * Data provider for testValidateSuccess
+     * @return array
+     */
+    public function validateSuccessDataProvider()
+    {
+        return [
+            [null],
+            [''],
+            [MageModeVariable::PRODUCTION_MODE],
+        ];
+    }
+
+    /**
+     * @param $mageMode string
+     * @dataProvider validateErrorDataProvider
+     */
+    public function testValidateError($mageMode)
+    {
+        $this->envDataMock->expects($this->once())
+            ->method('getMageMode')
+            ->willReturn($mageMode);
+        $this->resultFactoryMock->expects($this->never())
+            ->method('success');
+        $this->resultFactoryMock->expects($this->once())
+            ->method('error')
+            ->with(
+                'Environment variable MAGE_MODE was found and the value is differ than "production".',
+                'Magento Cloud does not support Magento modes other than "production". '
+                    . 'You should remove this variable or change the value to supported mode.',
+                Error::WARN_NOT_SUPPORTED_MAGE_MODE
+            );
+
+        $this->validator->validate();
+    }
+
+    /**
+     * Data provider for testValidateError
+     * @return array
+     */
+    public function validateErrorDataProvider()
+    {
+        return [
+            ['developer'],
+            ['default'],
+            ['maintenance'],
+        ];
+    }
+}

--- a/src/Test/Unit/Config/Validator/Deploy/MageModeVariableTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/MageModeVariableTest.php
@@ -92,7 +92,7 @@ class MageModeVariableTest extends TestCase
         $this->resultFactoryMock->expects($this->once())
             ->method('error')
             ->with(
-                'Environment variable MAGE_MODE was found and the value is differ than "production".',
+                'Environment variable MAGE_MODE was found and the value differs from "production".',
                 'Magento Cloud does not support Magento modes other than "production". '
                 . 'Remove this variable, or change the value to "production", '
                 . 'the only supported mode on Cloud projects.',

--- a/src/Test/Unit/Config/Validator/Deploy/MageModeVariableTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/MageModeVariableTest.php
@@ -11,6 +11,7 @@ use Magento\MagentoCloud\App\Error;
 use Magento\MagentoCloud\Config\EnvironmentDataInterface;
 use Magento\MagentoCloud\Config\Validator\Deploy\MageModeVariable;
 use Magento\MagentoCloud\Config\Validator\ResultFactory;
+use Magento\MagentoCloud\Filesystem\FileSystemException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -50,6 +51,7 @@ class MageModeVariableTest extends TestCase
 
     /**
      * @param $mageMode string|null
+     * @throws FileSystemException
      * @dataProvider validateSuccessDataProvider
      */
     public function testValidateSuccess($mageMode)
@@ -60,7 +62,7 @@ class MageModeVariableTest extends TestCase
         $this->resultFactoryMock->expects($this->once())
             ->method('success');
         $this->resultFactoryMock->expects($this->never())
-            ->method('error');
+            ->method('errorByCode');
 
         $this->validator->validate();
     }
@@ -80,6 +82,7 @@ class MageModeVariableTest extends TestCase
 
     /**
      * @param $mageMode string
+     * @throws FileSystemException
      * @dataProvider validateErrorDataProvider
      */
     public function testValidateError($mageMode)
@@ -90,14 +93,7 @@ class MageModeVariableTest extends TestCase
         $this->resultFactoryMock->expects($this->never())
             ->method('success');
         $this->resultFactoryMock->expects($this->once())
-            ->method('error')
-            ->with(
-                'Environment variable MAGE_MODE was found and the value differs from "production".',
-                'Magento Cloud does not support Magento modes other than "production". '
-                . 'Remove this variable, or change the value to "production", '
-                . 'the only supported mode on Cloud projects.',
-                Error::WARN_NOT_SUPPORTED_MAGE_MODE
-            );
+            ->method('errorByCode');
 
         $this->validator->validate();
     }

--- a/src/Test/Unit/Config/Validator/Deploy/MageModeVariableTest.php
+++ b/src/Test/Unit/Config/Validator/Deploy/MageModeVariableTest.php
@@ -94,7 +94,8 @@ class MageModeVariableTest extends TestCase
             ->with(
                 'Environment variable MAGE_MODE was found and the value is differ than "production".',
                 'Magento Cloud does not support Magento modes other than "production". '
-                . 'Remove this variable, or change the value to "%s", the only supported mode on Cloud projects.',
+                . 'Remove this variable, or change the value to "production", '
+                . 'the only supported mode on Cloud projects.',
                 Error::WARN_NOT_SUPPORTED_MAGE_MODE
             );
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.

    If this PR was initiated by an internal JIRA ticket, copy the description from the ticket here so that the information is visible to contributors from the Magento Cloud Community.
-->

If set environment variable MAGE_MODE with value developer, deployment on Cloud will be finished without error and Magento will work in that mode (until the error occurs because of read only permissions on some files).

AC:
 - add validation on deploy phase which checks that MAGE_MODE does not exist or have value production, otherwise add warning in error log file

### Fixed Issues (if relevant)

1. https://jira.corp.magento.com/browse/MCLOUD-6708

### Manual testing scenarios
1. add environment variable **MAGE_MODE** with value `developer`
2. After deployment cloud.log and cloud.error.log files should have a warning that only `production` mode is supported
** Check this scenario as on uninstalled as on installed Magento

### Release notes

Added validation to check the Magento configuration for incorrect configuration of the MAGE_MODE environment variable. If configured, the `MAGE_MODE` value must be set to `production.`

### Associated documentation updates

PR in devdocs https://github.com/magento/devdocs/pull/7728

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful updates for any required release notes and documentation changes
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
