### PR TITLE
Issue with cloud.error.log

### DIFF
--- a/src/App/Logger/Prepare/ErrorLogFile.php
+++ b/src/App/Logger/Prepare/ErrorLogFile.php
@@ -89,6 +89,11 @@ class ErrorLogFile
             return false;
         }
 
+        $buildPhaseLogContent = $this->file->fileGetContents($buildPhaseLogPath);
+        if (empty($buildPhaseLogContent)) {
+            return false;
+        }
+
         $deployLogFileExists = $this->file->isExists($deployLogPath);
         if (!$deployLogFileExists) {
             return true;
@@ -96,7 +101,7 @@ class ErrorLogFile
 
         return false === strpos(
             $this->file->fileGetContents($deployLogPath),
-            $this->file->fileGetContents($buildPhaseLogPath)
+            $buildPhaseLogContent
         );
     }
 }

--- a/src/Test/Unit/App/Logger/Prepare/ErrorLogFileTest.php
+++ b/src/Test/Unit/App/Logger/Prepare/ErrorLogFileTest.php
@@ -84,12 +84,31 @@ class ErrorLogFileTest extends TestCase
         $this->errorLogFile->prepare();
     }
 
+    public function testBuildLogFileEmpty()
+    {
+        $this->defaultMocks();
+        $this->fileMock->expects($this->once())
+            ->method('isExists')
+            ->willReturn(true);
+        $this->fileMock->expects($this->once())
+            ->method('fileGetContents')
+            ->with('/init/var/log/cloud.error.log')
+            ->willReturn('');
+        $this->fileMock->expects($this->never())
+            ->method('copy');
+
+        $this->errorLogFile->prepare();
+    }
+
     public function testDeployLogFileNotExists()
     {
         $this->defaultMocks();
         $this->fileMock->expects($this->exactly(2))
             ->method('isExists')
             ->willReturnOnConsecutiveCalls(true, false);
+        $this->fileMock->expects($this->once())
+            ->method('fileGetContents')
+            ->willReturn('content');
         $this->fileMock->expects($this->once())
             ->method('copy')
             ->with('/init/var/log/cloud.error.log', '/var/log/cloud.error.log');
@@ -105,8 +124,8 @@ class ErrorLogFileTest extends TestCase
             ->willReturn(true);
         $this->fileMock->expects($this->exactly(2))
             ->method('fileGetContents')
-            ->withConsecutive(['/var/log/cloud.error.log'], ['/init/var/log/cloud.error.log'])
-            ->willReturnOnConsecutiveCalls('some deploy log', 'some build log');
+            ->withConsecutive(['/init/var/log/cloud.error.log'], ['/var/log/cloud.error.log'])
+            ->willReturnOnConsecutiveCalls('some build log', 'some deploy log');
 
         $this->fileMock->expects($this->once())
             ->method('copy')
@@ -123,8 +142,8 @@ class ErrorLogFileTest extends TestCase
             ->willReturn(true);
         $this->fileMock->expects($this->exactly(2))
             ->method('fileGetContents')
-            ->withConsecutive(['/var/log/cloud.error.log'], ['/init/var/log/cloud.error.log'])
-            ->willReturnOnConsecutiveCalls('some build log, some deploy log', 'some build log');
+            ->withConsecutive(['/init/var/log/cloud.error.log'], ['/var/log/cloud.error.log'])
+            ->willReturnOnConsecutiveCalls('some build log', 'some build log, some deploy log');
 
         $this->fileMock->expects($this->never())
             ->method('copy');


### PR DESCRIPTION
### Description
When cloud.error.log is empty the next error occurs:
```
Deploying applications
  Starting deployment
  Preparing slugs
  Entering maintenance mode
  Running deploy hook
  W: 
  W: In Container.php line 99:
  W:                                                                                
  W:   Warning: strpos(): Empty needle in /app/<project_id>/vendor/magento/ece-to  
  W:   ols/src/App/Logger/Prepare/ErrorLogFile.php on line 99                       
  W:                                                                                
  W: 
  W: In ErrorHandler.php line 68:
  W:                                                                                
  W:   Warning: strpos(): Empty needle in /app/<project_id>/vendor/magento/ece-to  
  W:   ols/src/App/Logger/Prepare/ErrorLogFile.php on line 99                       
  W:                                                                                
  W: 
  E: Failed to run deploy hook
  E: Command '['sudo', '-u', '<project_id>', 'bash', '-c', '/etc/platform/<project_id>/post_deploy.sh']' returned non-zero exit status 1
  Exiting maintenance mode

E: Error: Cannot complete deployment
```

### Release notes

For user-facing changes, add a meaningful release note. For examples, see [Magento Cloud ECE-tools release notes](https://devdocs.magento.com/cloud/release-notes/ece-release-notes.html).

### Associated documentation updates
<!--
 If your proposed update requires user documentation, submit a PR to the Magento DevDocs repository. For extensive updates requiring assistance, submit an issue to DevDocs. See https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md.
 -->
Add link to Magento DevDocs PR or Issue, if needed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful updates for any required release notes and documentation changes
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
