### PR TITLE
Output stderr when in debug mode

### DIFF
--- a/src/Shell/Shell.php
+++ b/src/Shell/Shell.php
@@ -106,6 +106,9 @@ class Shell implements ShellInterface
             if ($output = $process->getOutput()) {
                 $this->logger->debug($output);
             }
+            if ($errorOutput = $process->getErrorOutput()) {
+                $this->logger->debug('Error: ' . $errorOutput);
+            }
         } catch (LogicException $exception) {
             $this->logger->error('Can\'t get command output: ' . $exception->getMessage());
         }


### PR DESCRIPTION
Some parts of the build process may output to `stderr` without failing the pipeline.

For example static content deploy does it here 
https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Deploy/Service/DeployPackage.php#L144-L147

If you have an issue that you want to debug and you set `MIN_LOGGING_LEVEL: debug` then I think it is unexpected that this data would not be present

### Manual testing scenarios

The most obvious part of a deployment process that outputs to `stderr` would be the di compilation, when you do a deployment with this in place you should get more output there.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful updates for any required release notes and documentation changes
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
