### PR TITLE
update_url fix

### DIFF
--- a/src/Step/Deploy/InstallUpdate/ConfigUpdate/Urls.php
+++ b/src/Step/Deploy/InstallUpdate/ConfigUpdate/Urls.php
@@ -81,13 +81,13 @@ class Urls implements StepInterface
                 if ($this->environment->isMasterBranch()) {
                     $this->logger->info(
                         'Skipping URL updates because we are deploying to a Production or Staging environment.'
-                        . ' You can override this behavior by setting the FORCE_URL_UPDATES variable to true.'
+                        . ' You can override this behavior by setting the FORCE_UPDATE_URLS variable to true.'
                     );
                     return;
                 }
 
                 if (!$this->stageConfig->get(DeployInterface::VAR_UPDATE_URLS)) {
-                    $this->logger->info('Skipping URL updates because the URL_UPDATES variable is set to false.');
+                    $this->logger->info('Skipping URL updates because the UPDATE_URLS variable is set to false.');
                     return;
                 }
             }

--- a/src/Test/Unit/Step/Deploy/InstallUpdate/ConfigUpdate/UrlsTest.php
+++ b/src/Test/Unit/Step/Deploy/InstallUpdate/ConfigUpdate/UrlsTest.php
@@ -159,7 +159,7 @@ class UrlsTest extends TestCase
             });
         $this->loggerMock->expects($this->once())
             ->method('info')
-            ->with($this->stringContains('Skipping URL updates because the URL_UPDATES variable is set to false.'));
+            ->with($this->stringContains('Skipping URL updates because the UPDATE_URLS variable is set to false.'));
         $this->databaseUrlMock->expects($this->never())
             ->method('execute');
         $this->environmentUrlMock->expects($this->never())


### PR DESCRIPTION
Quick and easy typo fix, to ensure users are not confused by the error message.

The logs for deployments are showing the incorrect variable names.

The documented variables are

https://experienceleague.adobe.com/en/docs/commerce-on-cloud/user-guide/configure/env/stage/variables-deploy#update_urls

and

https://experienceleague.adobe.com/en/docs/commerce-on-cloud/user-guide/configure/env/stage/variables-deploy#force_update_urls